### PR TITLE
Fix wrong German translation: "Kompass" -> "Zirkel"

### DIFF
--- a/resources/i18n/OpenBoard_de.ts
+++ b/resources/i18n/OpenBoard_de.ts
@@ -2176,7 +2176,7 @@ Miniaturansicht der Seite %1 wird geladen</translation>
     </message>
     <message>
         <source>Compass</source>
-        <translation>Kompass</translation>
+        <translation>Zirkel</translation>
     </message>
     <message>
         <source>Protractor</source>


### PR DESCRIPTION
In German, "Kompass" is the navigational instrument. The drawing tool is called "Zirkel."