### PR TITLE
Update podcast.pri

### DIFF
--- a/src/podcast/podcast.pri
+++ b/src/podcast/podcast.pri
@@ -69,7 +69,7 @@ linux-g++* {
             -lxcb-xfixes \
             -lxcb-render -lxcb-shape -lxcb -lX11 -lasound -lSDL -lx264 -lpthread -lvpx -lvorbisenc -lvorbis -ltheoraenc -ltheoradec -logg -lopus -lmp3lame -lfreetype -lfdk-aac -lass -llzma -lbz2 -lz -ldl -lswresample -lswscale -lavutil -lm
 
-    FFMPEG_VERSION = $$system(ffmpeg --version|& grep -oP "version.*?\K[0-9]\.[0-9]")
+    FFMPEG_VERSION = $$system(ffmpeg --version| grep -oP "version.*?\\K[0-9]\\.[0-9]")
     equals(FFMPEG_VERSION, 2.8) {
         LIBS -= -lswresample
         LIBS += -lavresample


### PR DESCRIPTION
When trying to compile on Ubuntu 20.04, I found the following bug and suggestion for improvement:
_(bug)_ The `&` needs to be removed, as the output of the `ffmpeg --version` command is piped to the `grep` command.
_(improv)_ Running `qmake` with option `-Wall` also shows that using an un-escaped `\` is deprecated. It needs to be escaped with a `\`.