### PR TITLE
Detect and handle change of stylusTool while device pressed

### DIFF
--- a/src/board/UBDrawingController.cpp
+++ b/src/board/UBDrawingController.cpp
@@ -120,6 +120,7 @@ void UBDrawingController::setStylusTool(int tool)
             emit colorIndexChanged(UBSettings::settings()->markerColorIndex());
         }
 
+        UBStylusTool::Enum previousTool = mStylusTool;
         mStylusTool = (UBStylusTool::Enum)tool;
 
 
@@ -148,7 +149,7 @@ void UBDrawingController::setStylusTool(int tool)
         else if (mStylusTool == UBStylusTool::Capture)
             UBApplication::mainWindow->actionCapture->setChecked(true);
 
-        emit stylusToolChanged(tool);
+        emit stylusToolChanged(tool, previousTool);
         if (mStylusTool != UBStylusTool::Selector)
             emit colorPaletteChanged();
     }

--- a/src/board/UBDrawingController.h
+++ b/src/board/UBDrawingController.h
@@ -82,7 +82,7 @@ class UBDrawingController : public QObject
         void setEraserWidthIndex(int index);
 
     signals:
-        void stylusToolChanged(int tool);
+        void stylusToolChanged(int tool, int previousTool = -1);
         void colorPaletteChanged();
 
         void lineWidthIndexChanged(int index);

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -141,7 +141,7 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem
 
         bool inputDevicePress(const QPointF& scenePos, const qreal& pressure = 1.0);
         bool inputDeviceMove(const QPointF& scenePos, const qreal& pressure = 1.0);
-        bool inputDeviceRelease();
+        bool inputDeviceRelease(int tool = -1);
 
         void leaveEvent (QEvent* event);
 
@@ -380,6 +380,8 @@ public slots:
         void zoomOutMagnifier();
         void changeMagnifierMode(int mode);
         void resizedMagnifier(qreal newPercent);
+
+        void stylusToolChanged(int tool, int previousTool);
 
     protected:
 


### PR DESCRIPTION
- Basically simulate a device release with the previous tool and a device press with the new tool to correctly terminate the previous action.
- Hide the eraser when switching to another tool.
- Add an additional guard against accessing an element of an empty list.

- Fixes #430 
- Fixes #354 