### PR TITLE
Fix massive memory leak in UBFFmpegVideoEncoderWorker.

### DIFF
--- a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
+++ b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
@@ -744,6 +744,7 @@ void UBFFmpegVideoEncoderWorker::writeLatestVideoFrame()
 {
     AVFrame* frame = mImageQueue.dequeue();
     writeFrame(frame, mVideoPacket, mController->mVideoStream, mController->mOutputFormatContext);
+    av_freep(&frame->data[0]);
     av_frame_free(&frame);
 }
 
@@ -756,6 +757,7 @@ void UBFFmpegVideoEncoderWorker::writeLatestAudioFrame()
 #if LIBAVFORMAT_VERSION_MICRO < 100
     if (audio_samples_buffer) {
         av_free(audio_samples_buffer);
+        av_freep(&frame->data[0]);
         audio_samples_buffer = NULL;
     }
 #endif


### PR DESCRIPTION
fix massive memory leak in UBFFmpegVideoEncoderWorker::writeLatest{Video/Audio}Frame()
resoulting from freeing av_frame without freeing its data.
fix #222