### PR TITLE
Fix bug 527: palette and tool resize

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -355,7 +355,7 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
     time.start();
     mScene = 0;
     UBGraphicsWidgetItem *currentWidget = 0;
-    bool pageDpiSpecified = true;
+    //bool pageDpiSpecified = true;
     saveSceneAfterLoading = false;
 
     mFileVersion = 40100; // default to 4.1.0
@@ -443,7 +443,7 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
 
                 else if (proxy->pageDpi() == 0) {
                     proxy->setPageDpi((UBApplication::desktop()->physicalDpiX() + UBApplication::desktop()->physicalDpiY())/2);
-                    pageDpiSpecified = false;
+                    //pageDpiSpecified = false;
                 }
 
                 bool darkBackground = false;
@@ -909,9 +909,9 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
 
                     if (textDelegate)
                     {
-                        QDesktopWidget* desktop = UBApplication::desktop();
-                        qreal currentDpi = (desktop->physicalDpiX() + desktop->physicalDpiY()) / 2;
-                        qreal textSizeMultiplier = qreal(proxy->pageDpi())/currentDpi;
+                        //QDesktopWidget* desktop = UBApplication::desktop();
+                        //qreal currentDpi = (desktop->physicalDpiX() + desktop->physicalDpiY()) / 2;
+                        //qreal textSizeMultiplier = qreal(proxy->pageDpi())/currentDpi;
                         //textDelegate->scaleTextSize(textSizeMultiplier);
                     }
 
@@ -2390,8 +2390,9 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::graphicsItemToSvg(QGraphicsItem* ite
     mXmlWriter.writeAttribute("x", "0");
     mXmlWriter.writeAttribute("y", "0");
 
-    mXmlWriter.writeAttribute("width", QString("%1").arg(item->boundingRect().width()));
-    mXmlWriter.writeAttribute("height", QString("%1").arg(item->boundingRect().height()));
+    QRectF rect = item->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
+    mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
 
     mXmlWriter.writeAttribute("transform", toSvgTransform(item->sceneMatrix()));
 
@@ -2487,8 +2488,9 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::graphicsWidgetToSvg(UBGraphicsWidget
     mXmlWriter.writeStartElement(nsXHtml, "iframe");
 
     mXmlWriter.writeAttribute("style", "border: none");
-    mXmlWriter.writeAttribute("width", QString("%1").arg(item->boundingRect().width()));
-    mXmlWriter.writeAttribute("height", QString("%1").arg(item->boundingRect().height()));
+    QRectF rect = item->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
+    mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
 
     QString startFileUrl;
     if (item->mainHtmlFileName().startsWith("http://"))
@@ -2817,10 +2819,11 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::curtainItemToSvg(UBGraphicsCurtainIt
      */
 
     mXmlWriter.writeStartElement(UBSettings::uniboardDocumentNamespaceUri, "curtain");
-    mXmlWriter.writeAttribute("x", QString("%1").arg(curtainItem->boundingRect().center().x()));
-    mXmlWriter.writeAttribute("y", QString("%1").arg(curtainItem->boundingRect().center().y()));
-    mXmlWriter.writeAttribute("width", QString("%1").arg(curtainItem->boundingRect().width()));
-    mXmlWriter.writeAttribute("height", QString("%1").arg(curtainItem->boundingRect().height()));
+    QRectF rect = curtainItem->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    mXmlWriter.writeAttribute("x", QString("%1").arg(rect.center().x()));
+    mXmlWriter.writeAttribute("y", QString("%1").arg(rect.center().y()));
+    mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
+    mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
     mXmlWriter.writeAttribute("transform", toSvgTransform(curtainItem->sceneMatrix()));
 
     //graphicsItemToSvg(curtainItem);
@@ -2877,10 +2880,11 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::rulerToSvg(UBGraphicsRuler* item)
      */
 
     mXmlWriter.writeStartElement(UBSettings::uniboardDocumentNamespaceUri, "ruler");
-    mXmlWriter.writeAttribute("x", QString("%1").arg(item->boundingRect().x()));
-    mXmlWriter.writeAttribute("y", QString("%1").arg(item->boundingRect().y()));
-    mXmlWriter.writeAttribute("width", QString("%1").arg(item->boundingRect().width()));
-    mXmlWriter.writeAttribute("height", QString("%1").arg(item->boundingRect().height()));
+    QRectF rect = item->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    mXmlWriter.writeAttribute("x", QString("%1").arg(rect.x()));
+    mXmlWriter.writeAttribute("y", QString("%1").arg(rect.y()));
+    mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
+    mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
     mXmlWriter.writeAttribute("transform", toSvgTransform(item->sceneMatrix()));
 
     QString zs;
@@ -3005,10 +3009,11 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::compassToSvg(UBGraphicsCompass* item
      */
 
     mXmlWriter.writeStartElement(UBSettings::uniboardDocumentNamespaceUri, "compass");
-    mXmlWriter.writeAttribute("x", QString("%1").arg(item->boundingRect().x()));
-    mXmlWriter.writeAttribute("y", QString("%1").arg(item->boundingRect().y()));
-    mXmlWriter.writeAttribute("width", QString("%1").arg(item->boundingRect().width()));
-    mXmlWriter.writeAttribute("height", QString("%1").arg(item->boundingRect().height()));
+    QRectF rect = item->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    mXmlWriter.writeAttribute("x", QString("%1").arg(rect.x()));
+    mXmlWriter.writeAttribute("y", QString("%1").arg(rect.y()));
+    mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
+    mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
     mXmlWriter.writeAttribute("transform", toSvgTransform(item->sceneMatrix()));
 
     QString zs;
@@ -3139,10 +3144,11 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::triangleToSvg(UBGraphicsTriangle *it
      */
 
     mXmlWriter.writeStartElement(UBSettings::uniboardDocumentNamespaceUri, "triangle");
-    mXmlWriter.writeAttribute("x", QString("%1").arg(item->boundingRect().x()));
-    mXmlWriter.writeAttribute("y", QString("%1").arg(item->boundingRect().y()));
-    mXmlWriter.writeAttribute("width", QString("%1").arg(item->boundingRect().width()));
-    mXmlWriter.writeAttribute("height", QString("%1").arg(item->boundingRect().height()));
+    QRectF rect = item->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    mXmlWriter.writeAttribute("x", QString("%1").arg(rect.x()));
+    mXmlWriter.writeAttribute("y", QString("%1").arg(rect.y()));
+    mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
+    mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
     mXmlWriter.writeAttribute("transform", toSvgTransform(item->sceneMatrix()));
     mXmlWriter.writeAttribute("orientation", UBGraphicsTriangle::orientationToStr(item->getOrientation()));
 

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -512,16 +512,18 @@ void UBBoardPaletteManager::containerResized()
         mKeyboardPalette->adjustSizeAndPosition();
     }
 
-    if(mLeftPalette)
+// NOTE @letsfindaway Fixed, but don't see any reason for this.
+// Probably remove.
+    if(mLeftPalette && mLeftPalette->width() > 0)
     {
         mLeftPalette->resize(mLeftPalette->width()-1, mContainer->height());
-        mLeftPalette->resize(mLeftPalette->width(), mContainer->height());
+        mLeftPalette->resize(mLeftPalette->width()+1, mContainer->height());
     }
 
-    if(mRightPalette)
+    if(mRightPalette && mRightPalette->width() > 0)
     {
         mRightPalette->resize(mRightPalette->width()-1, mContainer->height());
-        mRightPalette->resize(mRightPalette->width(), mContainer->height());
+        mRightPalette->resize(mRightPalette->width()+1, mContainer->height());
     }
 }
 


### PR DESCRIPTION
This pull request fixes #527 with the following corrections:

- When saving a scene, `UBSvgSubsetAdaptor` used `boundingRect()` to get size and position of items. This bounding rectangle is however half a pixel larger in each direction as the actual item. To fix this, that half-pixel margin is subtracted from the return value of `boundingRect()` before saving.
- The `UBBoardPaletteManager` tried to resize the left and right palette by one pixel and then revert that resizing, probably to correct a problem in Qt. The code to restore the original size was however wrong, so the left and right palette shrunk by 2 pixels each time OpenBoard was started. This code is now corrected. A comment now states, that it might probably be removed.
- Additionally I commented two lines defining and setting an elsewhere unused variable and related calculations.
