### PR TITLE
[DRAFT] draft live streaming for linux

### DIFF
--- a/src/podcast/UBPodcastController.cpp
+++ b/src/podcast/UBPodcastController.cpp
@@ -67,6 +67,7 @@
 #elif defined(Q_OS_LINUX)
     #include "ffmpeg/UBFFmpegVideoEncoder.h"
     #include "ffmpeg/UBMicrophoneInput.h"
+    #include "v4l2/UBv4l2loopVideo.h"
 #endif
 
 #include "core/memcheck.h"
@@ -313,7 +314,10 @@ void UBPodcastController::start()
 #elif defined(Q_OS_OSX)
         mVideoEncoder = new UBFFmpegVideoEncoder(this);
 #elif defined(Q_OS_LINUX)
-        mVideoEncoder = new UBFFmpegVideoEncoder(this);
+        if (getenv("V4L2_DEVICE") != NULL)
+            mVideoEncoder = new UBv4l2loopVideoEncoder(this);
+        else
+            mVideoEncoder = new UBFFmpegVideoEncoder(this);
 #endif
 
         if (mVideoEncoder)

--- a/src/podcast/podcast.pri
+++ b/src/podcast/podcast.pri
@@ -60,6 +60,10 @@ linux-g++* {
                 src/podcast/ffmpeg/UBMicrophoneInput.cpp
 
 
+    SOURCES  += src/podcast/v4l2/UBv4l2loopVideo.cpp
+    HEADERS  += src/podcast/v4l2/UBv4l2loopVideo.h
+
+
     DEPENDPATH += /usr/lib/x86_64-linux-gnu
 
     LIBS += -lavformat -lavcodec -lswscale -lavutil \

--- a/src/podcast/v4l2/UBv4l2loopVideo.cpp
+++ b/src/podcast/v4l2/UBv4l2loopVideo.cpp
@@ -1,0 +1,121 @@
+#include "UBv4l2loopVideo.h"
+
+#include <linux/videodev2.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+//-------------------------------------------------------------------------
+// UBv4l2loopVideoEncoder
+//-------------------------------------------------------------------------
+
+UBv4l2loopVideoEncoder::UBv4l2loopVideoEncoder(QObject* parent)
+    : UBAbstractVideoEncoder(parent)
+    , format({0})
+{
+}
+
+UBv4l2loopVideoEncoder::~UBv4l2loopVideoEncoder()
+{
+}
+
+void UBv4l2loopVideoEncoder::setLastErrorMessage(const QString& pMessage)
+{
+    qWarning() << "v4l2-loopback video encoder:" << pMessage;
+    mLastErrorMessage = pMessage;
+}
+
+
+/* send the v4l2_fmt struct to the kernel, and check it was accepted */
+bool UBv4l2loopVideoEncoder::update_format(bool check){
+    int rc;
+
+	if((rc = ioctl(fd, VIDIOC_S_FMT, &format)) < 0){
+		qWarning() << "v4l2 device setformat failed";
+		return false;
+	}
+
+    if (!check)
+        return true;
+
+    struct v4l2_format read_format = format;
+
+	if((rc = ioctl(fd, VIDIOC_G_FMT, &read_format)) < 0){
+		qWarning() << "v4l2 device getformat failed";
+		return false;
+	}
+
+	if(format.fmt.pix.pixelformat != read_format.fmt.pix.pixelformat){
+		qWarning() << "v4l2 format not supported";
+		return false;
+	}
+
+    return true;
+}
+
+
+bool UBv4l2loopVideoEncoder::start()
+{
+	int rc = 0;
+
+    qWarning() << "called init";
+
+	if((fd = open(getenv("V4L2_DEVICE"), O_RDWR)) < 0){
+		qWarning() << "v4l2 device open fail";
+		return false;
+	}
+
+    format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+	if((rc = ioctl(fd, VIDIOC_G_FMT, &format)) < 0){
+		qWarning() << "v4l2 device init getformat fail";
+		return false;
+	}
+
+    format.fmt.pix.pixelformat = pixelformat;
+    return update_format(true);
+}
+
+bool UBv4l2loopVideoEncoder::stop()
+{
+    qDebug() << "Video encoder: stop requested";
+    close(fd);
+    fd = -1;
+    emit encodingFinished(true);
+    return true;
+}
+
+/**
+ * This function should be called every time a new "screenshot" is ready.
+ * The image is converted to the right format and sent to the encoder.
+ */
+void UBv4l2loopVideoEncoder::newPixmap(const QImage &image, long timestamp)
+{
+    int rc;
+    std::size_t image_size = image.sizeInBytes();
+
+    // update the frame size if it changed
+    if (image.width() != format.fmt.pix.width || image.height() != format.fmt.pix.height) {
+        assert(image_size == image.width() * image.height() * 4);
+        format.fmt.pix.width = image.width();
+        format.fmt.pix.height = image.height();
+        format.fmt.pix.sizeimage = image_size;
+        update_format();
+    }
+
+    const uchar *image_data = image.bits();
+    if ((rc = write(fd, image_data, image_size)) < 0) {
+        qWarning() << "write failed in v4l2 encoder";
+    }
+}
+
+void UBv4l2loopVideoEncoder::onAudioAvailable(QByteArray data)
+{
+    (void)data;
+}
+
+void UBv4l2loopVideoEncoder::finishEncoding()
+{
+    qDebug() << "VideoEncoder::finishEncoding called";
+}

--- a/src/podcast/v4l2/UBv4l2loopVideo.h
+++ b/src/podcast/v4l2/UBv4l2loopVideo.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015-2018 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UBV4L2LOOPVIDEO_H
+#define UBV4L2LOOPVIDEO_H
+
+#include <atomic>
+
+#include <QtCore>
+#include <QImage>
+
+#include "podcast/UBAbstractVideoEncoder.h"
+
+class UBFFmpegVideoEncoderWorker;
+class UBPodcastController;
+
+/**
+ * This class provides an interface between the podcast controller and the ffmpeg
+ * back-end.
+ * It includes all the necessary objects and methods to record video (muxer, audio and
+ * video streams and encoders, etc) from inputs consisting of raw PCM audio and raw RGBA
+ * images.
+ *
+ */
+
+#include <linux/videodev2.h>
+
+class UBv4l2loopVideoEncoder : public UBAbstractVideoEncoder
+{
+    Q_OBJECT
+
+public:
+    UBv4l2loopVideoEncoder(QObject* parent = NULL);
+    virtual ~UBv4l2loopVideoEncoder();
+
+    bool start();
+    bool stop();
+
+    void newPixmap(const QImage& pImage, long timestamp);
+
+    QString videoFileExtension() const { return "novideo"; }
+
+    QString lastErrorMessage() { return mLastErrorMessage; }
+
+    void setRecordAudio(bool pRecordAudio __attribute__((unused))) {  }
+
+private slots:
+
+    void setLastErrorMessage(const QString& pMessage);
+    void onAudioAvailable(QByteArray data);
+    void finishEncoding();
+
+private:
+    const uint32_t pixelformat = V4L2_PIX_FMT_BGR32;
+
+    bool update_format(bool check=false);
+    struct v4l2_format format;
+
+    int fd;
+
+    QString mLastErrorMessage;
+};
+
+#endif // UBV4L2LOOPVIDEO_H


### PR DESCRIPTION
This is not intended for production use, it's more like a proof of concept.
With just this code, I can plug OpenBoard with OBS and stream the board even when in the background!

It requires having v4l2loopback installed and some virtual device enabled.

Just run this after installing the package:
`sudo modprobe v4l2loopback devices=1`

`V4L2_DEVICE/dev/videoFIXME path/to/OpenBoard`