### PR TITLE
OpenBoard-in-a-Window

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -98,6 +98,11 @@ ALPHA_BETA_STR = $$find(VERSION, "[ab]")
 count(ALPHA_BETA_STR, 1):DEFINES += PRE_RELEASE
 BUILD_DIR = build
 
+OB_INAWINDOW = $$(OB_INAWINDOW)
+!isEmpty(OB_INAWINDOW) {
+	DEFINES += OB_INAWINDOW
+}
+
 macx:BUILD_DIR = $$BUILD_DIR/macx
 win32:BUILD_DIR = $$BUILD_DIR/win32
 linux-g++*:BUILD_DIR = $$BUILD_DIR/linux
@@ -432,6 +437,7 @@ linux-g++* {
     QMAKE_CFLAGS += -fopenmp
     QMAKE_CXXFLAGS += -fopenmp
     QMAKE_LFLAGS += -fopenmp
+	INCLUDEPATH += /usr/include/ffmpeg
     UB_LIBRARY.path = $$DESTDIR
     UB_I18N.path = $$DESTDIR/i18n
     UB_ETC.path = $$DESTDIR

--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -437,7 +437,8 @@ linux-g++* {
     QMAKE_CFLAGS += -fopenmp
     QMAKE_CXXFLAGS += -fopenmp
     QMAKE_LFLAGS += -fopenmp
-	INCLUDEPATH += /usr/include/ffmpeg
+	# Necessary for CentOS/RHEL and won't harm in other distributions
+    INCLUDEPATH += /usr/include/ffmpeg
     UB_LIBRARY.path = $$DESTDIR
     UB_I18N.path = $$DESTDIR/i18n
     UB_ETC.path = $$DESTDIR

--- a/README-OB-IN-A-WINDOW.txt
+++ b/README-OB-IN-A-WINDOW.txt
@@ -1,0 +1,12 @@
+
+In order to compile a version of openboard which runs in it's own
+window instead of fullscreen, you should set the environment
+variable OB_INAWINDOW to yes before running qmake.
+
+For instance:
+env OB_INAWINDOW=yes qmake-qt5 OpenBoard.pro -spec linux-g++-64
+
+spd@daphne.cps.unizar.es
+https://webdiis.unizar.es/~spd/openboard
+
+

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -279,7 +279,13 @@ int UBApplication::exec(const QString& pFileToImport)
 
 
 #ifdef OB_INAWINDOW
-    mainWindow = new UBMainWindow(0, Qt::WindowCloseButtonHint); // deleted by application destructor
+    mainWindow = new UBMainWindow(0,
+		Qt::Window |
+		Qt::WindowCloseButtonHint |
+		Qt::WindowMinimizeButtonHint |
+		Qt::WindowMaximizeButtonHint |
+		Qt::WindowShadeButtonHint
+	); // deleted by application destructor
 #else
     mainWindow = new UBMainWindow(0, Qt::FramelessWindowHint); // deleted by application destructor
 #endif

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -278,7 +278,11 @@ int UBApplication::exec(const QString& pFileToImport)
     gs->setAttribute(QWebSettings::DnsPrefetchEnabled, true);
 
 
+#ifdef OB_INAWINDOW
+    mainWindow = new UBMainWindow(0, Qt::WindowCloseButtonHint); // deleted by application destructor
+#else
     mainWindow = new UBMainWindow(0, Qt::FramelessWindowHint); // deleted by application destructor
+#endif
     mainWindow->setAttribute(Qt::WA_NativeWindow, true);
 
     mainWindow->actionCopy->setShortcuts(QKeySequence::Copy);

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -439,7 +439,11 @@ void UBPlatformUtils::setFrontProcess()
 
 void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 {
-    pWidget->showFullScreen();
+#ifdef OB_INAWINDOW
+	pWidget->showNormal();
+#else
+	pWidget->showFullScreen();
+#endif
 }
 
 void UBPlatformUtils::showOSK(bool show)

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -436,7 +436,11 @@ void UBPlatformUtils::setFrontProcess()
 
 void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 {
+#ifdef OB_INAWINDOW
+	pWidget->showNormal();
+#else
     pWidget->showFullScreen();
+#endif
 }
 
 void UBPlatformUtils::showOSK(bool show)


### PR DESCRIPTION
With these changes normal compilation of OpenBoard won't change anything. But you can choose, when running "qmake", to create an OpenBoard executable which will run in its own window, instead of fullscreen.
I've tested in Linux, Windows and macOS.
http://webdiis.unizar.es/u/spd/openboard/