### PR TITLE
Feature: Export background grid/color to PDF

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -128,6 +128,7 @@ Margin=20
 PageFormat=A4
 Resolution=300
 ZoomBehavior=4
+ExportBackgroundGrid=false
 
 [Podcast]
 AudioRecordingDevice=Default

--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -124,11 +124,12 @@ RefreshRateInFramePerSecond=2
 
 [PDF]
 enableQualityLossToIncreaseZoomPerfs=true
+ExportBackgroundGrid=false
+ExportBackgroundColor=false
 Margin=20
 PageFormat=A4
 Resolution=300
 ZoomBehavior=4
-ExportBackgroundGrid=false
 
 [Podcast]
 AudioRecordingDevice=Default

--- a/src/adaptors/UBExportPDF.cpp
+++ b/src/adaptors/UBExportPDF.cpp
@@ -106,7 +106,15 @@ bool UBExportPDF::persistsDocument(UBDocumentProxy* pDocumentProxy, const QStrin
         // set background to white, no crossing for PDF output
         bool isDark = scene->isDarkBackground();
         UBPageBackground pageBackground = scene->pageBackground();
-        scene->setBackground(false, UBPageBackground::plain);
+
+        if (UBSettings::settings()->exportBackgroundGrid->get().toBool())
+        {
+            scene->setBackground(false, pageBackground);
+        }
+        else
+        {
+            scene->setBackground(false, UBPageBackground::plain);
+        }
 
         // pageSize is the output PDF page size; it is set to equal the scene's boundary size; if the contents
         // of the scene overflow from the boundaries, they will be scaled down.

--- a/src/adaptors/UBExportPDF.cpp
+++ b/src/adaptors/UBExportPDF.cpp
@@ -107,13 +107,15 @@ bool UBExportPDF::persistsDocument(UBDocumentProxy* pDocumentProxy, const QStrin
         bool isDark = scene->isDarkBackground();
         UBPageBackground pageBackground = scene->pageBackground();
 
+        bool exportDark = isDark && UBSettings::settings()->exportBackgroundColor->get().toBool();
+
         if (UBSettings::settings()->exportBackgroundGrid->get().toBool())
         {
-            scene->setBackground(false, pageBackground);
+            scene->setBackground(exportDark, pageBackground);
         }
         else
         {
-            scene->setBackground(false, UBPageBackground::plain);
+            scene->setBackground(exportDark, UBPageBackground::plain);
         }
 
         // pageSize is the output PDF page size; it is set to equal the scene's boundary size; if the contents

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -410,6 +410,7 @@ void UBSettings::init()
     pdfZoomBehavior = new UBSetting(this, "PDF", "ZoomBehavior", "4");
     enableQualityLossToIncreaseZoomPerfs = new UBSetting(this, "PDF", "enableQualityLossToIncreaseZoomPerfs", true);
     exportBackgroundGrid = new UBSetting(this, "PDF", "ExportBackgroundGrid", false);
+    exportBackgroundColor = new UBSetting(this, "PDF", "ExportBackgroundColor", false);
 
     podcastFramesPerSecond = new UBSetting(this, "Podcast", "FramesPerSecond", 10);
     podcastVideoSize = new UBSetting(this, "Podcast", "VideoSize", "Medium");

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -409,6 +409,7 @@ void UBSettings::init()
 
     pdfZoomBehavior = new UBSetting(this, "PDF", "ZoomBehavior", "4");
     enableQualityLossToIncreaseZoomPerfs = new UBSetting(this, "PDF", "enableQualityLossToIncreaseZoomPerfs", true);
+    exportBackgroundGrid = new UBSetting(this, "PDF", "ExportBackgroundGrid", false);
 
     podcastFramesPerSecond = new UBSetting(this, "Podcast", "FramesPerSecond", 10);
     podcastVideoSize = new UBSetting(this, "Podcast", "VideoSize", "Medium");

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -361,6 +361,7 @@ class UBSettings : public QObject
 
         UBSetting* pdfZoomBehavior;
         UBSetting* enableQualityLossToIncreaseZoomPerfs;
+        UBSetting* exportBackgroundGrid;
 
         UBSetting* podcastFramesPerSecond;
         UBSetting* podcastVideoSize;

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -362,6 +362,7 @@ class UBSettings : public QObject
         UBSetting* pdfZoomBehavior;
         UBSetting* enableQualityLossToIncreaseZoomPerfs;
         UBSetting* exportBackgroundGrid;
+        UBSetting* exportBackgroundColor;
 
         UBSetting* podcastFramesPerSecond;
         UBSetting* podcastVideoSize;


### PR DESCRIPTION
Some users suggested to add options to export the background grid and/or color to PDF. This pull request adds these features.

They can be enabled by the following configuration variables:

```
[PDF]
ExportBackgroundGrid=true
ExportBackgroundColor=true
```

Both variables are set to `false` by default, which is also the current behavior.

This feature is mentioned in

- https://github.com/OpenBoard-org/OpenBoard/issues/403
- https://github.com/OpenBoard-org/OpenBoard/issues/357
- https://github.com/OpenBoard-org/OpenBoard/issues/315
- https://github.com/OpenBoard-org/OpenBoard/issues/118

With this PR these options are only available via the configuration file. It is for further discussion if and possibly where they should also be added to the settings page of the user interface.