### PR TITLE
change  and QT_PATH on arm

### DIFF
--- a/release_scripts/linux/build.sh
+++ b/release_scripts/linux/build.sh
@@ -40,6 +40,10 @@ initializeVariables()
     if [ $ARCHITECTURE == "x86_64" ]; then
         ARCHITECTURE="amd64"
     fi
+    if [$ARCHITECTURE == "armv7l" ]; then
+        $ARCHITECTURE="armhf"
+        QT_PATH="/usr/lib/arm-linux-gnueabihf/qt5"
+    fi
   fi
 }
 


### PR DESCRIPTION
After reading source, issue https://github.com/OpenBoard-org/OpenBoard/issues/98 and doc https://github.com/OpenBoard-org/OpenBoard/wiki/Build-OpenBoard-on-Ubuntu-20.04, I succed compiling a .deb on Rpi OS for the french eductative distribution https://primtux.fr/

On Rpi 4, I had to force architecture name and QT_PATH.