### PR TITLE
Fix broken shortcuts with German translation

### DIFF
--- a/resources/i18n/OpenBoard_de.ts
+++ b/resources/i18n/OpenBoard_de.ts
@@ -85,7 +85,7 @@
     </message>
     <message>
         <source>Ctrl+T</source>
-        <translation>Strg + T</translation>
+        <translation>Strg+T</translation>
     </message>
     <message>
         <source>Backgrounds</source>
@@ -101,7 +101,7 @@
     </message>
     <message>
         <source>Ctrl+Z</source>
-        <translation>Strg + Z</translation>
+        <translation>Strg+Z</translation>
     </message>
     <message>
         <source>Redo</source>
@@ -109,7 +109,7 @@
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation>Strg + Y</translation>
+        <translation>Strg+Y</translation>
     </message>
     <message>
         <source>Previous</source>
@@ -141,7 +141,7 @@
     </message>
     <message>
         <source>Ctrl+D</source>
-        <translation>Strg + D</translation>
+        <translation>Strg+D</translation>
     </message>
     <message>
         <source>Web Browsing</source>
@@ -149,7 +149,7 @@
     </message>
     <message>
         <source>Ctrl+W</source>
-        <translation>Strg + W</translation>
+        <translation>Strg+W</translation>
     </message>
     <message>
         <source>Line</source>
@@ -245,7 +245,7 @@
     </message>
     <message>
         <source>Ctrl+B</source>
-        <translation>Strg + B</translation>
+        <translation>Strg+B</translation>
     </message>
     <message>
         <source>Erase</source>
@@ -273,7 +273,7 @@
     </message>
     <message>
         <source>Ctrl+L</source>
-        <translation>Strg + L</translation>
+        <translation>Strg+L</translation>
     </message>
     <message>
         <source>Show Desktop</source>
@@ -285,7 +285,7 @@
     </message>
     <message>
         <source>Ctrl+Shift+H</source>
-        <translation>Strg + Umschalt + H</translation>
+        <translation>Strg+Umschalt+H</translation>
     </message>
     <message>
         <source>Bigger</source>
@@ -353,7 +353,7 @@
     </message>
     <message>
         <source>Ctrl+O</source>
-        <translation>Strg + O</translation>
+        <translation>Strg+O</translation>
     </message>
     <message>
         <source>Duplicate</source>
@@ -545,7 +545,7 @@
     </message>
     <message>
         <source>Ctrl+I</source>
-        <translation>Strg + I</translation>
+        <translation>Strg+I</translation>
     </message>
     <message>
         <source>Erase Annotation</source>
@@ -553,7 +553,7 @@
     </message>
     <message>
         <source>Ctrl+E</source>
-        <translation>Strg + E</translation>
+        <translation>Strg+E</translation>
     </message>
     <message>
         <source>Marker</source>
@@ -565,7 +565,7 @@
     </message>
     <message>
         <source>Ctrl+M</source>
-        <translation>Strg + M</translation>
+        <translation>Strg+M</translation>
     </message>
     <message>
         <source>Selector</source>
@@ -577,7 +577,7 @@
     </message>
     <message>
         <source>Ctrl+F</source>
-        <translation>Strg + F</translation>
+        <translation>Strg+F</translation>
     </message>
     <message>
         <source>Hand</source>
@@ -597,7 +597,7 @@
     </message>
     <message>
         <source>Ctrl+G</source>
-        <translation>Strg + G</translation>
+        <translation>Strg+G</translation>
     </message>
     <message>
         <source>Draw Lines</source>
@@ -605,7 +605,7 @@
     </message>
     <message>
         <source>Ctrl+J</source>
-        <translation>Strg + J</translation>
+        <translation>Strg+J</translation>
     </message>
     <message>
         <source>Text</source>
@@ -617,7 +617,7 @@
     </message>
     <message>
         <source>Ctrl+K</source>
-        <translation>Strg + K</translation>
+        <translation>Strg+K</translation>
     </message>
     <message>
         <source>Capture</source>
@@ -757,7 +757,7 @@
     </message>
     <message>
         <source>Ctrl+H</source>
-        <translation>Strg + H</translation>
+        <translation>Strg+H</translation>
     </message>
     <message>
         <source>OpenBoard</source>
@@ -1232,7 +1232,7 @@
     </message>
     <message>
         <source>Empty My Documents</source>
-        <translation type="unfinished"></translation>
+        <translation>Eigene Dokumente leeren</translation>
     </message>
 </context>
 <context>
@@ -2589,7 +2589,7 @@ Bitte starten Sie die Anwendung erneut, um auf die aktualisierten Dokumente zugr
     <name>XPDFRenderer</name>
     <message>
         <source>Processing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Verarbeitet...</translation>
     </message>
 </context>
 <context>
@@ -2947,11 +2947,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>PDF Rendering</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF Darstellung</translation>
     </message>
     <message>
         <source>Enable quality loss to increase zoom performances</source>
-        <translation type="unfinished"></translation>
+        <translation>Reduzierte Qualität für schnelleres Zoomen</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Shortcuts are broken when using the German translation.

To fix this, this pull requests removes spaces from translation of shortcuts. Additionally it adds some missing translations.

Fixes #428

