### PR TITLE
remove bogus isAbsurdPoint check

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -986,11 +986,6 @@ void UBBoardView::mousePressEvent (QMouseEvent *event)
 
     mIsDragInProgress = false;
 
-    if (isAbsurdPoint (event->pos ())) {
-        event->accept ();
-        return;
-    }
-
     mMouseDownPos = event->pos ();
     movingItem = scene()->itemAt(this->mapToScene(event->localPos().toPoint()), QTransform());
 
@@ -1110,11 +1105,6 @@ void UBBoardView::mouseMoveEvent (QMouseEvent *event)
     mIsDragInProgress = true;
     mWidgetMoved = true;
     mLongPressTimer.stop();
-
-    if (isAbsurdPoint (event->pos ())) {
-        event->accept ();
-        return;
-    }
 
     if ((UBDrawingController::drawingController()->isDrawingTool()) && !mMouseButtonIsPressed)
         QGraphicsView::mouseMoveEvent(event);
@@ -1693,23 +1683,6 @@ void UBBoardView::virtualKeyboardActivated(bool b)
     UBPlatformUtils::setWindowNonActivableFlag(this, b);
     mVirtualKeyboardActive = b;
     setInteractive(!b);
-}
-
-
-// Apple remote desktop sends funny events when the transmission is bad
-
-bool UBBoardView::isAbsurdPoint(QPoint point)
-{
-    QDesktopWidget *desktop = qApp->desktop ();
-    bool isValidPoint = false;
-
-    for (int i = 0; i < desktop->numScreens (); i++)
-    {
-        QRect screenRect = desktop->screenGeometry (i);
-        isValidPoint = isValidPoint || screenRect.contains (mapToGlobal(point));
-    }
-
-    return !isValidPoint;
 }
 
 void UBBoardView::focusOutEvent (QFocusEvent * event)

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -149,8 +149,6 @@ private:
     bool mIsCreatingTextZone;
     bool mIsCreatingSceneGrabZone;
 
-    bool isAbsurdPoint(QPoint point);
-
     bool mVirtualKeyboardActive;
     bool mOkOnWidget;
 


### PR DESCRIPTION
This check fails to work with multiple screens having different
geometries. It causes some areas of the screen to ignore input, which makes the software almost unusable.

It really shouldn't be necessary anyway.