### PR TITLE
Dev

### DIFF
--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -945,7 +945,7 @@ void UBDesktopAnnotationController::updateMask(bool bTransparent)
     }
     else
     {
-	mMask = QPixmap(mTransparentDrawingView->width(), mTransparentDrawingView->height());
+        mMask = QPixmap(mTransparentDrawingView->width(), mTransparentDrawingView->height());
         mMask.fill(Qt::transparent);
 
         QPainter p;

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -85,7 +85,7 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
 #ifdef Q_OS_OSX
     mTransparentDrawingView->setAttribute(Qt::WA_MacNoShadow, true);
 #endif
-    mTransparentDrawingView->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Window | Qt::NoDropShadowWindowHint);
+    mTransparentDrawingView->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Window | Qt::NoDropShadowWindowHint | Qt::X11BypassWindowManagerHint);
     mTransparentDrawingView->setCacheMode(QGraphicsView::CacheNone);
     mTransparentDrawingView->resize(UBApplication::desktop()->width(), UBApplication::desktop()->height());
 
@@ -945,9 +945,20 @@ void UBDesktopAnnotationController::updateMask(bool bTransparent)
     }
     else
     {
-        // Remove the mask
-        QPixmap noMask(mTransparentDrawingView->width(), mTransparentDrawingView->height());
-        mTransparentDrawingView->setMask(noMask.mask());
+	mMask = QPixmap(mTransparentDrawingView->width(), mTransparentDrawingView->height());
+        mMask.fill(Qt::transparent);
+
+        QPainter p;
+
+        p.begin(&mMask);
+
+        p.setPen(Qt::red);
+        p.setBrush(QBrush(Qt::red));
+
+        p.drawRect(mTransparentDrawingView->geometry().x(), mTransparentDrawingView->geometry().y(), mTransparentDrawingView->width(), mTransparentDrawingView->height());
+        p.end();
+
+        mTransparentDrawingView->setMask(mMask.mask());
     }
 }
 


### PR DESCRIPTION
Fixes #66 
-added Qt::X11BypassWindowManagerHint to make the desktop mode stay in the front
-Modified UpdateMask to get a full mask when using pen / eraser / marker / etc to make drawing possible.
Simply filling the mask with Qt::red instead of transparent did not seem to work, I could only make it work by using a brush like the rest of the function. I am by no means a Qt pro, but I guess using the brush on the pixmap must change some parameters that I would otherwise have to set manually.

the issue was not present in Muffin/Cinnamon, so I also tested if I didn't break functionality in this window manager.