### PR TITLE
Fix compile error in UBPlatformUtils on 1.7-dev branch

### DIFF
--- a/src/frameworks/UBPlatformUtils.cpp
+++ b/src/frameworks/UBPlatformUtils.cpp
@@ -66,9 +66,7 @@ UBKeyboardLocale::~UBKeyboardLocale()
 
 int UBPlatformUtils::nKeyboardLayouts;
 UBKeyboardLocale** UBPlatformUtils::keyboardLayouts;
-#ifdef Q_OS_OSX
 bool UBPlatformUtils::errorOpeningVirtualKeyboard = false;
-#endif
 UBKeyboardLocale** UBPlatformUtils::getKeyboardLayouts(int& nCount)
 {
     nCount = nKeyboardLayouts;

--- a/src/frameworks/UBPlatformUtils.h
+++ b/src/frameworks/UBPlatformUtils.h
@@ -213,9 +213,8 @@ public:
 #ifdef Q_OS_OSX
         static void SetMacLocaleByIdentifier(const QString& id);
         static void toggleFinder(const bool on);
-
-        static bool errorOpeningVirtualKeyboard;
 #endif
+        static bool errorOpeningVirtualKeyboard;
 };
 
 


### PR DESCRIPTION
The static variable `errorOpeningVirtualKeyboard` was previously only declared on OSX, but referenced unconditionally.