### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Version (please complete the following information):**
+ - OS and version: [e.g. Windows 10, Ubuntu 20.04, etc.]
+ - OpenBoard version [e.g. 1.6.1]
+ - Installation source [e.g. OpenBoard download page, Linux distribution repository, own build, etc.]
+
+**Additional context**
+Add any other context about the problem here, e.g.
+- Number and resolution of monitors
+- Manufacturer and model of graphic tablet input device

--- a/.github/ISSUE_TEMPLATE/build-problem.md
+++ b/.github/ISSUE_TEMPLATE/build-problem.md
@@ -1,0 +1,26 @@
+---
+name: Build problem
+about: Describe a problem building OpenBoard for a specific platform
+title: "[Build]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the problem**
+Describe the problems do you face when trying to build OpenBoard.
+
+**Versions**
+Provide version information for all components and libraries.
+- OpenBoard version [e.g. 1.6.1, or a branch name, e.g. `1.7-dev`]
+- Qt version [e.g. 5.15.2]
+- Version for other third-party libraries e.g. poppler, ffmpeg as appropriate
+
+**Build commands**
+Describe the commands you're using to build OpenBoard. It is best to paste them here literally.
+
+**Error messages**
+Paste the resulting error messages.
+
+**Suggestions, solutions**
+Provide your suggestions here if you already have some idea how to solve the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for the OpenBoard interactive whiteboard
+title: "[Feature]"
+labels: ''
+assignees: ''
+
+---
+
+OpenBoard is committed to provide a limited set of useful features for using it as an interactive whiteboard for education. Ease of use is a primary design goal. Please consider this when describing your feature request. 
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. It would help me doing [...] if [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
In order to encourage contributors to write good bug reports and useful feature requests I propose to add a set of issue templates to the project. 

These issue templates are based on the default proposals of GitHub and adapted to the needs of OpenBoard. See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates for a description of issue templates in GitHub.