### PR TITLE
OpenBoard.css: Add background color to QMenu, QPushButton and QComboBox

### DIFF
--- a/resources/etc/OpenBoard.css
+++ b/resources/etc/OpenBoard.css
@@ -9,6 +9,7 @@ QWidget:disabled
 }
 
 QComboBox,
+QPushButton,
 QComboBox QAbstractItemView
 {
     background: #dddddd;

--- a/resources/etc/OpenBoard.css
+++ b/resources/etc/OpenBoard.css
@@ -8,6 +8,12 @@ QWidget:disabled
     color: #777777;
 }
 
+QComboBox,
+QComboBox QAbstractItemView
+{
+    background: #dddddd;
+}
+
 QTextEdit,
 QLineEdit,
 QComboBox#DockPaletteWidgetComboBox QAbstractItemView

--- a/resources/etc/OpenBoard.css
+++ b/resources/etc/OpenBoard.css
@@ -40,6 +40,7 @@ QMenu
 {
     border: none;
     font-size: 12px;
+    background-color: #dddddd;
 }
 
 QMenu::item


### PR DESCRIPTION
Fixes ui with dark system themes

before:
![image](https://user-images.githubusercontent.com/13609393/61319111-d21e9300-a806-11e9-8f26-9db2929b04d7.png)

after:
![image](https://user-images.githubusercontent.com/13609393/61319065-b61af180-a806-11e9-9599-df54301da60a.png)
