### PR TITLE
feat: mouse wheel zoom and scroll

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -81,6 +81,7 @@ SimplifyPenStrokesThresholdAngle=3
 SimplifyPenStrokesThresholdWidthDifference=2
 StartupKeyboardLocale=0
 UseHighResTabletEvent=true
+ZoomBase=1.0005
 ZoomFactor=1.4099999999999999
 
 [Community]

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1542,6 +1542,17 @@ void UBBoardView::mouseDoubleClickEvent (QMouseEvent *event)
 
 void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
 {
+    // Zoom in/out when Ctrl is pressed
+    if (wheelEvent->modifiers() == Qt::ControlModifier && wheelEvent->orientation() == Qt::Vertical)
+    {
+        qreal angle = wheelEvent->angleDelta().y();
+        qreal zoomBase = UBSettings::settings()->boardZoomBase->get().toDouble();
+        qreal zoomFactor = qPow(zoomBase, angle);
+        mController->zoom(zoomFactor, mapToScene(wheelEvent->pos()));
+        wheelEvent->accept();
+        return;
+    }
+
     QList<QGraphicsItem *> selItemsList = scene()->selectedItems();
     // if NO have selected items, than no need process mouse wheel. just exist
     if( selItemsList.count() > 0 )

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1554,7 +1554,7 @@ void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
     }
 
     QList<QGraphicsItem *> selItemsList = scene()->selectedItems();
-    // if NO have selected items, than no need process mouse wheel. just exist
+    // if items selected, then forward mouse wheel event to item
     if( selItemsList.count() > 0 )
     {
         // only one selected item possible, so we will work with first item only
@@ -1567,12 +1567,22 @@ void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
         bool isSelectedAndMouseHower = itemsList.contains(selItem);
         if(isSelectedAndMouseHower)
         {
+            QTransform previousTransform = viewportTransform();
             QGraphicsView::wheelEvent(wheelEvent);
-            wheelEvent->accept();
-        }
 
+            if (previousTransform != viewportTransform())
+            {
+                // processing the event changed the transformation
+                UBApplication::applicationController->adjustDisplayView();
+            }
+
+            return;
+        }
     }
 
+    // event not handled, send it to QAbstractScrollArea to scroll with wheel event
+    QAbstractScrollArea::wheelEvent(wheelEvent);
+    UBApplication::applicationController->adjustDisplayView();
 }
 
 void UBBoardView::leaveEvent (QEvent * event)

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -380,6 +380,11 @@ void UBSettings::init()
     widgetFileExtensions << "wdgt" << "wgt" << "pwgt";
     interactiveContentFileExtensions << widgetFileExtensions << "swf";
 
+    boardZoomBase = new UBSetting(this, "Board", "ZoomBase", 1.0005);
+
+    if (boardZoomBase->get().toDouble() <= 1. || boardZoomBase->get().toDouble() > 1.01)
+        boardZoomBase->set(1.0005);
+
     boardZoomFactor = new UBSetting(this, "Board", "ZoomFactor", QVariant(1.41));
 
     if (boardZoomFactor->get().toDouble() <= 1.)

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -341,6 +341,7 @@ class UBSettings : public QObject
 
         UBSetting* pageCacheSize;
 
+        UBSetting* boardZoomBase;
         UBSetting* boardZoomFactor;
 
         UBSetting* mirroringRefreshRateInFps;


### PR DESCRIPTION
This PR adds handling of the mouse wheel to zoom and scroll in a page as follows:

- If no modifier button is pressed, then the mouse wheel scrolls vertically
  - If a widget with scrollable content is selected and the mouse cursor is within that widget (e.g. a captured web page), then the content of that widget is scrolled.
  - If no widget is selected or the mouse cursor is outside of that widget, then the page is scrolled.
- If the `Alt` button is pressed, then the mouse wheel scrolls horizontally.
- If the `Ctrl` button is pressed, then the mouse wheel zooms in and out.

There is a new `ZoomBase` configuration value for the base of the exponential function computing the zoom factor from the wheel angle. This can be adjusted to create finer or more coarse zooming and should always be close to 1.0. When choosing a value below 1.0, then the zoom direction is inverted.

This PR is similar to #343 with the following differences:

- It is based on the current `dev` branch and also targets to be merged to `dev`.
- It additionally handles scrolling vertically and horizontally, not only zooming.
- When zooming first in and then out again out in sequence, it ends up at the original zoom level.
- There is no "smooth zoom" animation feature.

