### PR TITLE
Adds RunInWindow flag to OpenBoard

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -14,6 +14,7 @@ OnlineUserName=
 PageCacheSize=20
 PreferredLanguage=fr_CH
 ProductWebAddress=http://www.openboard.ch
+RunInWindow=false
 SoftwareUpdateURL=http://www.openboard.ch/update.json
 StartMode=
 SwapControlAndDisplayScreens=false

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -276,8 +276,18 @@ int UBApplication::exec(const QString& pFileToImport)
     gs->setAttribute(QWebSettings::JavascriptCanAccessClipboard, true);
     gs->setAttribute(QWebSettings::DnsPrefetchEnabled, true);
 
+    if (UBSettings::settings()->appRunInWindow->get().toBool()) {
+        mainWindow = new UBMainWindow(0,
+                Qt::Window |
+                Qt::WindowCloseButtonHint |
+                Qt::WindowMinimizeButtonHint |
+                Qt::WindowMaximizeButtonHint |
+                Qt::WindowShadeButtonHint
+        ); // deleted by application destructor
+    } else {
+        mainWindow = new UBMainWindow(0, Qt::FramelessWindowHint); // deleted by application destructor
+    }
 
-    mainWindow = new UBMainWindow(0, Qt::FramelessWindowHint); // deleted by application destructor
     mainWindow->setAttribute(Qt::WA_NativeWindow, true);
 
     mainWindow->actionCopy->setShortcuts(QKeySequence::Copy);

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -266,6 +266,7 @@ void UBSettings::init()
     appLookForOpenSankoreInstall = new UBSetting(this, "App", "LookForOpenSankoreInstall", true);
 
     appStartMode = new UBSetting(this, "App", "StartMode", "");
+    appRunInWindow = new UBSetting(this, "App", "RunInWindow", false);
 
     featureSliderPosition = new UBSetting(this, "Board", "FeatureSliderPosition", 40);
 

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -261,6 +261,7 @@ class UBSettings : public QObject
         UBSetting* appHideSwapDisplayScreens;
         UBSetting* appToolBarOrientationVertical;
         UBSetting* appPreferredLanguage;
+        UBSetting* appRunInWindow;
 
         UBSetting* appIsInSoftwareUpdateProcess;
 

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -36,6 +36,7 @@
 #include <X11/keysym.h>
 
 #include "frameworks/UBFileSystemUtils.h"
+#include "core/UBSettings.h"
 
 
 void UBPlatformUtils::init()
@@ -439,7 +440,11 @@ void UBPlatformUtils::setFrontProcess()
 
 void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 {
-    pWidget->showFullScreen();
+    if (UBSettings::settings()->appRunInWindow->get().toBool()) {
+        pWidget->showNormal();
+    } else {
+        pWidget->showFullScreen();
+    }
 }
 
 void UBPlatformUtils::showOSK(bool show)

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -36,6 +36,7 @@
 
 #include "frameworks/UBFileSystemUtils.h"
 #include "core/memcheck.h"
+#include "core/UBSettings.h"
 
 void UBPlatformUtils::init()
 {
@@ -436,7 +437,11 @@ void UBPlatformUtils::setFrontProcess()
 
 void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 {
-    pWidget->showFullScreen();
+    if (UBSettings::settings()->appRunInWindow->get().toBool()) {
+        pWidget->showNormal();
+    } else {
+        pWidget->showFullScreen();
+    }
 }
 
 void UBPlatformUtils::showOSK(bool show)


### PR DESCRIPTION
This patch is based on work by @fsckawk and @sagredo-dev in #327 and #340:

* removed the "RunInWindow patch" comments, because this is no longer "just a patch" :)
* removed additional ffmpeg include (which appears to be another bug, not related to this issue)
* fix indentation

My intent in opening this PR is to make sure the patch is not lost.  It still requires editing the configuration file, but this is significantly easier than building OpenBoard from source.

I think that will help OpenBoard users:

* use it with screen sharing software for remote learning
* use it with OBS or other video mixing software
* use it on computers with more than 2 monitors (if it's a window, it can be put anywhere)

There are [community OpenBoard builds with this or similar functionality](https://webdiis.unizar.es/~spd/openboard/), based on old versions of OpenBoard which may have other issues. There are also many forum posts about this issue since 2017.

**Note:** I'm unable to compile or test this properly because [Qt have resumed restricting downloads to those with a Qt account as of 2020](https://www.qt.io/blog/qt-offering-changes-2020), [despite a previous walk-back in 2015](https://www.qt.io/blog/2015/05/06/changing-qt-account-to-be-optional-in-the-online-installer). This also makes it impossible for me to work on a GUI for this option. 😞 