### PR TITLE
Make Dev qt5.1x build on both windows and (Debian) Linux

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -1,8 +1,6 @@
 TARGET = "OpenBoard"
 TEMPLATE = app
 
-THIRD_PARTY_PATH=../OpenBoard-ThirdParty
-
 CONFIG += c++14
 CONFIG -= flat
 CONFIG += debug_and_release \
@@ -46,7 +44,7 @@ QT += core
 
 INCLUDEPATH += src
 
-include($$THIRD_PARTY_PATH/libs.pri)
+include(libs.pri)
 include(src/adaptors/adaptors.pri)
 include(src/api/api.pri)
 include(src/board/board.pri)
@@ -71,11 +69,6 @@ include(src/pdf-merger/pdfMerger.pri)
 include(plugins/plugins.pri)
 INCLUDEPATH += plugins/cffadaptor/src
 
-#ThirdParty
-DEPENDPATH += $$THIRD_PARTY_PATH/quazip/
-INCLUDEPATH += $$THIRD_PARTY_PATH/quazip/
-include($$THIRD_PARTY_PATH/quazip/quazip.pri)
-
 FORMS += resources/forms/mainWindow.ui \
    resources/forms/preferences.ui \
    resources/forms/brushProperties.ui \
@@ -86,11 +79,11 @@ FORMS += resources/forms/mainWindow.ui \
    resources/forms/capturePublishing.ui \
    resources/forms/intranetPodcastPublishingDialog.ui
 
-UB_ETC.files = resources/etc
+UB_ETC.files = resources/etc/*
 UB_I18N.files = resources/i18n/*.qm
-UB_LIBRARY.files = resources/library
-UB_FONTS.files = resources/fonts
-UB_THIRDPARTY_INTERACTIVE.files = thirdparty/interactive
+UB_LIBRARY.files = resources/library/*
+UB_FONTS.files = resources/fonts/*
+UB_THIRDPARTY_INTERACTIVE.files = thirdparty/interactive/*
 
 DEFINES += NO_THIRD_PARTY_WARNINGS
 DEFINES += UBVERSION=\"\\\"$${LONG_VERSION}\"\\\" \
@@ -109,6 +102,8 @@ CONFIG(release, debug|release) {
    CONFIG += warn_off
 }
 
+# TODO DEBIAN:
+# DESTDIR =
 DESTDIR = $$BUILD_DIR/product
 OBJECTS_DIR = $$BUILD_DIR/objects
 MOC_DIR = $$BUILD_DIR/moc
@@ -430,12 +425,6 @@ linux-g++* {
     LIBS += -lcrypto
     #LIBS += -lprofiler
     LIBS += -lX11
-    LIBS += -lquazip5
-    INCLUDEPATH += "/usr/include/quazip"
-
-    LIBS += -lpoppler
-    INCLUDEPATH += "/usr/include/poppler"
-
     QMAKE_CFLAGS += -fopenmp
     QMAKE_CXXFLAGS += -fopenmp
     QMAKE_LFLAGS += -fopenmp
@@ -443,6 +432,13 @@ linux-g++* {
     UB_I18N.path = $$DESTDIR/i18n
     UB_ETC.path = $$DESTDIR
     UB_THIRDPARTY_INTERACTIVE.path = $$DESTDIR/library
+
+# TODO DEBIAN:
+#    UB_LIBRARY.path = $$DESTDIR/usr/share/openboard/library
+#    UB_I18N.path = $$DESTDIR/usr/share/openboard/i18n
+#    UB_ETC.path = $$DESTDIR/etc/openboard
+#    UB_THIRDPARTY_INTERACTIVE.path = $$DESTDIR/usr/share/openboard/library
+
     system(mkdir -p $$BUILD_DIR)
     system(echo "$$VERSION" > $$BUILD_DIR/version)
     system(echo "$$LONG_VERSION" > $$BUILD_DIR/longversion)

--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -488,5 +488,6 @@ INSTALLS = UB_ETC \
 
 DISTFILES += \
     resources/images/moveDown.svg \
-    resources/images/moveDownDisabled.svg
+    resources/images/moveDownDisabled.svg \
+    libs.pri
 

--- a/libs.pri
+++ b/libs.pri
@@ -31,4 +31,8 @@ linux {
 !linux {
     DEFINES += USE_XPDF
     include($$THIRD_PARTY_PATH/libs.pri)
+    #ThirdParty
+    DEPENDPATH += $$THIRD_PARTY_PATH/quazip/
+    INCLUDEPATH += $$THIRD_PARTY_PATH/quazip/
+    include($$THIRD_PARTY_PATH/quazip/quazip.pri)
 }

--- a/libs.pri
+++ b/libs.pri
@@ -29,5 +29,6 @@ linux {
 }
 
 !linux {
+    DEFINES += USE_XPDF
     include($$THIRD_PARTY_PATH/libs.pri)
 }

--- a/libs.pri
+++ b/libs.pri
@@ -1,0 +1,33 @@
+THIRD_PARTY_PATH="../OpenBoard-ThirdParty"
+
+linux {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += poppler
+    PKGCONFIG += poppler-splash
+    PKGCONFIG += freetype2
+
+    # Find different versions of quazip
+    packagesExist(quazip) {
+        PKGCONFIG += quazip
+        message("using quazip >= 0.7.4 with pkgconfig support")
+    } else {
+
+        # Debian stretch
+        exists(/usr/include/quazip/quazip.h) {
+            INCLUDEPATH += "/usr/include/quazip"
+            LIBS        += "-lquazip5"
+            message("using quazip =< 0.7.4 without pkgconfig support, headers in /usr/include/quazip")
+        }
+
+        # Debian buster and beyond
+        exists(/usr/include/quazip5/quazip.h) {
+            INCLUDEPATH += "/usr/include/quazip5"
+            LIBS        += "-lquazip5"
+            message("using quazip =< 0.7.4 without pkgconfig support, headers in /usr/include/quazip5")
+        }
+    }
+}
+
+!linux {
+    include($$THIRD_PARTY_PATH/libs.pri)
+}

--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -33,11 +33,18 @@
 #include "UBGlobals.h"
 #include "UBCFFConstants.h"
 
-//THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-#include "quazipfileinfo.h"
-//THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+    #include <quazipfileinfo.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    #include "quazipfileinfo.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 UBCFFAdaptor::UBCFFAdaptor()
 {}

--- a/src/adaptors/UBExportDocument.cpp
+++ b/src/adaptors/UBExportDocument.cpp
@@ -39,10 +39,16 @@
 
 #include "globals/UBGlobals.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 #include "core/memcheck.h"
 

--- a/src/adaptors/UBExportDocumentSetAdaptor.cpp
+++ b/src/adaptors/UBExportDocumentSetAdaptor.cpp
@@ -40,10 +40,16 @@
 #include "core/UBPersistenceManager.h"
 #include "core/UBForeignObjectsHandler.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 #include "core/memcheck.h"
 

--- a/src/adaptors/UBExportDocumentSetAdaptor.h
+++ b/src/adaptors/UBExportDocumentSetAdaptor.h
@@ -33,10 +33,16 @@
 #include "frameworks/UBFileSystemUtils.h"
 #include "globals/UBGlobals.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 class UBDocumentProxy;
 class UBDocumentTreeModel;

--- a/src/adaptors/UBExportWeb.cpp
+++ b/src/adaptors/UBExportWeb.cpp
@@ -39,10 +39,16 @@
 
 #include "globals/UBGlobals.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 #include "core/memcheck.h"
 

--- a/src/adaptors/UBImportCFF.cpp
+++ b/src/adaptors/UBImportCFF.cpp
@@ -43,11 +43,16 @@
 
 #include "globals/UBGlobals.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-#include "quazipfileinfo.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 #include "core/memcheck.h"
 

--- a/src/adaptors/UBImportDocument.cpp
+++ b/src/adaptors/UBImportDocument.cpp
@@ -38,11 +38,16 @@
 
 #include "globals/UBGlobals.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-#include "quazipfileinfo.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 #include "core/memcheck.h"
 

--- a/src/adaptors/UBImportDocumentSetAdaptor.cpp
+++ b/src/adaptors/UBImportDocumentSetAdaptor.cpp
@@ -36,11 +36,16 @@
 
 #include "globals/UBGlobals.h"
 
-THIRD_PARTY_WARNINGS_DISABLE
-#include "quazip.h"
-#include "quazipfile.h"
-#include "quazipfileinfo.h"
-THIRD_PARTY_WARNINGS_ENABLE
+// Use installed quazip if available
+#if __has_include(<quazip.h>)
+    #include <quazip.h>
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazip.h"
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
 
 #include "core/memcheck.h"
 

--- a/src/frameworks/UBFileSystemUtils.cpp
+++ b/src/frameworks/UBFileSystemUtils.cpp
@@ -35,8 +35,16 @@
 
 #include "globals/UBGlobals.h"
 
+// Use installed quazip if available
+#if __has_include(<quazipfile.h>)
+    #include <quazipfile.h>
+#else
+    THIRD_PARTY_WARNINGS_DISABLE
+    #include "quazipfile.h"
+    THIRD_PARTY_WARNINGS_ENABLE
+#endif
+
 THIRD_PARTY_WARNINGS_DISABLE
-#include "quazipfile.h"
 #include <openssl/md5.h>
 THIRD_PARTY_WARNINGS_ENABLE
 

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -46,6 +46,9 @@ void UBPlatformUtils::init()
 QString UBPlatformUtils::applicationResourcesDirectory()
 {
     return QApplication::applicationDirPath();
+
+    // TODO Why?
+    // Debian:  return QString("/usr/share/openboard");
 }
 
 void UBPlatformUtils::hideFile(const QString &filePath)

--- a/src/gui/UBToolbarButtonGroup.cpp
+++ b/src/gui/UBToolbarButtonGroup.cpp
@@ -112,6 +112,7 @@ void UBToolbarButtonGroup::setIcon(const QIcon &icon, int index)
         if (button)
         {
             button->setIcon(icon);
+            button->setCheckable(true);
         }
     }
 }

--- a/src/pdf/PDFRenderer.cpp
+++ b/src/pdf/PDFRenderer.cpp
@@ -59,6 +59,9 @@ PDFRenderer* PDFRenderer::rendererForUuid(const QUuid &uuid, const QString &file
     {
         PDFRenderer *newRenderer = new XPDFRenderer(filename,importingFile);
 
+	// DEBIAN: PDFRenderer *newRenderer = new PopplerPDFRenderer(filename,importingFile);
+	// TODO - verify, should not XPDFRenderer already use Poppler?
+
         newRenderer->setRefCount(0);
         newRenderer->setFileUuid(uuid);
 

--- a/src/pdf/UBWebPluginPDFWidget.cpp
+++ b/src/pdf/UBWebPluginPDFWidget.cpp
@@ -75,6 +75,7 @@ UBWebPluginPDFWidget::~UBWebPluginPDFWidget()
 void UBWebPluginPDFWidget::handleFile(const QString &filePath)
 {
     mRenderer = new XPDFRenderer(filePath);
+// TODO DEBIAN : mRenderer = new PopplerPDFRenderer(filePath);
 }
 
 void UBWebPluginPDFWidget::keyReleaseEvent(QKeyEvent *keyEvent)

--- a/src/pdf/XPDFRenderer.cpp
+++ b/src/pdf/XPDFRenderer.cpp
@@ -34,6 +34,8 @@
 #include <frameworks/UBPlatformUtils.h>
 #ifndef USE_XPDF
     #include <poppler/cpp/poppler-version.h>
+#else
+	#define GooString GString
 #endif
 #include "core/memcheck.h"
 
@@ -57,11 +59,7 @@ XPDFRenderer::XPDFRenderer(const QString &filename, bool importingFile)
         globalParams->setupBaseFonts(QFile::encodeName(UBPlatformUtils::applicationResourcesDirectory() + "/" + "fonts").data());
     }
 
-#ifdef USE_XPDF
-    mDocument = new PDFDoc(new GString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
-#else
-    mDocument = new PDFDoc(new GooString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
-#endif
+mDocument = new PDFDoc(new GooString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
     sInstancesCount.ref();
 }
 

--- a/src/pdf/XPDFRenderer.h
+++ b/src/pdf/XPDFRenderer.h
@@ -36,10 +36,23 @@
 #include "globals/UBGlobals.h"
 
 THIRD_PARTY_WARNINGS_DISABLE
-#include <poppler/Object.h>
-#include <poppler/GlobalParams.h>
-#include <poppler/SplashOutputDev.h>
-#include <poppler/PDFDoc.h>
+
+#ifdef WIN32
+    #define USE_XPDF
+#endif
+
+#ifdef USE_XPDF
+    #include <xpdf/Object.h>
+    #include <xpdf/GlobalParams.h>
+    #include <xpdf/SplashOutputDev.h>
+    #include <xpdf/PDFDoc.h>
+#else
+    #include <poppler/Object.h>
+    #include <poppler/GlobalParams.h>
+    #include <poppler/SplashOutputDev.h>
+    #include <poppler/PDFDoc.h>
+#endif
+
 THIRD_PARTY_WARNINGS_ENABLE
 
 class PDFDoc;

--- a/src/pdf/XPDFRenderer.h
+++ b/src/pdf/XPDFRenderer.h
@@ -37,10 +37,6 @@
 
 THIRD_PARTY_WARNINGS_DISABLE
 
-#ifdef WIN32
-    #define USE_XPDF
-#endif
-
 #ifdef USE_XPDF
     #include <xpdf/Object.h>
     #include <xpdf/GlobalParams.h>

--- a/src/podcast/podcast.pri
+++ b/src/podcast/podcast.pri
@@ -67,7 +67,7 @@ linux-g++* {
             -lva \
             -lxcb-shm \
             -lxcb-xfixes \
-            -lxcb-render -lxcb-shape -lxcb -lX11 -lasound -lSDL -lx264 -lpthread -lvpx -lvorbisenc -lvorbis -ltheoraenc -ltheoradec -logg -lopus -lmp3lame -lfreetype -lfdk-aac -lass -llzma -lbz2 -lz -ldl -lswresample -lswscale -lavutil -lm
+            -lxcb-render -lxcb-shape -lxcb -lX11 -lasound -lSDL -lx264 -lpthread -lvpx -lvorbisenc -lvorbis -ltheoraenc -ltheoradec -logg -lopus -lmp3lame -lfreetype -lass -llzma -lbz2 -lz -ldl -lswresample -lswscale -lavutil -lm
 
     FFMPEG_VERSION = $$system(ffmpeg --version|& grep -oP "version.*?\K[0-9]\.[0-9]")
     equals(FFMPEG_VERSION, 2.8) {


### PR DESCRIPTION
Incorporated most (but not all!) changes from the debian package (built by @sunweaver) into the current branch. 

NOT done: All the java script libraries...

With these changes this package build on Debian Linux (once the dependencies are installed - taken from @sunweaver 's package). It does not require the Third Party Libs.

On Windows it links to Third Party libs and still needs them.

This works for me but has not been tested extensively - and I am _not_ an experienced CPP/QT developer.