### PR TITLE
Improved (Wacom) Tablet handling

### DIFF
--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -53,6 +53,8 @@ public:
     UBBoardView(UBBoardController* pController, int pStartLayer, int pEndLayer, QWidget* pParent = 0, bool isControl = false, bool isDesktop = false);
     virtual ~UBBoardView();
 
+    bool event(QEvent* event) override;
+
     UBGraphicsScene* scene();
 
     void forcedTabletRelease();
@@ -88,8 +90,6 @@ protected:
     QGraphicsItem* determineItemToMove(QGraphicsItem *item);
     void handleItemMousePress(QMouseEvent *event);
     void handleItemMouseMove(QMouseEvent *event);
-
-    virtual bool event (QEvent * e);
 
     virtual void keyPressEvent(QKeyEvent *event);
     virtual void keyReleaseEvent(QKeyEvent *event);
@@ -175,6 +175,8 @@ private:
     bool mRubberBandInPlayMode;
 
     static bool hasSelectedParents(QGraphicsItem * item);
+
+    bool tabletDeviceActive;
 
 private slots:
 

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -435,7 +435,7 @@ bool UBGraphicsScene::inputDevicePress(const QPointF& scenePos, const qreal& pre
 
             if (currentTool != UBStylusTool::Line){
                 // Handle the pressure
-                width = UBDrawingController::drawingController()->currentToolWidth() * pressure;
+                width = UBDrawingController::drawingController()->currentToolWidth() * pressure/2+1;
             }
             else{
                 // Ignore pressure for the line tool
@@ -527,7 +527,7 @@ bool UBGraphicsScene::inputDeviceMove(const QPointF& scenePos, const qreal& pres
 
             if (currentTool != UBStylusTool::Line){
                 // Handle the pressure
-                width = dc->currentToolWidth() * qMax(pressure, 0.2);
+                width = dc->currentToolWidth() * pressure/2 + 1;// qMax(pressure, 0.2);
             }else{
                 // Ignore pressure for line tool
                 width = dc->currentToolWidth();


### PR DESCRIPTION
**Improved (Wacom) tablet handling.** 
Existing handling did not handle pressure well and added additional artefacts due to now actually working as described in the documentation.

- Fix handling of tablet events (Bug)
- Better (Prettier) handling of tablet (wacom) pressure (perhaps matter of taste)

**Reference:** https://stackoverflow.com/a/33525420/1878199

Note: This does not build on my Windows system without setting `USE_XPDF` - see my comment on the other commit.

```
#ifdef WIN32
    #define USE_XPDF
#endif
```