### PR TITLE
SMART Notebook import

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -443,9 +443,9 @@ linux-g++* {
     LIBS += -lpoppler
     INCLUDEPATH += "/usr/include/poppler"
 
-    QMAKE_CFLAGS += -fopenmp
-    QMAKE_CXXFLAGS += -fopenmp
-    QMAKE_LFLAGS += -fopenmp
+    QMAKE_CFLAGS += -fopenmp -pg
+    QMAKE_CXXFLAGS += -fopenmp -pg
+    QMAKE_LFLAGS += -fopenmp -pg
     UB_LIBRARY.path = $$DESTDIR
     UB_I18N.path = $$DESTDIR/i18n
     UB_ETC.path = $$DESTDIR

--- a/resources/forms/preferences.ui
+++ b/resources/forms/preferences.ui
@@ -1047,6 +1047,50 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="importTab">
+      <attribute name="title">
+       <string>Import</string>
+      </attribute>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>331</width>
+         <height>91</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>SMART Notebook files</string>
+       </property>
+       <widget class="QCheckBox" name="importViewWholePagesCheckBox">
+        <property name="geometry">
+         <rect>
+          <x>70</x>
+          <y>30</y>
+          <width>181</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>View whole pages at once</string>
+        </property>
+       </widget>
+       <widget class="QCheckBox" name="importCombineTextCheckBox">
+        <property name="geometry">
+         <rect>
+          <x>70</x>
+          <y>60</y>
+          <width>201</width>
+          <height>21</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Combine related text items</string>
+        </property>
+       </widget>
+      </widget>
+     </widget>
      <widget class="QWidget" name="thirdPartyLicence">
       <property name="enabled">
        <bool>true</bool>

--- a/src/adaptors/UBImportSMART.cpp
+++ b/src/adaptors/UBImportSMART.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (C) 2015-2018 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * Copyright (C) 2013 Open Education Foundation
+ *
+ * Copyright (C) 2010-2013 Groupement d'Intérêt Public pour
+ * l'Education Numérique en Afrique (GIP ENA)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#include <QDir>
+#include <QList>
+#include <QXmlStreamReader>
+
+#include "adaptors/UBSvgSubsetAdaptor.h"
+#include "core/UBApplication.h"
+#include "core/UBPersistenceManager.h"
+#include "core/UBDocumentManager.h"
+#include "core/UBPersistenceManager.h"
+#include "document/UBDocumentProxy.h"
+#include "frameworks/UBFileSystemUtils.h"
+
+#include "UBSvgSubsetAdaptor.h"
+
+#include "UBImportSMART.h"
+
+#include "globals/UBGlobals.h"
+
+THIRD_PARTY_WARNINGS_DISABLE
+#include "quazip.h"
+#include "quazipfile.h"
+#include "quazipfileinfo.h"
+THIRD_PARTY_WARNINGS_ENABLE
+
+#include "core/memcheck.h"
+
+UBImportSMART::UBImportSMART(QObject *parent)
+    : UBDocumentBasedImportAdaptor(parent)
+{
+    // NOOP
+}
+
+
+UBImportSMART::~UBImportSMART()
+{
+    // NOOP
+}
+
+
+QStringList UBImportSMART::supportedExtentions()
+{
+    return QStringList("notebook");
+}
+
+
+QString UBImportSMART::importFileFilter()
+{
+    QString filter = tr("SMART Notebook (");
+    QStringList formats = supportedExtentions();
+    bool isFirst = true;
+
+    foreach(QString format, formats)
+    {
+            if(isFirst)
+                    isFirst = false;
+            else
+                    filter.append(" ");
+
+        filter.append("*."+format);
+    }
+
+    filter.append(")");
+
+    return filter;
+}
+
+QString UBImportSMART::expandFileToDir(const QFile& pZipFile, const QString& pDir)
+{
+    QuaZip zip(pZipFile.fileName());
+
+    if(!zip.open(QuaZip::mdUnzip)) {
+        qWarning() << "Import failed. Cause zip.open(): " << zip.getZipError();
+        return "";
+    }
+
+    zip.setFileNameCodec("UTF-8");
+    QuaZipFileInfo info;
+    QuaZipFile file(&zip);
+
+    //create temporary document root folder
+    //use current date/time and temp number for folder name
+    QString documentRootFolder;
+    int tmpNumber = 0;
+    QDir rootDir;
+    while (true) {
+        QString tempPath = QString("%1/sank%2.%3")
+                .arg(pDir)
+                .arg(QDateTime::currentDateTime().toString("dd_MM_yyyy_HH-mm"))
+                .arg(tmpNumber);
+        if (!rootDir.exists(tempPath)) {
+            documentRootFolder = tempPath;
+            break;
+        }
+        tmpNumber++;
+        if (tmpNumber == 100000) {
+            qWarning() << "Import failed. Failed to create temporary directory for iwb file";
+            return "";
+        }
+    }
+    if (!rootDir.mkdir(documentRootFolder)) {
+        qWarning() << "Import failed. Couse: failed to create temp folder for cff package";
+    }
+
+    QFile out;
+    char c;
+    for(bool more=zip.goToFirstFile(); more; more=zip.goToNextFile()) {
+        if(!zip.getCurrentFileInfo(&info)) {
+            //TOD UB 4.3 O display error to user or use crash reporter
+            qWarning() << "Import failed. Cause: getCurrentFileInfo(): " << zip.getZipError();
+            return "";
+        }
+//        if(!file.open(QIODevice::ReadOnly)) {
+//            qWarning() << "Import failed. Cause: file.open(): " << zip.getZipError();
+//            return "";
+//        }
+        file.open(QIODevice::ReadOnly);
+        if(file.getZipError()!= UNZ_OK) {
+            qWarning() << "Import failed. Cause: file.getFileName(): " << zip.getZipError();
+            return "";
+        }
+
+        QString newFileName = documentRootFolder + "/" + file.getActualFileName();
+
+        QFileInfo newFileInfo(newFileName);
+        rootDir.mkpath(newFileInfo.absolutePath());
+
+        out.setFileName(newFileName);
+        out.open(QIODevice::WriteOnly);
+
+        while(file.getChar(&c))
+            out.putChar(c);
+
+        out.close();
+
+        if(file.getZipError()!=UNZ_OK) {
+            qWarning() << "Import failed. Cause: " << zip.getZipError();
+            return "";
+        }
+        if(!file.atEnd()) {
+            qWarning() << "Import failed. Cause: read all but not EOF";
+            return "";
+        }
+
+        file.close();
+
+        if(file.getZipError()!=UNZ_OK) {
+            qWarning() << "Import failed. Cause: file.close(): " <<  file.getZipError();
+            return "";
+        }
+    }
+
+    zip.close();
+
+    if(zip.getZipError()!=UNZ_OK) {
+        qWarning() << "Import failed. Cause: zip.close(): " << zip.getZipError();
+        return "";
+    }
+
+    return documentRootFolder;
+}
+
+
+UBDocumentProxy* UBImportSMART::importFile(const QFile& pFile, const QString& pGroup)
+{
+    QList<UBGraphicsScene*> pages;
+
+    QFileInfo fi(pFile);
+    UBApplication::showMessage(tr("Importing file %1...").arg(fi.baseName()), true);
+
+    // first unzip the file to the correct place
+    QString path = QDir::tempPath();
+
+    QString documentRootFolder = expandFileToDir(pFile, path);
+    QString contentFile;
+    if (documentRootFolder.isEmpty())
+        //if file has failed to unzip it is probably just svg file (.xbk extension)
+        return 0;
+    else
+        //get path to imsmanifest xml
+        contentFile = QString("%1/imsmanifest.xml").arg(documentRootFolder);
+
+    if(!contentFile.length()){
+            UBApplication::showMessage(tr("Import of file %1 failed.").arg(fi.baseName()));
+    }
+    else
+    {
+      QFile file(contentFile);
+
+      if (!file.open(QIODevice::ReadOnly))
+      {
+          qWarning() << "Cannot open file " << contentFile << " for reading ...";
+          return 0;
+      }
+
+      QDomDocument doc("smart-import");
+      if (!doc.setContent(&file)) {
+        file.close();
+        return 0;
+      }
+      file.close();
+
+      QString documentName = QFileInfo(pFile.fileName()).completeBaseName();
+      UBDocumentProxy* document = UBPersistenceManager::persistenceManager()->createDocument(pGroup, documentName, false, QString(), 0, true);
+
+      QString documentPath = document->persistencePath();
+      QDir imgDir(documentRootFolder + "/images");
+      if (imgDir.exists())
+      {
+        if (!UBFileSystemUtils::copyDir(documentRootFolder + "/images",
+                 documentPath + "/images"))
+          return 0;
+      }
+
+
+
+      // In imsmanifest.xml, pages are named in the href attributes
+      // of <file> elements.  They may be named more than once by elements
+      // contained by different <resource> elements, so only import each
+      // page the first time it is seen.
+      QDomNodeList filelist = doc.elementsByTagName("file");
+      QHash<QString, bool> fileSeen;
+
+      int length = filelist.length();
+      int pageIndex = 0;
+      for (int fileIndex = 0; fileIndex < length; fileIndex++)
+      {
+          QDomNode node = filelist.at(fileIndex);
+          QDomElement element = node.toElement();
+          QString base = element.attribute("href");
+          if (!base.isEmpty() && base.endsWith(".svg") && !fileSeen[base])
+          {
+            fileSeen[base] = true;
+            QString pageFile;
+            pageFile = QString("%1/%2").arg(documentRootFolder).arg(base);
+
+            QFile file(pageFile);
+            if (!file.open(QIODevice::ReadOnly))
+            {
+                UBFileSystemUtils::deleteDir(documentRootFolder);
+                return 0;
+            }
+            pageIndex = document->pageCount();
+            UBApplication::showMessage(tr("Inserting page %1").arg(pageIndex), true);
+
+            UBGraphicsScene* scene = UBSvgSubsetAdaptor::loadScene(document, file.readAll());
+
+            // Adjust coordinates of scene items so (0,0) is the
+            // very centre of the page.
+            qreal adjust_x = scene->width() / 2;
+            qreal adjust_y = scene->height() / 2;
+
+            // Do not use the original height of the page, as the
+            // page is scaled to appear on the screen.  Use a 4:3 ratio
+            // instead so the page is large enough to read.
+            qreal newHeight = scene->width() * 0.75;
+            adjust_y -= 0.5 * (scene->height() - newHeight);
+
+            for (QGraphicsItem* item : scene->items())
+            {
+              if (nullptr == item->parentItem() && item->isVisible())
+                item->setPos(item->x() - adjust_x, item->y() - adjust_y);
+              // I don't know why but without the isVisible() check
+              // mouse pointer movement is broken.  There must be an
+              // invisible item that is used for pointer positioning.
+            }
+
+            QRectF rect = scene->sceneRect();
+            rect.setHeight(newHeight);
+            scene->setSceneRect(rect);
+
+            QSize sceneSize;
+            sceneSize.setWidth(rect.width());
+            sceneSize.setHeight(newHeight());
+            scene->setNominalSize(sceneSize);
+
+            UBPersistenceManager::persistenceManager()->insertDocumentSceneAt(document, scene, pageIndex++);
+          }
+      }
+
+      UBPersistenceManager::persistenceManager()->persistDocumentMetadata(document);
+      UBApplication::showMessage(tr("Import successful."));
+      UBFileSystemUtils::deleteDir(documentRootFolder);
+      return document;
+    }
+  UBFileSystemUtils::deleteDir(documentRootFolder);
+  return 0;
+}
+
+bool UBImportSMART::addFileToDocument(UBDocumentProxy* pDocument, const QFile& pFile)
+{
+  qWarning() << "addFileToDocument not implemented";
+  return false;
+}
+
+

--- a/src/adaptors/UBImportSMART.cpp
+++ b/src/adaptors/UBImportSMART.cpp
@@ -75,7 +75,7 @@ QStringList UBImportSMART::supportedExtentions()
 QString UBImportSMART::importFileFilter()
 {
     QString filter = tr("SMART Notebook (");
-    QStringList formats = supportedExtentions();
+    const QStringList formats = supportedExtentions();
     bool isFirst = true;
 
     for (const QString &format : formats)

--- a/src/adaptors/UBImportSMART.cpp
+++ b/src/adaptors/UBImportSMART.cpp
@@ -208,7 +208,8 @@ void UBImportSMART::importSinglePage(UBDocumentProxy* document,
     qreal newHeight = scene->width() * 0.75;
     adjust_y -= 0.5 * (scene->height() - newHeight);
 
-    for (QGraphicsItem* item : scene->items())
+    const auto sceneItems = scene->items();
+    for (QGraphicsItem* item : sceneItems)
     {
         if (nullptr == item->parentItem() && item->isVisible())
             item->setPos(item->x() - adjust_x, item->y() - adjust_y);
@@ -342,4 +343,3 @@ bool UBImportSMART::addFileToDocument(UBDocumentProxy* pDocument, const QFile& p
   qWarning() << "addFileToDocument not implemented";
   return false;
 }
-

--- a/src/adaptors/UBImportSMART.cpp
+++ b/src/adaptors/UBImportSMART.cpp
@@ -78,7 +78,7 @@ QString UBImportSMART::importFileFilter()
     QStringList formats = supportedExtentions();
     bool isFirst = true;
 
-    foreach(QString format, formats)
+    for (const QString &format : formats)
     {
             if(isFirst)
                     isFirst = false;
@@ -342,5 +342,4 @@ bool UBImportSMART::addFileToDocument(UBDocumentProxy* pDocument, const QFile& p
   qWarning() << "addFileToDocument not implemented";
   return false;
 }
-
 

--- a/src/adaptors/UBImportSMART.cpp
+++ b/src/adaptors/UBImportSMART.cpp
@@ -298,7 +298,7 @@ UBDocumentProxy* UBImportSMART::importFile(const QFile& pFile, const QString& pG
 
             QSize sceneSize;
             sceneSize.setWidth(rect.width());
-            sceneSize.setHeight(newHeight());
+            sceneSize.setHeight(newHeight);
             scene->setNominalSize(sceneSize);
 
             UBPersistenceManager::persistenceManager()->insertDocumentSceneAt(document, scene, pageIndex++);

--- a/src/adaptors/UBImportSMART.h
+++ b/src/adaptors/UBImportSMART.h
@@ -50,7 +50,7 @@ class UBImportSMART : public UBDocumentBasedImportAdaptor
 
     private:
         QString expandFileToDir(const QFile& pZipFile, const QString& pDir);
-        void importSinglePage(UBDocumentProxy* document,  QString file);
+        void importSinglePage(UBDocumentProxy* document, QByteArray xml);
 };
 
 #endif // UBIMPORTSMART_H

--- a/src/adaptors/UBImportSMART.h
+++ b/src/adaptors/UBImportSMART.h
@@ -50,6 +50,7 @@ class UBImportSMART : public UBDocumentBasedImportAdaptor
 
     private:
         QString expandFileToDir(const QFile& pZipFile, const QString& pDir);
+        void importSinglePage(UBDocumentProxy* document,  QString file);
 };
 
 #endif // UBIMPORTSMART_H

--- a/src/adaptors/UBImportSMART.h
+++ b/src/adaptors/UBImportSMART.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015-2018 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * Copyright (C) 2013 Open Education Foundation
+ *
+ * Copyright (C) 2010-2013 Groupement d'Intérêt Public pour
+ * l'Education Numérique en Afrique (GIP ENA)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#ifndef UBIMPORTSMARTFF_H
+#define UBIMPORTSMART_H
+
+#include <QtGui>
+#include "UBImportAdaptor.h"
+
+class UBDocumentProxy;
+
+class UBImportSMART : public UBDocumentBasedImportAdaptor
+{
+    Q_OBJECT;
+
+    public:
+        UBImportSMART(QObject *parent = 0);
+        virtual ~UBImportSMART();
+
+        virtual QStringList supportedExtentions();
+        virtual QString importFileFilter();
+
+        virtual bool addFileToDocument(UBDocumentProxy* pDocument, const QFile& pFile);
+        virtual UBDocumentProxy* importFile(const QFile& pFile, const QString& pGroup);
+
+    private:
+        QString expandFileToDir(const QFile& pZipFile, const QString& pDir);
+};
+
+#endif // UBIMPORTSMART_H

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -1871,20 +1871,18 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromPol
         QPointF point;
         for (i = ts.constBegin(); i != ts.constEnd(); ++i)
         {
-            sCoord = i->toString().split(QLatin1Char(','), QString::SkipEmptyParts);
+            char *p = i->toUtf8().data();
 
-            if (sCoord.size() == 2)
+            float x, y;
+            x = atof(p);
+            p = strchr(p, ',');
+            if (p)
             {
-                point.setX(sCoord.at(0).toFloat());
-                point.setY(sCoord.at(1).toFloat());
-                polygon << point;
-            }
-            else if (sCoord.size() == 4){
-                //This is the case on system were the "," is used to seperate decimal
-                QString x = sCoord.at(0) + "." + sCoord.at(1);
-                QString y = sCoord.at(2) + "." + sCoord.at(3);
-                point.setX(x.toFloat());
-                point.setY(y.toFloat());
+                p++;
+                y = atof(p);
+
+                point.setX(x);
+                point.setY(y);
                 polygon << point;
             }
             else

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -333,7 +333,8 @@ QUuid UBSvgSubsetAdaptor::sceneUuid(UBDocumentProxy* proxy, const int pageIndex)
 
 UBGraphicsScene* UBSvgSubsetAdaptor::loadScene(UBDocumentProxy* proxy, const QByteArray& pArray)
 {
-    UBSvgSubsetReader reader(proxy, UBTextTools::cleanHtmlCData(QString(pArray)).toUtf8());
+    //UBSvgSubsetReader reader(proxy, UBTextTools::cleanHtmlCData(QString(pArray)).toUtf8());
+    UBSvgSubsetReader reader(proxy, pArray);
     return reader.loadScene(proxy);
 }
 
@@ -348,7 +349,7 @@ UBSvgSubsetAdaptor::UBSvgSubsetReader::UBSvgSubsetReader(UBDocumentProxy* pProxy
 
 UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProxy* proxy)
 {
-    qDebug() << "loadScene() : starting reading...";
+    qWarning() << "loadScene() : starting reading...";
     QTime time;
     time.start();
     mScene = 0;
@@ -1045,8 +1046,8 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
         mScene->enableUndoRedoStack();
     }
 
-    qDebug() << "loadScene() : created scene and read file";
-    qDebug() << "spent milliseconds: " << time.elapsed();
+    qWarning() << "loadScene() : created scene and read file";
+    qWarning() << "spent milliseconds: " << time.elapsed();
     return mScene;
 }
 
@@ -1862,22 +1863,24 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromPol
 
     if (!svgPoints.isNull())
     {
-        QStringList ts = svgPoints.toString().split(QLatin1Char(' '), QString::SkipEmptyParts);
+        QVector<QStringRef> ts = svgPoints.split(QLatin1Char(' '), QString::SkipEmptyParts);
+        polygon.reserve(ts.length());
 
-        foreach(const QString sPoint, ts)
+        QVector<QStringRef>::const_iterator i;
+        QStringList sCoord;
+        QPointF point;
+        for (i = ts.constBegin(); i != ts.constEnd(); ++i)
         {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), QString::SkipEmptyParts);
+            sCoord = i->toString().split(QLatin1Char(','), QString::SkipEmptyParts);
 
             if (sCoord.size() == 2)
             {
-                QPointF point;
                 point.setX(sCoord.at(0).toFloat());
                 point.setY(sCoord.at(1).toFloat());
                 polygon << point;
             }
             else if (sCoord.size() == 4){
                 //This is the case on system were the "," is used to seperate decimal
-                QPointF point;
                 QString x = sCoord.at(0) + "." + sCoord.at(1);
                 QString y = sCoord.at(2) + "." + sCoord.at(3);
                 point.setX(x.toFloat());

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -2991,6 +2991,7 @@ void UBSvgSubsetAdaptor::UBSvgSubsetReader::readFontAttributes (QFont& font)
 void UBSvgSubsetAdaptor::UBSvgSubsetReader::extractSvgText (QFont& font, qreal& dx, qreal& dy, qreal& textEnd, UBGraphicsTextItem*& textItem, qreal& last_y)
 {
     QString text;
+    bool lumpTextTogether = UBSettings::settings()->importCombineText->get().toBool();
     readFontAttributes(font);
 
     // dx, dy are from transform property on <text> element
@@ -3029,7 +3030,8 @@ void UBSvgSubsetAdaptor::UBSvgSubsetReader::extractSvgText (QFont& font, qreal& 
               // There should also be an option to combine separate
               // lines into a single text item.
               if (textItem
-                  && ((x == 0.0 && y == 0.0) // no x, y given
+                  && (lumpTextTogether
+                       || (x == 0.0 && y == 0.0) // no x, y given
                        || (-5.e-1 < x - textEnd && x - textEnd < 5.e-1
                            && y == last_y)))
               {

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -1004,8 +1004,11 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
                 }
                 writer.writeCurrentToken(mXmlReader);
 
-                qWarning() << "Reading" << outerXml;
-                QString svgDoc = QString("<svg>%1</svg>").arg(outerXml);
+                QString svgDoc = QString(
+                    "<svg width=\"%1\" height=\"%2\">%3</svg>")
+                       .arg(QString::number(mScene->width()))
+                       .arg(QString::number(mScene->height()))
+                       .arg(outerXml);
                 QSvgRenderer renderer(svgDoc.toUtf8());
                 if (!renderer.isValid())
                 {
@@ -1015,7 +1018,6 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
                 {
                     QString imagePath = QString("%1/%2").arg(mDocumentPath, "images");
                     QString path = QString("%1/UB-import.svg").arg(imagePath);
-                    qDebug() << "OPEN " << path;
                     QFile file(path);
                     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
                     {
@@ -1027,6 +1029,9 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
                     file.close();
 
                     UBGraphicsSvgItem *svgItem = mScene->addSvg(QUrl::fromLocalFile(path));
+                    // reset to identity transform
+                    svgItem->setPos(0,0);
+                    svgItem->setTransform(QTransform());
 
                     QString uuid = QUuid::createUuid().toString();
                     svgItem->setUuid(QUuid(uuid));

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -3148,7 +3148,8 @@ void UBSvgSubsetAdaptor::UBSvgSubsetReader::doTransform (QString& trString, qrea
   qreal angle = 0.0;
 #endif
 
-  foreach(QString trStr, trString.split(" ", QString::SkipEmptyParts))
+  const auto splitTrString = trString.split(" ", QString::SkipEmptyParts);
+  for (const QString &trStr : splitTrString)
   {
       QRegExp regexp;
 #if 0

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -940,16 +940,22 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
                     color.setNamedColor(fill);
                     if (color.isValid())
                     {
-                      brush.setColor(color);
-                      auto rect = new QGraphicsRectItem(x, y, width, height);
-                      graphicsItemFromSvg(rect);
+                      if (height == mScene->height()
+                          && width == mScene->width())
+                        mScene->setBgColor(color);
+                      else
+                      {
+                        brush.setColor(color);
+                        auto rect = new QGraphicsRectItem(x, y, width, height);
+                        graphicsItemFromSvg(rect);
 
-                      mScene->addItem(rect);
-                      rect->setBrush(brush);
+                        mScene->addItem(rect);
+                        rect->setBrush(brush);
 
-                      QPen pen;
-                      pen.setStyle(Qt::NoPen);
-                      rect->setPen(pen);
+                        QPen pen;
+                        pen.setStyle(Qt::NoPen);
+                        rect->setPen(pen);
+                      }
                     }
                  }
                  // color could also be "white" or "black" representing
@@ -1196,7 +1202,12 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::writeSvgElement(UBDocumentProxy* pro
 
 
     mXmlWriter.writeStartElement("rect");
-    mXmlWriter.writeAttribute("fill", mScene->isDarkBackground() ? "black" : "white");
+    QString fillString;
+    if (mScene->bgColor().isValid())
+      fillString = mScene->bgColor().name();
+    else
+      fillString = mScene->isDarkBackground() ? "black" : "white";
+    mXmlWriter.writeAttribute("fill", fillString);
     mXmlWriter.writeAttribute("x", QString::number(normalized.x()));
     mXmlWriter.writeAttribute("y", QString::number(normalized.y()));
     mXmlWriter.writeAttribute("width", QString::number(normalized.width()));

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -958,11 +958,6 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
                       }
                     }
                  }
-                 // color could also be "white" or "black" representing
-                 // the background of the page: do not add a
-                 // QGraphicsRectItem for these as this makes the page
-                 // non-empty and stops an empty document being removed
-                 // at closing time.
               }
             }
             else if (currentWidget && (mXmlReader.name() == "preference"))

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -1703,26 +1703,26 @@ bool UBSvgSubsetAdaptor::UBSvgSubsetWriter::persistScene(UBDocumentProxy* proxy,
 void
 UBSvgSubsetAdaptor::UBSvgSubsetWriter::persistDefs()
 {
-  QPixmap bgPattern = mScene->bgPattern();
-  QString bgPatternName = mScene->bgPatternName();
-  if (bgPattern.isNull())
+    QPixmap bgPattern = mScene->bgPattern();
+    QString bgPatternName = mScene->bgPatternName();
+    if (bgPattern.isNull())
       return;
-  mXmlWriter.writeStartElement("defs");
-  mXmlWriter.writeStartElement("pattern");
-  mXmlWriter.writeAttribute("x", "0");
-  mXmlWriter.writeAttribute("y", "0");
-  mXmlWriter.writeAttribute("patternUnits", "userSpaceOnUse");
-  mXmlWriter.writeAttribute("width", QString::number(bgPattern.width()));
-  mXmlWriter.writeAttribute("height", QString::number(bgPattern.height()));
-  mXmlWriter.writeAttribute("id", bgPatternName);
+    mXmlWriter.writeStartElement("defs");
+    mXmlWriter.writeStartElement("pattern");
+    mXmlWriter.writeAttribute("x", "0");
+    mXmlWriter.writeAttribute("y", "0");
+    mXmlWriter.writeAttribute("patternUnits", "userSpaceOnUse");
+    mXmlWriter.writeAttribute("width", QString::number(bgPattern.width()));
+    mXmlWriter.writeAttribute("height", QString::number(bgPattern.height()));
+    mXmlWriter.writeAttribute("id", bgPatternName);
 
-  mXmlWriter.writeStartElement("image");
-  QString fileName = QString("%1/%2.png").arg("images").arg(bgPatternName);
-  mXmlWriter.writeAttribute(nsXLink, "href", fileName);
+    mXmlWriter.writeStartElement("image");
+    QString fileName = QString("%1/%2.png").arg("images").arg(bgPatternName);
+    mXmlWriter.writeAttribute(nsXLink, "href", fileName);
 
-  mXmlWriter.writeEndElement();
-  mXmlWriter.writeEndElement();
-  mXmlWriter.writeEndElement();
+    mXmlWriter.writeEndElement();
+    mXmlWriter.writeEndElement();
+    mXmlWriter.writeEndElement();
 }
 
 void UBSvgSubsetAdaptor::UBSvgSubsetWriter::persistGroupToDom(QGraphicsItem *groupItem, QDomElement *curParent, QDomDocument *groupDomDocument)

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -1803,7 +1803,9 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::polygonItemToSvgPolygon(UBGraphicsPo
 
         QString points = pointsToSvgPointsAttribute(polygon);
         mXmlWriter.writeAttribute("points", points);
-        mXmlWriter.writeAttribute("transform",toSvgTransform(polygonItem->matrix()));
+        QMatrix matrix = polygonItem->matrix();
+        if (!matrix.isIdentity())
+            mXmlWriter.writeAttribute("transform", toSvgTransform(matrix));
         mXmlWriter.writeAttribute("fill", polygonItem->brush().color().name());
 
         qreal alpha = polygonItem->brush().color().alphaF();

--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -183,6 +183,12 @@ class UBSvgSubsetAdaptor
                 UBGraphicsScene *mScene;
 
                 QHash<QString,UBGraphicsStrokesGroup*> mStrokesList;
+
+                void startSvgPattern();
+                void finishSvgPattern();
+                QString patternID;
+                qreal patternWidth;
+                qreal patternHeight;
         };
 
         class UBSvgSubsetWriter

--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -189,6 +189,8 @@ class UBSvgSubsetAdaptor
                 QString patternID;
                 qreal patternWidth;
                 qreal patternHeight;
+
+                void importSvgElement(QStringRef name);
         };
 
         class UBSvgSubsetWriter

--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -267,6 +267,7 @@ class UBSvgSubsetAdaptor
                 void cacheToSvg(UBGraphicsCache* item);
                 void triangleToSvg(UBGraphicsTriangle *item);
                 void writeSvgElement(UBDocumentProxy *proxy);
+                void persistDefs();
 
         private:
 

--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -140,6 +140,15 @@ class UBSvgSubsetAdaptor
 
                 UBGraphicsTextItem* textItemFromSvg();
 
+                void addTextItemsFromSvg();
+                void extractSvgText (QFont& font, qreal& dx, qreal& dy, qreal& textEnd, UBGraphicsTextItem*& textItem, qreal& last_y);
+                void doTransform (QString& trString,  qreal& dx, qreal& dy);
+                void readFontAttributes (QFont& font);
+
+                void parseTextAttributes(qreal &fontSize, QColor &fontColor, QString &fontFamily,
+                                                                QString &fontStretch, bool &italic, int &fontWeight);
+
+
                 UBGraphicsCurtainItem* curtainItemFromSvg();
 
                 UBGraphicsRuler* rulerFromSvg();

--- a/src/adaptors/adaptors.pri
+++ b/src/adaptors/adaptors.pri
@@ -11,6 +11,7 @@ HEADERS      += src/adaptors/UBExportAdaptor.h\
                 src/adaptors/UBImportPDF.h \
                 src/adaptors/UBImportImage.h \
                 src/adaptors/UBExportWeb.h \
+                src/adaptors/UBImportSMART.h \
     $$PWD/UBExportDocumentSetAdaptor.h \
     $$PWD/UBImportDocumentSetAdaptor.h \
     $$PWD/UBExportCFF.h \
@@ -30,6 +31,7 @@ SOURCES      += src/adaptors/UBExportAdaptor.cpp\
                 src/adaptors/UBImportPDF.cpp \
                 src/adaptors/UBImportImage.cpp \
                 src/adaptors/UBExportWeb.cpp \
+                src/adaptors/UBImportSMART.cpp \
     $$PWD/UBExportDocumentSetAdaptor.cpp \
     $$PWD/UBImportDocumentSetAdaptor.cpp \
     $$PWD/UBExportCFF.cpp \

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1606,6 +1606,7 @@ void UBBoardView::drawBackground (QPainter *painter, const QRectF &rect)
         QBrush brush;
         brush.setTexture(bgPixmap);
         painter->setBrushOrigin(-scene()->width() / 2, -scene()->height() / 2);
+        painter->setRenderHints(QPainter::SmoothPixmapTransform);
         painter->fillRect (rect, brush);
     }
     else if (scene()->bgColor().isValid())

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1601,7 +1601,11 @@ void UBBoardView::drawBackground (QPainter *painter, const QRectF &rect)
 
     bool darkBackground = scene () && scene ()->isDarkBackground ();
 
-    if (darkBackground)
+    if (scene()->bgColor().isValid())
+    {
+        painter->fillRect (rect, QBrush (scene()->bgColor()));
+    }
+    else if (darkBackground)
     {
         painter->fillRect (rect, QBrush (QColor (Qt::black)));
     }

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1598,10 +1598,17 @@ void UBBoardView::drawBackground (QPainter *painter, const QRectF &rect)
         QGraphicsView::drawBackground (painter, rect);
         return;
     }
-
     bool darkBackground = scene () && scene ()->isDarkBackground ();
 
-    if (scene()->bgColor().isValid())
+    QPixmap bgPixmap = scene()->bgPattern();
+    if (!bgPixmap.isNull())
+    {
+        QBrush brush;
+        brush.setTexture(bgPixmap);
+        painter->setBrushOrigin(-scene()->width() / 2, -scene()->height() / 2);
+        painter->fillRect (rect, brush);
+    }
+    else if (scene()->bgColor().isValid())
     {
         painter->fillRect (rect, QBrush (scene()->bgColor()));
     }

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1582,8 +1582,16 @@ void UBBoardView::dropEvent (QDropEvent *event)
 
 void UBBoardView::resizeEvent (QResizeEvent * event)
 {
-    const qreal maxWidth = width () * 10;
-    const qreal maxHeight = height () * 10;
+    QRectF oldRect = sceneRect();
+
+    qreal maxWidth = width () * 10;
+    qreal maxHeight = height () * 20;
+
+    // avoid making parts of a large page inaccessible
+    if (maxWidth < oldRect.width())
+        maxWidth = oldRect.width();
+    if (maxHeight < oldRect.height())
+        maxHeight = oldRect.height();
 
     setSceneRect (-(maxWidth / 2), -(maxHeight / 2), maxWidth, maxHeight);
     centerOn (0, 0);

--- a/src/core/UBDocumentManager.cpp
+++ b/src/core/UBDocumentManager.cpp
@@ -38,6 +38,7 @@
 #include "adaptors/UBImportPDF.h"
 #include "adaptors/UBImportImage.h"
 #include "adaptors/UBImportCFF.h"
+#include "adaptors/UBImportSMART.h"
 #include "adaptors/UBImportDocumentSetAdaptor.h"
 
 #include "domain/UBGraphicsScene.h"
@@ -101,6 +102,8 @@ UBDocumentManager::UBDocumentManager(QObject *parent)
     mImportAdaptors.append(imageImport);
     UBImportCFF* cffImport = new UBImportCFF(this);
     mImportAdaptors.append(cffImport);
+    UBImportSMART* smartImport = new UBImportSMART(this);
+    mImportAdaptors.append(smartImport);
 }
 
 

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -866,6 +866,7 @@ void UBPersistenceManager::insertDocumentSceneAt(UBDocumentProxy* proxy, UBGraph
     mSceneCache.shiftUpScenes(proxy, index, count -1);
 
     mSceneCache.insert(proxy, index, scene);
+    scene->setModified(true);
 
     proxy->incPageCount();
 

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -258,6 +258,11 @@ void UBPreferencesController::wire()
     connect(mMarkerProperties->pressureSensitiveCheckBox, SIGNAL(clicked(bool)), settings, SLOT(setMarkerPressureSensitive(bool)));
     connect(mMarkerProperties->opacitySlider, SIGNAL(valueChanged(int)), this, SLOT(opacitySliderChanged(int)));
 
+
+    // SMART Notebook import options
+    connect(mPreferencesUI->importCombineTextCheckBox, SIGNAL(clicked(bool)), settings->importCombineText, SLOT(setBool(bool)));
+    connect(mPreferencesUI->importViewWholePagesCheckBox, SIGNAL(clicked(bool)), settings->importViewWholePages, SLOT(setBool(bool)));
+
     // about tab
     connect(mPreferencesUI->checkSoftwareUpdateAtLaunchCheckBox, SIGNAL(clicked(bool)), settings->appEnableAutomaticSoftwareUpdates, SLOT(setBool(bool)));
 
@@ -318,6 +323,9 @@ void UBPreferencesController::init()
 
     mMarkerProperties->opacitySlider->setValue(settings->boardMarkerAlpha->get().toDouble() * 100);
 
+    // import tab
+    mPreferencesUI->importViewWholePagesCheckBox->setChecked(settings->importViewWholePages->get().toBool());
+    mPreferencesUI->importCombineTextCheckBox->setChecked(settings->importCombineText->get().toBool());
 }
 
 void UBPreferencesController::close()
@@ -444,6 +452,13 @@ void UBPreferencesController::defaultSettings()
         mPreferencesUI->lightBackgroundOpacitySlider->setValue(lightBackgroundOpacity);
         lightBackgroundCrossOpacityValueChanged(lightBackgroundOpacity);
 
+    }
+    else if (mPreferencesUI->mainTabWidget->currentWidget() == mPreferencesUI->importTab)
+    {
+        bool defaultValue = settings->importCombineText->reset().toBool();
+        mPreferencesUI->importCombineTextCheckBox->setChecked(defaultValue);
+        defaultValue = settings->importViewWholePages->reset().toBool();
+        mPreferencesUI->importViewWholePagesCheckBox->setChecked(defaultValue);
     }
 }
 

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -464,6 +464,9 @@ void UBSettings::init()
     emptyTrashForOlderDocuments = new UBSetting(this, "Document", "emptyTrashForOlderDocuments", false);
     emptyTrashDaysValue = new UBSetting(this, "Document", "emptyTrashDaysValue", 30);
 
+    importViewWholePages = new UBSetting(this, "Import", "ViewWholePages", false);
+    importCombineText = new UBSetting(this, "Import", "CombineText", false);
+
     cleanNonPersistentSettings();
     checkNewSettings();
 }

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -423,6 +423,9 @@ class UBSettings : public QObject
         UBSetting* magnifierDrawingMode;
         UBSetting* autoSaveInterval;
 
+        UBSetting* importViewWholePages;
+        UBSetting* importCombineText;
+
     public slots:
 
         void setPenWidthIndex(int index);

--- a/src/domain/UBGraphicsPixmapItem.cpp
+++ b/src/domain/UBGraphicsPixmapItem.cpp
@@ -192,3 +192,17 @@ void UBGraphicsPixmapItem::clearSource()
     QString diskPath =  UBApplication::boardController->selectedDocument()->persistencePath() + "/" + fileName;
     UBFileSystemUtils::deleteFile(diskPath);
 }
+
+void UBGraphicsPixmapItem::setHref(QStringRef href)
+{
+  mHref.clear();
+  mHref.append(href);
+}
+
+QString UBGraphicsPixmapItem::getHref()
+{
+  if (!mHref.isNull())
+    return mHref;
+  else
+    return UBPersistenceManager::imageDirectory + "/" + this->uuid().toString() + ".png";
+}

--- a/src/domain/UBGraphicsPixmapItem.h
+++ b/src/domain/UBGraphicsPixmapItem.h
@@ -31,6 +31,7 @@
 #define UBGRAPHICSPIXMAPITEM_H_
 
 #include <QtGui>
+#include <QString>
 
 #include "core/UB.h"
 
@@ -66,6 +67,8 @@ class UBGraphicsPixmapItem : public QObject, public QGraphicsPixmapItem, public 
         virtual void clearSource();
 
         virtual void setUuid(const QUuid &pUuid);
+        QString getHref();
+        void setHref(QStringRef href);
 
 protected:
 
@@ -76,6 +79,9 @@ protected:
         virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
 
         virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+
+private:
+  	QString mHref;
 };
 
 #endif /* UBGRAPHICSPIXMAPITEM_H_ */

--- a/src/domain/UBGraphicsPolygonItem.cpp
+++ b/src/domain/UBGraphicsPolygonItem.cpp
@@ -186,7 +186,7 @@ void UBGraphicsPolygonItem::paint ( QPainter * painter, const QStyleOptionGraphi
     if(mHasAlpha && scene() && scene()->isLightBackground())
         painter->setCompositionMode(QPainter::CompositionMode_SourceOver);
 
-    painter->setRenderHints(QPainter::Antialiasing);
+    //painter->setRenderHints(QPainter::Antialiasing);
 
     QGraphicsPolygonItem::paint(painter, option, widget);
 }

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2620,7 +2620,17 @@ void UBGraphicsScene::drawBackground(QPainter *painter, const QRectF &rect)
     }
     bool darkBackground = isDarkBackground ();
 
-    if (mBgColor.isValid())
+    if (!mBgPattern.isEmpty())
+    {
+      QPixmap pixmap = mPatterns[mBgPattern];
+      if (!pixmap.isNull())
+      {
+        QBrush brush;
+        brush.setTexture(pixmap);
+        painter->fillRect (rect, brush);
+      }
+    }
+    else if (mBgColor.isValid())
     {
       painter->fillRect (rect, QBrush (mBgColor));
     }

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2620,7 +2620,11 @@ void UBGraphicsScene::drawBackground(QPainter *painter, const QRectF &rect)
     }
     bool darkBackground = isDarkBackground ();
 
-    if (darkBackground)
+    if (mBgColor.isValid())
+    {
+      painter->fillRect (rect, QBrush (mBgColor));
+    }
+    else if (darkBackground)
     {
       painter->fillRect (rect, QBrush (QColor (Qt::black)));
     }

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -235,6 +235,13 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem
             return (mBackgroundObject != 0);
         }
 
+        void setBgColor(const QColor &color)
+        {
+            mBgColor = color;
+        }
+
+        QColor bgColor() { return mBgColor; }
+
         void addRuler(QPointF center);
         void addProtractor(QPointF center);
         void addCompass(QPointF center);
@@ -441,6 +448,7 @@ public slots:
         bool mDarkBackground;
         UBPageBackground mPageBackground;
         int mBackgroundGridSize;
+        QColor mBgColor;
 
         bool mIsDesktopMode;
         qreal mZoomFactor;

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -235,12 +235,19 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem
             return (mBackgroundObject != 0);
         }
 
-        void setBgColor(const QColor &color)
-        {
-            mBgColor = color;
-        }
+        void setBgColor(const QColor &color) { mBgColor = color; }
 
         QColor bgColor() { return mBgColor; }
+
+        void setBgPattern(const QString& pattern) { mBgPattern = pattern; }
+        QPixmap bgPattern() { return mPatterns[mBgPattern]; }
+
+        void addPattern(QString id, QPixmap& pixmap)
+        {
+          mPatterns[id] = pixmap;
+        }
+
+        QPixmap getPattern(QString id) { return mPatterns[id]; }
 
         void addRuler(QPointF center);
         void addProtractor(QPointF center);
@@ -449,6 +456,8 @@ public slots:
         UBPageBackground mPageBackground;
         int mBackgroundGridSize;
         QColor mBgColor;
+        QString mBgPattern;
+        QHash <QString, QPixmap> mPatterns;
 
         bool mIsDesktopMode;
         qreal mZoomFactor;

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -240,6 +240,7 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem
         QColor bgColor() { return mBgColor; }
 
         void setBgPattern(const QString& pattern) { mBgPattern = pattern; }
+        QString bgPatternName() { return mBgPattern; }
         QPixmap bgPattern() { return mPatterns[mBgPattern]; }
 
         void addPattern(QString id, QPixmap& pixmap)

--- a/src/pdf/XPDFRenderer.h
+++ b/src/pdf/XPDFRenderer.h
@@ -89,7 +89,7 @@ class XPDFRenderer : public PDFRenderer
         void init();
 
         struct PdfZoomCacheData {
-            PdfZoomCacheData(double const a_ratio) : splashBitmap(nullptr), cachedPageNumber(-1), splash(nullptr), ratio(a_ratio), hasToBeProcessed(false) {};
+            PdfZoomCacheData(double const a_ratio = 1.0) : splashBitmap(nullptr), cachedPageNumber(-1), splash(nullptr), ratio(a_ratio), hasToBeProcessed(false) {};
             ~PdfZoomCacheData() {};
             SplashBitmap* splashBitmap;
             //! Note: The 'cachedImage' uses a buffer from 'splash'. Make sure it is invalidated BEFORE 'splash' deallocation.


### PR DESCRIPTION
Linked to issue #404. Recreated pull request with some commits removed. (Old pull request was https://github.com/OpenBoard-org/OpenBoard/pull/424).

Here is the work I have done on creating a SMART Notebook importer. Importing text, images, pen strokes, shapes and page backgrounds is supported.

Before I continue work on missing features it would be very helpful to have some feedback before the code diverges too much from the original, and to avoid creating an incompatible version of OpenBoard.

As well as implementing missing features, I also want to look at building the software for Microsoft Windows.

Some of the changes to the `src/adaptors/UBSvgSubsetAdaptor.cpp` file may affect loading native OpenBoard documents:
* I replaced the handling of the <text> SVG element with new code. The old code used the same code to handle these as to handle text elements output by OpenBoard (which are not output as \<text\> elements, but as \<foreignObject\> elements) , with a comment: "This is for backward compatibility with proto text field prior to version 4.3". Since OpenBoard is only at version 1.5 I assume this refers to one of OpenBoard's predecessor projects (OpenSankoré or UniBoard).
* In `loadScene` in `src/adaptors/UBSvgSubsetAdaptor.cpp`, there was a `currentStroke` variable whose purpose I didn't understand. This led to separate strokes in the source file being joined together as one continuous stroke when a file was saved and reloaded. In these changes, a new `UBGraphicsStroke` is created for each stroke in the source file.
* In the SMART Notebook format, it's possible for an image to be referenced more than once (which will happen if a page is duplicated). To accommodate this I allowed image files to be named with their original names rather than a filename based on a "UUID".

I compiled this under Linux Mint 19.2. I tested with my personal collection of SMART Notebook files (most created with SMART Notebook 11). I can supply test files on request.
