### PR TITLE
Add compatibility with OpenSSL 1.1

### DIFF
--- a/src/frameworks/UBCryptoUtils.h
+++ b/src/frameworks/UBCryptoUtils.h
@@ -60,8 +60,13 @@ class UBCryptoUtils : public QObject
 
         void aesInit();
 
+#if OPENSSL_VERSION_NUMBER >= 10100000L
+        EVP_CIPHER_CTX *mAesEncryptContext;
+        EVP_CIPHER_CTX *mAesDecryptContext;
+#else
         EVP_CIPHER_CTX mAesEncryptContext;
         EVP_CIPHER_CTX mAesDecryptContext;
+#endif
 
 };
 


### PR DESCRIPTION
OpenSSL 1.1 has a new API. This commit allows to compile against it, as well
as it keeps compatibility with previous versions of OpenSSL.