### PR TITLE
fix: coordinates when display screen is left of control screen

### DIFF
--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -465,6 +465,7 @@ void UBApplicationController::showDesktop(bool dontSwitchFrontProcess)
     if (mMirror)
     {
         QRect rect = qApp->desktop()->screenGeometry(desktopWidgetIndex);
+        rect.moveTo(0, 0);
         mMirror->setSourceRect(rect);
     }
 

--- a/src/core/UBDisplayManager.cpp
+++ b/src/core/UBDisplayManager.cpp
@@ -236,7 +236,7 @@ void UBDisplayManager::positionScreens()
 
     if (mDisplayWidget && mDisplayScreenIndex > -1)
     {
-        mDisplayWidget->hide();
+        mDisplayWidget->showNormal();
         mDisplayWidget->setGeometry(mDesktop->screenGeometry(mDisplayScreenIndex));
         UBPlatformUtils::showFullScreen(mDisplayWidget);
     }

--- a/src/desktop/UBCustomCaptureWindow.cpp
+++ b/src/desktop/UBCustomCaptureWindow.cpp
@@ -79,6 +79,8 @@ int UBCustomCaptureWindow::execute(const QPixmap &pScreenPixmap)
 
     QDesktopWidget *desktop = QApplication::desktop();
     int currentScreen = desktop->screenNumber(QCursor::pos());
+    // necessary so that changing geometry really affects the widget
+    showNormal();
     setGeometry(desktop->screenGeometry(currentScreen));
     this->show();
     setWindowOpacity(1.0);

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -516,6 +516,7 @@ QPixmap UBDesktopAnnotationController::getScreenPixmap()
     QScreen * screen = UBApplication::controlScreen();
 
     QRect rect = desktop->screenGeometry(QCursor::pos());
+    rect.moveTo(0, 0);
 
     return screen->grabWindow(desktop->effectiveWinId(),
                               rect.x(), rect.y(), rect.width(), rect.height());
@@ -556,7 +557,7 @@ void UBDesktopAnnotationController::penActionPressed()
 
     // Check if the mouse cursor is on the little arrow
     QPoint cursorPos = QCursor::pos();
-    QPoint palettePos = mDesktopPalette->pos();
+    QPoint palettePos = mDesktopPalette->mapToGlobal(QPoint(0, 0));  // global coordinates of palette
     QPoint buttonPos = mDesktopPalette->buttonPos(UBApplication::mainWindow->actionPen);
 
     int iX = cursorPos.x() - (palettePos.x() + buttonPos.x());    // x position of the cursor in the palette
@@ -610,7 +611,7 @@ void UBDesktopAnnotationController::eraserActionPressed()
 
     // Check if the mouse cursor is on the little arrow
     QPoint cursorPos = QCursor::pos();
-    QPoint palettePos = mDesktopPalette->pos();
+    QPoint palettePos = mDesktopPalette->mapToGlobal(QPoint(0, 0));
     QPoint buttonPos = mDesktopPalette->buttonPos(UBApplication::mainWindow->actionEraser);
 
     int iX = cursorPos.x() - (palettePos.x() + buttonPos.x());    // x position of the cursor in the palette
@@ -665,7 +666,7 @@ void UBDesktopAnnotationController::markerActionPressed()
 
     // Check if the mouse cursor is on the little arrow
     QPoint cursorPos = QCursor::pos();
-    QPoint palettePos = mDesktopPalette->pos();
+    QPoint palettePos = mDesktopPalette->mapToGlobal(QPoint(0, 0));
     QPoint buttonPos = mDesktopPalette->buttonPos(UBApplication::mainWindow->actionMarker);
 
     int iX = cursorPos.x() - (palettePos.x() + buttonPos.x());    // x position of the cursor in the palette
@@ -967,7 +968,7 @@ void UBDesktopAnnotationController::updateMask(bool bTransparent)
         p.setPen(Qt::red);
         p.setBrush(QBrush(Qt::red));
 
-        p.drawRect(mTransparentDrawingView->geometry().x(), mTransparentDrawingView->geometry().y(), mTransparentDrawingView->width(), mTransparentDrawingView->height());
+        p.drawRect(0, 0, mTransparentDrawingView->width(), mTransparentDrawingView->height());
         p.end();
 
         mTransparentDrawingView->setMask(mMask.mask());


### PR DESCRIPTION
Desktop mode did not work correctly when the display screen is positioned left to the control screen in a two-monitor setup. The reason is that global coordinates covering the complete desktop with multiple monitors are used as local coordinates in a widget at some places. This works as long as the control screen is located at (0,0), but leads to offsets if this is not the case.

- fix usage of global coordinates where local coordinates are required
- show widget before changing geometry (necessary in some environments)

This PR fixes https://github.com/letsfindaway/OpenBoard/issues/72 and https://github.com/letsfindaway/OpenBoard/issues/73 (minimal fix without rework of `UBDisplayManager`).