### PR TITLE
Fix to build against later versions of OpenSSL

### DIFF
--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -749,9 +749,23 @@ void UBCFFSubsetAdaptor::UBCFFSubsetReader::parseTSpan(const QDomElement &parent
         } else if (curNode.nodeType() == QDomNode::CharacterDataNode
                    || curNode.nodeType() == QDomNode::CDATASectionNode
                    || curNode.nodeType() == QDomNode::TextNode) {
-
-            QDomCharacterData textData = curNode.toCharacterData();
-            QString text = textData.data().trimmed();
+            QString text;
+            switch (curNode.nodeType()) {
+                case QDomNode::CharacterDataNode: {
+                    text = curNode.toCharacterData().data().trimmed();
+                    break;
+                }
+                case QDomNode::CDATASectionNode: {
+                    text = curNode.toCDATASection().data().trimmed();
+                    break;
+                }
+                case QDomNode::TextNode: {
+                    text = curNode.toText().data().trimmed();
+                    break;
+                }
+                default:
+                    break;
+            }
 //            width = painter.fontMetrics().width(text);
             //get bounding rect to obtain desired text height
             lastDrawnTextBoundingRect = painter.boundingRect(QRectF(curX, curY, width, height - curY), textAlign|Qt::TextWordWrap, text);
@@ -784,8 +798,23 @@ void UBCFFSubsetAdaptor::UBCFFSubsetReader::parseTSpan(const QDomElement &elemen
                    || curNode.nodeType() == QDomNode::CDATASectionNode
                    || curNode.nodeType() == QDomNode::TextNode) {
 
-            QDomCharacterData textData = curNode.toCharacterData();
-            QString text = textData.data().trimmed();
+            QString text;
+            switch (curNode.nodeType()) {
+                case QDomNode::CharacterDataNode: {
+                    text = curNode.toCharacterData().data().trimmed();
+                    break;
+                }
+                case QDomNode::CDATASectionNode: {
+                    text = curNode.toCDATASection().data().trimmed();
+                    break;
+                }
+                case QDomNode::TextNode: {
+                    text = curNode.toText().data().trimmed();
+                    break;
+                }
+                default:
+                    break;
+            }
             cursor.insertText(text, charFormat);
 
         } else if (curNode.nodeType() == QDomNode::ElementNode

--- a/src/domain/UBGraphicsItemDelegate.cpp
+++ b/src/domain/UBGraphicsItemDelegate.cpp
@@ -574,7 +574,9 @@ void UBGraphicsItemDelegate::lock(bool locked)
     mDelegated->update();
 
     positionHandles();
-    mFrame->positionHandles();
+
+    if (mFrame)
+        mFrame->positionHandles();
 }
 
 

--- a/src/frameworks/UBCryptoUtils.h
+++ b/src/frameworks/UBCryptoUtils.h
@@ -60,8 +60,8 @@ class UBCryptoUtils : public QObject
 
         void aesInit();
 
-        EVP_CIPHER_CTX mAesEncryptContext;
-        EVP_CIPHER_CTX mAesDecryptContext;
+        EVP_CIPHER_CTX * mAesEncryptContext;
+        EVP_CIPHER_CTX * mAesDecryptContext;
 
 };
 


### PR DESCRIPTION
Quick fix for building against later versions of openssl. I am not familiar enough with OpenBoard to make this backward compatible with earlier versions of openssl. Maybe someone else can suggest a wrapper.