### PR TITLE
Take systemScaleFactor into account for pointer diameter

### DIFF
--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -808,6 +808,7 @@ void UBGraphicsScene::hideEraser()
 void UBGraphicsScene::drawPointer(const QPointF &pPoint, bool isFirstDraw)
 {
     qreal pointerDiameter = UBSettings::pointerDiameter / UBApplication::boardController->currentZoom();
+    pointerDiameter /= UBApplication::boardController->systemScaleFactor();
     qreal pointerRadius = pointerDiameter / 2;
 
     // TODO UB 4.x optimize - no need to do that every time we move it


### PR DESCRIPTION
When computing the actual radius of the pointer, the `systemScaleFactor` is not included in the calculation. This simple PR fixes this.

Closes https://github.com/OpenBoard-org/OpenBoard/issues/444#issuecomment-798982133