### PR TITLE
fix: compile with poppler >= 22.01

### DIFF
--- a/src/pdf/XPDFRenderer.cpp
+++ b/src/pdf/XPDFRenderer.cpp
@@ -95,6 +95,8 @@ XPDFRenderer::XPDFRenderer(const QString &filename, bool importingFile)
     }
 #ifdef USE_XPDF
     mDocument = new PDFDoc(new GString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
+#elif POPPLER_VERSION_MAJOR > 22 || (POPPLER_VERSION_MAJOR == 22 && POPPLER_VERSION_MINOR >= 3)
+    mDocument = new PDFDoc(std::make_unique<GooString>(filename.toLocal8Bit()));
 #else
     mDocument = new PDFDoc(new GooString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
 #endif

--- a/src/pdf/pdf.pri
+++ b/src/pdf/pdf.pri
@@ -1,3 +1,4 @@
+CONFIG += c++17
 
 HEADERS      += src/pdf/GraphicsPDFItem.h \
                 src/pdf/PDFRenderer.h \


### PR DESCRIPTION
Fix similar to the change done in inkscape, as referenced in #571. Also added flag to use c++17 compliance for compiling src/pdf as needed by poppler >= 22.01.

Closes #571, #560