### PR TITLE
Make pointer diameter configurable

### DIFF
--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -466,6 +466,8 @@ void UBSettings::init()
     emptyTrashForOlderDocuments = new UBSetting(this, "Document", "emptyTrashForOlderDocuments", false);
     emptyTrashDaysValue = new UBSetting(this, "Document", "emptyTrashDaysValue", 30);
 
+    pointerDiameter = value("Board/PointerDiameter", pointerDiameter).toInt();
+
     cleanNonPersistentSettings();
     checkNewSettings();
 }


### PR DESCRIPTION
Pointer diameter is now configurable using the settings. Add e.g.

```
[Board]
PointerDiameter=20
```

to change the pointer diameter from the default size of 40 to 20.

Fixes #444 