### PR TITLE
Fix support hand shortcut (ctrl + h)

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -288,6 +288,12 @@ void UBBoardView::keyPressEvent (QKeyEvent *event)
                 event->accept ();
                 break;
             }
+            case Qt::Key_H:
+            {
+                UBDrawingController::drawingController()->setStylusTool(UBStylusTool::Hand);
+                event->accept ();
+                break;
+            }
             default:
             {
                 // NOOP

--- a/src/gui/UBDocumentNavigator.cpp
+++ b/src/gui/UBDocumentNavigator.cpp
@@ -37,6 +37,7 @@
 #include <QGraphicsPixmapItem>
 
 #include "core/UBApplication.h"
+#include "UBDrawingController.h"
 #include "UBDocumentNavigator.h"
 #include "board/UBBoardController.h"
 #include "board/UBBoardView.h"
@@ -451,6 +452,12 @@ void UBDocumentNavigator::keyPressEvent(QKeyEvent *event)
             case Qt::Key_Down:
             {
                 controller->handScroll (0, 100);
+                event->accept ();
+                break;
+            }
+            case Qt::Key_H:
+            {
+                UBDrawingController::drawingController()->setStylusTool(UBStylusTool::Hand);
                 event->accept ();
                 break;
             }


### PR DESCRIPTION
Hi everyone,

There is no shortcut for the Hand tool (known as `Scroll Page` in stylus tools), so tried to add this shortcut. It's very annoying to click the button without any shortcut! I guess it's useful.

I don't know anything about C++ and didn't build the project to see if this works, can anyone check this?
It seems be alright when I read the code, hope it works :)