### PR TITLE
Handle HiDPI screens

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -29,6 +29,7 @@
 
 #include <QtGui>
 #include <QTextCodec>
+#include <QApplication>
 
 #include "frameworks/UBPlatformUtils.h"
 #include "frameworks/UBFileSystemUtils.h"
@@ -96,6 +97,8 @@ int main(int argc, char *argv[])
     // QT_NO_GLIB=1 is set by default on Linux, and prevents media playback
     if (qEnvironmentVariableIsSet("QT_NO_GLIB"))
         qunsetenv("QT_NO_GLIB");
+
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     Q_INIT_RESOURCE(OpenBoard);
 


### PR DESCRIPTION
Without this patch, OpenBoard looks like this with a HiDPI screen on wayland:
![ko](https://user-images.githubusercontent.com/5047140/80272306-fb652d00-867c-11ea-87c8-8f4346d0a868.png)

With the patch, the scale is much more reasonable
![ok](https://user-images.githubusercontent.com/5047140/80272305-facc9680-867c-11ea-823e-a91820bafec1.png)

I'm targeting dev-qt5.1x as it's the branch that works for me

Can anyone confirm it doesn't break on windows? (I really don't expect it to, but who knows)