### PR TITLE
Dev qt5.1x mac

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -161,6 +161,8 @@ win32 {
 }
 
 macx {
+   DEFINES += Q_WS_MACX
+
    LIBS += -framework Foundation
    LIBS += -framework Cocoa
    LIBS += -framework Carbon
@@ -169,11 +171,23 @@ macx {
    LIBS += -lcrypto
 
    LIBS += -L/usr/local/opt/openssl/lib
-   LIBS += -L/usr/local/opt/quazip/lib -lquazip
+
+   # quazip depends on QT. Current is 5.14, so if you wish to build
+   # OB using a previous QT version, you have to build your own quazip,
+   # otherwise it won't link.
+   equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 14) {
+      LIBS += "-L../OpenBoard-ThirdParty/quazip/lib/macx" "-lquazip"
+   } else {
+       LIBS += -L/usr/local/opt/quazip/lib -lquazip
+   }
    LIBS += -L/usr/local/opt/ffmpeg/lib
    INCLUDEPATH += /usr/local/opt/openssl/include
    INCLUDEPATH += /usr/local/opt/ffmpeg/include
-   INCLUDEPATH += /usr/local/opt/quazip/include/quazip
+   equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 14) {
+       INCLUDEPATH += ../OpenBoard-ThirdParty/quazip/quazip-0.7.1
+   } else {
+       INCLUDEPATH += /usr/local/opt/quazip/include/quazip
+   }
 
    LIBS        += -L/usr/local/opt/poppler/lib -lpoppler
    INCLUDEPATH += /usr/local/opt/poppler/include

--- a/src/api/UBLibraryAPI.h
+++ b/src/api/UBLibraryAPI.h
@@ -31,7 +31,6 @@
 #define UBLIBRARYAPI_H_
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QWebView>
 
 class UBLibraryAPI : public QObject

--- a/src/api/UBW3CWidgetAPI.cpp
+++ b/src/api/UBW3CWidgetAPI.cpp
@@ -30,7 +30,6 @@
 #include "UBW3CWidgetAPI.h"
 
 #include <QtGui>
-#include <QtWebKit>
 
 #include "core/UBApplication.h"
 #include "core/UBApplicationController.h"

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -30,7 +30,6 @@
 #include "UBBoardController.h"
 
 #include <QtWidgets>
-#include <QtWebKitWidgets>
 
 #include "frameworks/UBFileSystemUtils.h"
 #include "frameworks/UBPlatformUtils.h"

--- a/src/board/UBBoardPaletteManager.h
+++ b/src/board/UBBoardPaletteManager.h
@@ -31,7 +31,6 @@
 #define UBBOARDPALETTEMANAGER_H_
 
 #include <QtGui>
-#include <QtWebKit>
 
 #include "gui/UBLeftPalette.h"
 #include "gui/UBRightPalette.h"

--- a/src/core/UB.h
+++ b/src/core/UB.h
@@ -35,6 +35,10 @@
 
 #define UB_MAX_ZOOM 9
 
+#if defined(Q_OS_LINUX) || (defined(Q_OS_OSX) && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)))
+#define UB_REQUIRES_MASK_UPDATE 1
+#endif
+
 struct UBMimeType
 {
     enum Enum

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -30,7 +30,6 @@
 #include "UBApplication.h"
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QtXml>
 #include <QFontDatabase>
 #include <QStyleFactory>

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -84,6 +84,9 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     mTransparentDrawingView->setAttribute(Qt::WA_TranslucentBackground, true);
 #ifdef Q_OS_OSX
     mTransparentDrawingView->setAttribute(Qt::WA_MacNoShadow, true);
+#endif //Q_OS_OSX
+
+#if defined(Q_OS_OSX) && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     /* https://bugreports.qt.io/browse/QTBUG-81456 */
     if (QOperatingSystemVersion::current().minorVersion() > 12) /* > Sierra */
     {

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -911,7 +911,6 @@ void UBDesktopAnnotationController::updateMask(bool bTransparent)
             p.drawRect(tabsPalette);
         }
 
-#ifdef Q_OS_LINUX
         //Rquiered only for compiz wm
         //TODO. Window manager detection screen
 
@@ -919,7 +918,6 @@ void UBDesktopAnnotationController::updateMask(bool bTransparent)
             p.drawRect(UBApplication::boardController->paletteManager()->addItemPalette()->geometry());
         }
 
-#endif
 
         p.end();
 

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -86,19 +86,7 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     mTransparentDrawingView->setAttribute(Qt::WA_MacNoShadow, true);
 #endif //Q_OS_OSX
 
-#if defined(Q_OS_OSX) && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-    /* https://bugreports.qt.io/browse/QTBUG-81456 */
-    if (QOperatingSystemVersion::current().minorVersion() > 12) /* > Sierra */
-    {
-        mTransparentDrawingView->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnBottomHint | Qt::Window | Qt::NoDropShadowWindowHint | Qt::X11BypassWindowManagerHint);
-    }
-    else
-    {
-        mTransparentDrawingView->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Window | Qt::NoDropShadowWindowHint | Qt::X11BypassWindowManagerHint);
-    }
-#else
     mTransparentDrawingView->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Window | Qt::NoDropShadowWindowHint | Qt::X11BypassWindowManagerHint);
-#endif
     mTransparentDrawingView->setCacheMode(QGraphicsView::CacheNone);
     mTransparentDrawingView->resize(UBApplication::desktop()->width(), UBApplication::desktop()->height());
 
@@ -124,7 +112,7 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
         connect( UBApplication::boardController->paletteManager()->mKeyboardPalette, SIGNAL(keyboardActivated(bool)), 
                  mTransparentDrawingView, SLOT(virtualKeyboardActivated(bool)));
 
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
         connect(UBApplication::boardController->paletteManager()->mKeyboardPalette, SIGNAL(moved(QPoint)), this, SLOT(refreshMask()));
         connect(UBApplication::mainWindow->actionVirtualKeyboard, SIGNAL(triggered(bool)), this, SLOT(refreshMask()));
         connect(mDesktopPalette,SIGNAL(refreshMask()), this, SLOT(refreshMask()));
@@ -179,7 +167,7 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     connect(&mHoldTimerMarker, SIGNAL(timeout()), this, SLOT(markerActionReleased()));
     connect(&mHoldTimerEraser, SIGNAL(timeout()), this, SLOT(eraserActionReleased()));
 
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
     connect(mDesktopPalette, SIGNAL(moving()), this, SLOT(refreshMask()));
     connect(UBApplication::boardController->paletteManager()->rightPalette(), SIGNAL(resized()), this, SLOT(refreshMask()));
     connect(UBApplication::boardController->paletteManager()->addItemPalette(), SIGNAL(closed()), this, SLOT(refreshMask()));
@@ -359,9 +347,9 @@ void UBDesktopAnnotationController::showWindow()
 
     mDesktopPalette->appear();
 
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
     updateMask(true);
-#endif
+#endif // UB_REQUIRES_MASK_UPDATE
 }
 
 
@@ -404,9 +392,9 @@ void UBDesktopAnnotationController::updateBackground()
             || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Selector)
     {
         newBrush = QBrush(Qt::transparent);
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
         updateMask(true);
-#endif
+#endif //UB_REQUIRES_MASK_UPDATE
     }
     else
     {
@@ -415,9 +403,9 @@ void UBDesktopAnnotationController::updateBackground()
 #else
         newBrush = QBrush(QColor(127, 127, 127, 1));
 #endif
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
         updateMask(false);
-#endif
+#endif //UB_REQUIRES_MASK_UPDATE
     }
 
     if (mTransparentDrawingScene && mTransparentDrawingScene->backgroundBrush() != newBrush)

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -173,7 +173,7 @@ void UBDesktopPalette::minimizeMe(eMinimizedLocation location)
 
     adjustSizeAndPosition();
 
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
         emit refreshMask();
 #endif
 }
@@ -203,7 +203,7 @@ void UBDesktopPalette::maximizeMe()
 
     // Notify that the maximization has been done
     emit maximized();
-#ifdef Q_OS_LINUX
+#ifdef UB_REQUIRES_MASK_UPDATE
         emit refreshMask();
 #endif
 }

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -30,7 +30,6 @@
 #include "UBGraphicsScene.h"
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QtSvg>
 #include <QGraphicsView>
 #include <QGraphicsVideoItem>
@@ -2803,6 +2802,8 @@ void UBGraphicsScene::simplifyCurrentStroke()
     }
 
 }
+
+
 
 void UBGraphicsScene::setDocumentUpdated()
 {

--- a/src/domain/UBGraphicsWidgetItem.h
+++ b/src/domain/UBGraphicsWidgetItem.h
@@ -31,7 +31,6 @@
 #define UBGRAPHICSWIDGETITEM_H
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QDomElement>
 #include <QGraphicsWebView>
 

--- a/src/frameworks/UBPlatformUtils_mac.mm
+++ b/src/frameworks/UBPlatformUtils_mac.mm
@@ -88,6 +88,7 @@ void UBPlatformUtils::setDesktopMode(bool desktop)
 {
 
     @try {
+#if defined(Q_OS_OSX) && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         // temporarily disabled due to bug: when switching to desktop mode (and calling this),
         // openboard switches right back to the board mode. clicking again on desktop mode works.
         if (desktop) {
@@ -95,6 +96,9 @@ void UBPlatformUtils::setDesktopMode(bool desktop)
         }
         else
             [NSApp setPresentationOptions:NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock];
+#else // QT_VERSION_CHECK(5, 10, 0)
+        [NSApp setPresentationOptions:NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock];
+#endif // QT_VERSION_CHECK(5, 10, 0)
     }
 
     @catch(NSException * exception) {
@@ -526,6 +530,7 @@ QString UBPlatformUtils::urlFromClipboard()
 
 void UBPlatformUtils::toggleFinder(const bool on)
 {
+#if defined(Q_OS_OSX) && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     if (on)
     {
         [NSApp setPresentationOptions:NSApplicationPresentationDefault];
@@ -534,6 +539,9 @@ void UBPlatformUtils::toggleFinder(const bool on)
     {
         [NSApp setPresentationOptions:NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock];
     }
+#else // QT_VERSION_CHECK(5, 10, 0)
+    Q_UNUSED(on);
+#endif //QT_VERSION_CHECK(5, 10, 0)
 }
 
 

--- a/src/gui/UBFeaturesWidget.h
+++ b/src/gui/UBFeaturesWidget.h
@@ -54,7 +54,6 @@
 #include "api/UBWidgetUniboardAPI.h"
 #include "UBFeaturesActionBar.h"
 #include "UBRubberBand.h"
-#include <QtWebKit>
 #include <QWebView>
 #include <QWebSettings>
 

--- a/src/gui/UBMainWindow.h
+++ b/src/gui/UBMainWindow.h
@@ -32,7 +32,6 @@
 
 #include <QMainWindow>
 #include <QWidget>
-#include <QtWebKitWidgets/QWebView>
 #include <QMessageBox>
 #include "UBDownloadWidget.h"
 

--- a/src/network/UBCookieJar.cpp
+++ b/src/network/UBCookieJar.cpp
@@ -75,8 +75,7 @@
 #include "core/UBSettings.h"
 
 #include <QtGui>
-#include <QtWebKit>
-
+#include <QWebSettings>
 #include "core/memcheck.h"
 
 static const unsigned int JAR_VERSION = 23;

--- a/src/pdf/XPDFRenderer.h
+++ b/src/pdf/XPDFRenderer.h
@@ -76,6 +76,7 @@ class XPDFRenderer : public PDFRenderer
         void init();
 
         struct PdfZoomCacheData {
+            PdfZoomCacheData() : splashBitmap(nullptr), cachedPageNumber(-1), splash(nullptr), ratio(1.0) {};
             PdfZoomCacheData(double const a_ratio) : splashBitmap(nullptr), cachedPageNumber(-1), splash(nullptr), ratio(a_ratio) {};
             ~PdfZoomCacheData() {};
             SplashBitmap* splashBitmap;

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -31,6 +31,7 @@
 #include <QDomDocument>
 #include <QXmlQuery>
 #include <QWebFrame>
+#include <QWebElementCollection>
 
 #include "frameworks/UBPlatformUtils.h"
 

--- a/src/web/UBWebController.h
+++ b/src/web/UBWebController.h
@@ -31,7 +31,6 @@
 #define UBWEBCONTROLLER_H_
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QWebView>
 
 #include "UBOEmbedParser.h"

--- a/src/web/UBWebKitUtils.h
+++ b/src/web/UBWebKitUtils.h
@@ -30,7 +30,8 @@
 #ifndef UBWEBKITUTILS_H_
 #define UBWEBKITUTILS_H_
 
-#include <QtWebKit>
+// Forward declarations.
+class QWebFrame;
 
 class UBWebKitUtils
 {

--- a/src/web/browser/WBBrowserWindow.cpp
+++ b/src/web/browser/WBBrowserWindow.cpp
@@ -71,7 +71,7 @@
 #include "WBBrowserWindow.h"
 
 #include <QtGui>
-#include <QtWebKit>
+#include <QWebHistory>
 #include <QDesktopWidget>
 
 #include "core/UBSettings.h"

--- a/src/web/browser/WBBrowserWindow.h
+++ b/src/web/browser/WBBrowserWindow.h
@@ -72,7 +72,6 @@
 #define WBBROWSERMAINWINDOW_H
 
 #include <QtGui>
-#include <QtWebKit>
 
 class WBChaseWidget;
 class WBTabWidget;

--- a/src/web/browser/WBDownloadManager.cpp
+++ b/src/web/browser/WBDownloadManager.cpp
@@ -71,8 +71,8 @@
 #include "WBDownloadManager.h"
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QFileDialog>
+#include <QWebSettings>
 
 #include "network/UBAutoSaver.h"
 #include "network/UBNetworkAccessManager.h"

--- a/src/web/browser/WBHistory.cpp
+++ b/src/web/browser/WBHistory.cpp
@@ -73,7 +73,7 @@
 #include "WBBrowserWindow.h"
 
 #include <QtGui>
-#include <QtWebKit>
+#include <QWebSettings>
 
 #include "core/UBSettings.h"
 #include "network/UBAutoSaver.h"

--- a/src/web/browser/WBHistory.h
+++ b/src/web/browser/WBHistory.h
@@ -74,7 +74,7 @@
 #include "WBModelMenu.h"
 
 #include <QtGui>
-#include <QtWebKit>
+#include <QWebHistoryInterface>
 
 class WBHistoryItem
 {

--- a/src/web/browser/WBTabWidget.h
+++ b/src/web/browser/WBTabWidget.h
@@ -118,8 +118,6 @@ class WBTabBar : public QTabBar
         QPoint mDragStartPos;
 };
 
-#include <QtWebKit>
-
 
 class WBWebView;
 /*!

--- a/src/web/browser/WBToolBarSearch.cpp
+++ b/src/web/browser/WBToolBarSearch.cpp
@@ -71,7 +71,6 @@
 #include "WBToolBarSearch.h"
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QMenu>
 #include <QCompleter>
 

--- a/src/web/browser/WBWebTrapWebView.cpp
+++ b/src/web/browser/WBWebTrapWebView.cpp
@@ -30,7 +30,7 @@
 #include "WBWebTrapWebView.h"
 
 #include <QtGui>
-#include <QtWebKit>
+#include <QWebElement>
 #include <QWebHitTestResult>
 #include <QWebFrame>
 

--- a/src/web/browser/WBWebTrapWebView.h
+++ b/src/web/browser/WBWebTrapWebView.h
@@ -31,9 +31,7 @@
 #define WBWEBTRAPWEBVIEW_H_
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QWebView>
-
 
 class WBWebTrapWebView : public QWebView
 {

--- a/src/web/browser/WBWebView.cpp
+++ b/src/web/browser/WBWebView.cpp
@@ -82,7 +82,6 @@
 #include "network/UBCookieJar.h"
 
 #include <QtGui>
-#include <QtWebKit>
 #include <QtUiTools/QUiLoader>
 #include <QMessageBox>
 #include <QWebFrame>

--- a/src/web/browser/WBWebView.h
+++ b/src/web/browser/WBWebView.h
@@ -72,7 +72,6 @@
 #define WBWEBVIEW_H
 
 #include <QtGui>
-#include <QtWebKit>
 
 #include "WBWebTrapWebView.h"
 #include "web/UBWebPage.h"


### PR DESCRIPTION
Fixes current MAC desktop mode issues, by either allowing to compile with Qt5.9, or by updating the QGraphicsScene mask, as it is already done on Linux.