### PR TITLE
fix a number of uninitialized variable uses

### DIFF
--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -345,6 +345,7 @@ UBDocumentTreeNode *UBDocumentTreeNode::previousSibling()
 UBDocumentTreeModel::UBDocumentTreeModel(QObject *parent) :
     QAbstractItemModel(parent)
   , mRootNode(0)
+  , mCurrentNode(nullptr)
 {
     UBDocumentTreeNode *rootNode = new UBDocumentTreeNode(UBDocumentTreeNode::Catalog, "root");
 

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -67,6 +67,7 @@ UBGraphicsDelegateFrame::UBGraphicsDelegateFrame(UBGraphicsItemDelegate* pDelega
     , mFlippedY(false)
     , mMirrorX(false)
     , mMirrorY(false)
+    , mResizing(false)
     , mTitleBarHeight(hasTitleBar ? 20 :0)
     , mNominalTitleBarHeight(hasTitleBar ? 20:0)
 {

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -337,8 +337,9 @@ UBGraphicsScene::UBGraphicsScene(UBDocumentProxy* parent, bool enableUndoRedoSta
     , magniferDisplayViewWidget(0)
     , mZLayerController(new UBZLayerController(this))
     , mpLastPolygon(NULL)
-    , mCurrentPolygon(0)
     , mTempPolygon(NULL)
+    , mDrawWithCompass(false)
+    , mCurrentPolygon(0)
     , mSelectionFrame(0)
 {
     UBCoreGraphicsScene::setObjectName("BoardScene");

--- a/src/domain/UBGraphicsStrokesGroup.cpp
+++ b/src/domain/UBGraphicsStrokesGroup.cpp
@@ -35,7 +35,10 @@
 #include "core/memcheck.h"
 
 UBGraphicsStrokesGroup::UBGraphicsStrokesGroup(QGraphicsItem *parent)
-    :QGraphicsItemGroup(parent), UBGraphicsItem()
+    : QGraphicsItemGroup(parent)
+    , UBGraphicsItem()
+    , debugTextEnabled(false) // set to true to get a graphical display of strokes' Z-levels
+    , mDebugText(nullptr)
 {
     setDelegate(new UBGraphicsItemDelegate(this, 0, GF_COMMON
                                            | GF_RESPECT_RATIO
@@ -49,9 +52,6 @@ UBGraphicsStrokesGroup::UBGraphicsStrokesGroup(QGraphicsItem *parent)
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setFlag(QGraphicsItem::ItemIsMovable, true);
-
-    mDebugText = NULL;
-    debugTextEnabled = false; // set to true to get a graphical display of strokes' Z-levels
 }
 
 UBGraphicsStrokesGroup::~UBGraphicsStrokesGroup()


### PR DESCRIPTION
I did a valgrind run to try and figure out why it OpenBoard crashes from
time to time, and found these two uninitialized variable uses.