### PR TITLE
refactor: drawBackground mostly in scene

### DIFF
--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2711,15 +2711,16 @@ void UBGraphicsScene::drawBackground(QPainter *painter, const QRectF &rect)
         QGraphicsScene::drawBackground (painter, rect);
         return;
     }
+
     bool darkBackground = isDarkBackground ();
 
     if (darkBackground)
     {
-      painter->fillRect (rect, QBrush (QColor (Qt::black)));
+        painter->fillRect (rect, QBrush (QColor (Qt::black)));
     }
     else
     {
-      painter->fillRect (rect, QBrush (QColor (Qt::white)));
+        painter->fillRect (rect, QBrush (QColor (Qt::white)));
     }
 
     if (mZoomFactor > 0.5)
@@ -2730,38 +2731,69 @@ void UBGraphicsScene::drawBackground(QPainter *painter, const QRectF &rect)
             bgCrossColor = QColor(UBSettings::settings()->boardCrossColorDarkBackground->get().toString());
         else
             bgCrossColor = QColor(UBSettings::settings()->boardCrossColorLightBackground->get().toString());
+
         if (mZoomFactor < 0.7)
         {
             int alpha = 255 * mZoomFactor / 2;
             bgCrossColor.setAlpha (alpha); // fade the crossing on small zooms
         }
 
+        qreal gridSize = backgroundGridSize();
         painter->setPen (bgCrossColor);
 
         if (mPageBackground == UBPageBackground::crossed)
         {
-            qreal firstY = ((int) (rect.y () / backgroundGridSize())) * backgroundGridSize();
+            qreal firstY = ((int) (rect.y () / gridSize)) * gridSize;
 
-            for (qreal yPos = firstY; yPos < rect.y () + rect.height (); yPos += backgroundGridSize())
+            for (qreal yPos = firstY; yPos < rect.y () + rect.height (); yPos += gridSize)
             {
                 painter->drawLine (rect.x (), yPos, rect.x () + rect.width (), yPos);
             }
 
-            qreal firstX = ((int) (rect.x () / backgroundGridSize())) * backgroundGridSize();
+            qreal firstX = ((int) (rect.x () / gridSize)) * gridSize;
 
-            for (qreal xPos = firstX; xPos < rect.x () + rect.width (); xPos += backgroundGridSize())
+            for (qreal xPos = firstX; xPos < rect.x () + rect.width (); xPos += gridSize)
             {
                 painter->drawLine (xPos, rect.y (), xPos, rect.y () + rect.height ());
+            }
+
+            if (mIntermediateLines)
+            {
+                QColor intermediateColor = bgCrossColor;
+                intermediateColor.setAlphaF(0.5 * bgCrossColor.alphaF());
+                painter->setPen(intermediateColor);
+
+                for (qreal yPos = firstY - gridSize/2; yPos < rect.y () + rect.height (); yPos += gridSize)
+                {
+                    painter->drawLine (rect.x (), yPos, rect.x () + rect.width (), yPos);
+                }
+
+                for (qreal xPos = firstX - gridSize/2; xPos < rect.x () + rect.width (); xPos += gridSize)
+                {
+                    painter->drawLine (xPos, rect.y (), xPos, rect.y () + rect.height ());
+                }
             }
         }
 
         else if (mPageBackground == UBPageBackground::ruled)
         {
-            qreal firstY = ((int) (rect.y () / backgroundGridSize())) * backgroundGridSize();
+            qreal firstY = ((int) (rect.y () / gridSize)) * gridSize;
 
-            for (qreal yPos = firstY; yPos < rect.y () + rect.height (); yPos += backgroundGridSize())
+            for (qreal yPos = firstY; yPos < rect.y () + rect.height (); yPos += gridSize)
             {
                 painter->drawLine (rect.x (), yPos, rect.x () + rect.width (), yPos);
+            }
+
+            if (mIntermediateLines)
+            {
+                QColor intermediateColor = bgCrossColor;
+                intermediateColor.setAlphaF(0.5 * bgCrossColor.alphaF());
+                painter->setPen(intermediateColor);
+
+                for (qreal yPos = firstY - gridSize/2; yPos < rect.y () + rect.height (); yPos += gridSize)
+                {
+                    painter->drawLine (rect.x (), yPos, rect.x () + rect.width (), yPos);
+                }
             }
         }
     }

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -1136,22 +1136,17 @@ void UBGraphicsScene::setBackground(bool pIsDark, UBPageBackground pBackground)
         recolorAllItems();
 
         needRepaint = true;
-        setModified(true);
     }
 
     if (mPageBackground != pBackground)
     {
         mPageBackground = pBackground;
         needRepaint = true;
-        setModified(true);
     }
 
     if (needRepaint)
     {
-        foreach(QGraphicsView* view, views())
-        {
-            view->resetCachedContent();
-        }
+        updateBackground();
     }
 }
 
@@ -1165,20 +1160,14 @@ void UBGraphicsScene::setBackgroundGridSize(int pSize)
 {
     if (pSize > 0) {
         mBackgroundGridSize = pSize;
-        setModified(true);
-
-        foreach(QGraphicsView* view, views())
-            view->resetCachedContent();
+        updateBackground();
     }
 }
 
 void UBGraphicsScene::setIntermediateLines(bool checked)
 {
     mIntermediateLines = checked;
-    setModified(true);
-
-    foreach(QGraphicsView* view, views())
-        view->resetCachedContent();
+    updateBackground();
 }
 
 void UBGraphicsScene::setDrawingMode(bool bModeDesktop)
@@ -2584,13 +2573,7 @@ void UBGraphicsScene::setNominalSize(const QSize& pSize)
     if (nominalSize() != pSize)
     {
         mNominalSize = pSize;
-        setModified(true);    // modifying the size modifies the scene
-
-        // force redrawing the background
-        foreach(QGraphicsView* view, views())
-        {
-            view->resetCachedContent();
-        }
+        updateBackground();
 
         if(mDocument)
             mDocument->setDefaultDocumentSize(pSize);
@@ -2937,6 +2920,17 @@ void UBGraphicsScene::setDocumentUpdated()
         QDateTime now = QDateTime::currentDateTime();
         document()->setMetaData(UBSettings::documentUpdatedAt, UBStringUtils::toUtcIsoDateTime(now));
     }
+}
+
+void UBGraphicsScene::updateBackground()
+{
+    setModified(true);
+
+    foreach(QGraphicsView* view, views())
+    {
+        view->resetCachedContent();
+    }
+
 }
 
 void UBGraphicsScene::createEraiser()

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -428,6 +428,7 @@ public slots:
 
     private:
         void setDocumentUpdated();
+        void updateBackground();
         void createEraiser();
         void createPointer();
         void createMarkerCircle();


### PR DESCRIPTION
This PR harmonized the drawing of the background in the scene and the view, which is currently duplicated with mostly identical code. It does:

- move all drawing of background grid to UBGraphicsScene
- only add document border in UBBoardView
- avoid some compiler warnings

This PR should be merged before enabling the intermediate background grid lines by default, as currently the intermediate lines are not drawn in the magnifier tool due to an inconsistency in the two implementations.

See also discussion at https://github.com/letsfindaway/OpenBoard/issues/12