### PR TITLE
Refactor for Qt 6.2

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -33,13 +33,12 @@ VERSION_RC = $$replace(VERSION_RC, "rc", "192" ) # 0xC0
 VERSION_RC = $$replace(VERSION_RC, "r", "240") # 0xF0
 
 QT += svg
+greaterThan(QT_MAJOR_VERSION, 5):QT += svgwidgets
 QT += network
 QT += xml
-QT += xmlpatterns
 QT += uitools
 QT += multimedia
 QT += multimediawidgets
-QT += webengine
 QT += webenginewidgets
 QT += printsupport
 QT += core
@@ -454,8 +453,14 @@ linux-g++* {
     LIBS += -lcrypto
     #LIBS += -lprofiler
     LIBS += -lX11
-    LIBS += -lquazip5
-    INCLUDEPATH += "/usr/include/quazip5"
+
+    greaterThan(QT_MAJOR_VERSION, 5) {
+        LIBS += -lquazip6
+        INCLUDEPATH += "/usr/include/quazip6"
+    } else {
+        LIBS += -lquazip5
+        INCLUDEPATH += "/usr/include/quazip5"
+    }
 
     LIBS += -lpoppler
     INCLUDEPATH += "/usr/include/poppler"

--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -51,12 +51,10 @@
 #endif
 //THIRD_PARTY_WARNINGS_ENABLE
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
 typedef Qt::SplitBehaviorFlags SplitBehavior;
-typedef QMultiMapIterator<int, QDomElement> MultiMapIterator;
 #else
 typedef QString::SplitBehavior SplitBehavior;
-typedef QMapIterator<int, QDomElement> MultiMapIterator;
 #endif
 
 UBCFFAdaptor::UBCFFAdaptor()
@@ -638,10 +636,9 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parsePageset(const QStringList &page
 
     QDomElement svgPagesetElement = mDocumentToWrite->createElementNS(svgIWBNS,":"+ tIWBPageSet);
 
-    MultiMapIterator nextSVGElement(pageList);
-    nextSVGElement.toFront();
-    while (nextSVGElement.hasNext()) 
-        svgPagesetElement.appendChild(nextSVGElement.next().value());
+    for (const auto &value : qAsConst(pageList)) {
+        svgPagesetElement.appendChild(value);
+    }
 
     return svgPagesetElement.hasChildNodes() ? svgPagesetElement : QDomElement();
 }
@@ -688,10 +685,9 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parseSvgPageSection(const QDomElemen
     // to do:
     // there we must to sort elements (take elements from list and assign parent ordered like in parseSVGGGroup)
     // we returns just element because we don't care about layer.
-    MultiMapIterator nextSVGElement(svgElements);
-    nextSVGElement.toFront();
-    while (nextSVGElement.hasNext()) 
-        svgElementPart.appendChild(nextSVGElement.next().value());
+    for (const auto &value : qAsConst(svgElements)) {
+        svgElementPart.appendChild(value);
+    }
  
     return svgElementPart.hasChildNodes() ? svgElementPart : QDomElement();
 }
@@ -1613,16 +1609,17 @@ bool UBCFFAdaptor::UBToCFFConverter::parseSVGGGroup(const QDomElement &element, 
     }
 
     QList<int> layers;
-    MultiMapIterator nextSVGElement(svgElements);
-    while (nextSVGElement.hasNext()) 
-        layers << nextSVGElement.next().key();
+    const auto keys = svgElements.keys();
+    for (const auto key : keys) {
+        layers << key;
+    }
 
     std::sort(layers.begin(), layers.end());
     int layer = layers.at(0);
 
-    nextSVGElement.toFront();
-    while (nextSVGElement.hasNext()) 
-        svgElementPart.appendChild(nextSVGElement.next().value());
+    for (const auto &value : qAsConst(svgElements)) {
+        svgElementPart.appendChild(value);
+    }
 
     addSVGElementToResultModel(svgElementPart, dstSvgList, layer);
  

--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -51,7 +51,7 @@
 #endif
 //THIRD_PARTY_WARNINGS_ENABLE
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 typedef Qt::SplitBehaviorFlags SplitBehavior;
 typedef QMultiMapIterator<int, QDomElement> MultiMapIterator;
 #else

--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -53,8 +53,10 @@
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
 typedef Qt::SplitBehaviorFlags SplitBehavior;
+typedef QMultiMapIterator<int, QDomElement> MultiMapIterator;
 #else
 typedef QString::SplitBehavior SplitBehavior;
+typedef QMapIterator<int, QDomElement> MultiMapIterator;
 #endif
 
 UBCFFAdaptor::UBCFFAdaptor()
@@ -636,7 +638,7 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parsePageset(const QStringList &page
 
     QDomElement svgPagesetElement = mDocumentToWrite->createElementNS(svgIWBNS,":"+ tIWBPageSet);
 
-    QMapIterator<int, QDomElement> nextSVGElement(pageList);
+    MultiMapIterator nextSVGElement(pageList);
     nextSVGElement.toFront();
     while (nextSVGElement.hasNext()) 
         svgPagesetElement.appendChild(nextSVGElement.next().value());
@@ -686,7 +688,7 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parseSvgPageSection(const QDomElemen
     // to do:
     // there we must to sort elements (take elements from list and assign parent ordered like in parseSVGGGroup)
     // we returns just element because we don't care about layer.
-    QMapIterator<int, QDomElement> nextSVGElement(svgElements);
+    MultiMapIterator nextSVGElement(svgElements);
     nextSVGElement.toFront();
     while (nextSVGElement.hasNext()) 
         svgElementPart.appendChild(nextSVGElement.next().value());
@@ -1611,7 +1613,7 @@ bool UBCFFAdaptor::UBToCFFConverter::parseSVGGGroup(const QDomElement &element, 
     }
 
     QList<int> layers;
-    QMapIterator<int, QDomElement> nextSVGElement(svgElements);
+    MultiMapIterator nextSVGElement(svgElements);
     while (nextSVGElement.hasNext()) 
         layers << nextSVGElement.next().key();
 

--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -51,6 +51,12 @@
 #endif
 //THIRD_PARTY_WARNINGS_ENABLE
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
 UBCFFAdaptor::UBCFFAdaptor()
 {}
 
@@ -808,7 +814,7 @@ QString UBCFFAdaptor::UBToCFFConverter::getSrcContentFolderName(QString href)
 QString UBCFFAdaptor::UBToCFFConverter::getFileNameFromPath(const QString sPath)
 {
     QString sRet;
-    QStringList sl = sPath.split("/",QString::SkipEmptyParts);
+    QStringList sl = sPath.split("/",SplitBehavior::SkipEmptyParts);
 
     if (0 < sl.count())
     {
@@ -831,7 +837,7 @@ QString UBCFFAdaptor::UBToCFFConverter::getFileNameFromPath(const QString sPath)
 
 QString UBCFFAdaptor::UBToCFFConverter::getExtentionFromFileName(const QString &filename)
 {
-    QStringList sl = filename.split("/",QString::SkipEmptyParts);
+    QStringList sl = filename.split("/",SplitBehavior::SkipEmptyParts);
 
     if (0 < sl.count())
     {
@@ -878,7 +884,7 @@ QString UBCFFAdaptor::UBToCFFConverter::getElementTypeFromUBZ(const QDomElement 
             if (element.hasAttribute(aUBZHref))
                 sPath = element.attribute(aUBZHref);
 
-            QStringList tsl = sPath.split(".", QString::SkipEmptyParts);
+            QStringList tsl = sPath.split(".", SplitBehavior::SkipEmptyParts);
             if (0 < tsl.count())
             {
                 QString elementType = tsl.at(tsl.count()-1);
@@ -914,7 +920,7 @@ bool UBCFFAdaptor::UBToCFFConverter::itIsSupportedFormat(const QString &format) 
 {
     bool bRet;
 
-    QStringList tsl = format.split(".", QString::SkipEmptyParts);
+    QStringList tsl = format.split(".", SplitBehavior::SkipEmptyParts);
     if (0 < tsl.count())
         bRet = cffSupportedFileFormats.contains(tsl.at(tsl.count()-1).toLower());       
     else
@@ -1021,7 +1027,7 @@ QTransform UBCFFAdaptor::UBToCFFConverter::getTransformFromUBZ(const QDomElement
     ubzTransform.remove("(");
     ubzTransform.remove(")");
 
-    transformParameters = ubzTransform.split(",", QString::SkipEmptyParts);
+    transformParameters = ubzTransform.split(",", SplitBehavior::SkipEmptyParts);
 
     if (6 <= transformParameters.count())
     {
@@ -1240,12 +1246,12 @@ void UBCFFAdaptor::UBToCFFConverter::setCFFTextFromHTMLTextNode(const QDomElemen
                         for (int i = 0; i < attrCount; i++)
                         {
                             // html attributes like: style="font-size:40pt; color:"red";".
-                            QStringList cffAttributes = spanNode.attributes().item(i).nodeValue().split(";", QString::SkipEmptyParts);
+                            QStringList cffAttributes = spanNode.attributes().item(i).nodeValue().split(";", SplitBehavior::SkipEmptyParts);
                             {
                                 for (int i = 0; i < cffAttributes.count(); i++)
                                 {                       
                                     QString attr = cffAttributes.at(i).trimmed();
-                                    QStringList AttrVal = attr.split(":", QString::SkipEmptyParts);
+                                    QStringList AttrVal = attr.split(":", SplitBehavior::SkipEmptyParts);
                                     if(1 < AttrVal.count())
                                     {    
                                         QString sAttr = ubzAttrNameToCFFAttrName(AttrVal.at(0));
@@ -1827,10 +1833,10 @@ bool UBCFFAdaptor::UBToCFFConverter::parseUBZText(const QDomElement &element, QM
             commonParams.remove(" ");
             commonParams.remove("'");
 
-            QStringList commonAttributes = commonParams.split(";", QString::SkipEmptyParts);
+            QStringList commonAttributes = commonParams.split(";", SplitBehavior::SkipEmptyParts);
             for (int i = 0; i < commonAttributes.count(); i++)
             {
-                QStringList AttrVal = commonAttributes.at(i).split(":", QString::SkipEmptyParts);
+                QStringList AttrVal = commonAttributes.at(i).split(":", SplitBehavior::SkipEmptyParts);
                 if (1 < AttrVal.count())
                 {                
                     QString sAttr = ubzAttrNameToCFFAttrName(AttrVal.at(0));
@@ -2018,7 +2024,7 @@ QSize UBCFFAdaptor::UBToCFFConverter::getSVGDimentions(const QString &element)
 
     QStringList dimList;
 
-    dimList = element.split(dimensionsDelimiter1, QString::KeepEmptyParts);
+    dimList = element.split(dimensionsDelimiter1);
     if (dimList.count() != 2) // row unlike 0x0
         return QSize();
 
@@ -2040,7 +2046,7 @@ QRect UBCFFAdaptor::UBToCFFConverter::getViewboxRect(const QString &element) con
 {
     QStringList dimList;
 
-    dimList = element.split(dimensionsDelimiter2, QString::KeepEmptyParts);
+    dimList = element.split(dimensionsDelimiter2);
     if (dimList.count() != 4) // row unlike 0 0 0 0
         return QRect();
     

--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -120,6 +120,12 @@ static QString aEditable        = "editable";
 static QString apRotate         = "rotate";
 static QString apTranslate      = "translate";
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
 
 UBCFFSubsetAdaptor::UBCFFSubsetAdaptor()
 {}
@@ -350,10 +356,10 @@ bool UBCFFSubsetAdaptor::UBCFFSubsetReader::parseSvgPolygon(const QDomElement &e
     QPolygonF polygon;
 
     if (!svgPoints.isNull()) {
-        QStringList ts = svgPoints.split(QLatin1Char(' '), QString::SkipEmptyParts);
+        QStringList ts = svgPoints.split(QLatin1Char(' '), SplitBehavior::SkipEmptyParts);
 
         foreach(const QString sPoint, ts) {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), QString::SkipEmptyParts);
+            QStringList sCoord = sPoint.split(QLatin1Char(','), SplitBehavior::SkipEmptyParts);
             if (sCoord.size() == 2) {
                 QPointF point;
                 point.setX(sCoord.at(0).toFloat());
@@ -439,7 +445,7 @@ bool UBCFFSubsetAdaptor::UBCFFSubsetReader::parseSvgPolygon(const QDomElement &e
         QTransform transform;
         QString textTransform = element.attribute(aTransform);
         
-        QUuid uuid = QUuid::createUuid().toString();
+        QUuid uuid = QUuid::createUuid();
         mRefToUuidMap.insert(element.attribute(aId), uuid.toString());
         svgItem->setUuid(uuid);
 
@@ -466,10 +472,10 @@ bool UBCFFSubsetAdaptor::UBCFFSubsetReader::parseSvgPolyline(const QDomElement &
 
     if (!svgPoints.isNull()) {
         QStringList ts = svgPoints.split(QLatin1Char(' '),
-                                                    QString::SkipEmptyParts);
+                                                    SplitBehavior::SkipEmptyParts);
 
         foreach(const QString sPoint, ts) {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), QString::SkipEmptyParts);
+            QStringList sCoord = sPoint.split(QLatin1Char(','), SplitBehavior::SkipEmptyParts);
             if (sCoord.size() == 2) {
                 QPointF point;
                 point.setX(sCoord.at(0).toFloat());
@@ -1427,7 +1433,7 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
     qreal angle = 0.0;
     QTransform tr;
 
-    foreach(QString trStr, trString.split(" ", QString::SkipEmptyParts))
+    foreach(QString trStr, trString.split(" ", SplitBehavior::SkipEmptyParts))
     {
         //check pattern for strings like 'rotate(10)'
         static const QRegularExpression rotate1(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
@@ -1472,7 +1478,7 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
 
 bool UBCFFSubsetAdaptor::UBCFFSubsetReader::getViewBoxDimenstions(const QString& viewBox)
 {
-    QStringList capturedTexts = viewBox.split(" ", QString::SkipEmptyParts);
+    QStringList capturedTexts = viewBox.split(" ", SplitBehavior::SkipEmptyParts);
     if (capturedTexts.count())
     {
         if (4 == capturedTexts.count())

--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -26,7 +26,7 @@
 
 
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSvgGenerator>
 #include <QSvgRenderer>
 #include <QPixmap>
@@ -1394,19 +1394,20 @@ QColor UBCFFSubsetAdaptor::UBCFFSubsetReader::colorFromString(const QString& clr
 {
     //init regexp with pattern
     //pattern corresponds to strings like 'rgb(1,2,3) or rgb(10%,20%,30%)'
-    QRegExp regexp("rgb\\(([0-9]+%{0,1}),([0-9]+%{0,1}),([0-9]+%{0,1})\\)");
-    if (regexp.exactMatch(clrString))
+    QRegularExpression regexp(QRegularExpression::anchoredPattern("rgb\\(([0-9]+%{0,1}),([0-9]+%{0,1}),([0-9]+%{0,1})\\)"));
+    QRegularExpressionMatch match = regexp.match(clrString);
+    if (match.hasMatch())
     {
-        if (regexp.capturedTexts().count() == 4 && regexp.capturedTexts().at(0).length() == clrString.length())
+        if (match.lastCapturedIndex() == 3 && match.capturedTexts().at(0).length() == clrString.length())
         {
-            int r = regexp.capturedTexts().at(1).toInt();
-            if (regexp.capturedTexts().at(1).indexOf("%") != -1)
+            int r = match.capturedTexts().at(1).toInt();
+            if (match.capturedTexts().at(1).indexOf("%") != -1)
                 r = r * 255 / 100;
-            int g = regexp.capturedTexts().at(2).toInt();
-            if (regexp.capturedTexts().at(2).indexOf("%") != -1)
+            int g = match.capturedTexts().at(2).toInt();
+            if (match.capturedTexts().at(2).indexOf("%") != -1)
                 g = g * 255 / 100;
-            int b = regexp.capturedTexts().at(3).toInt();
-            if (regexp.capturedTexts().at(3).indexOf("%") != -1)
+            int b = match.capturedTexts().at(3).toInt();
+            if (match.capturedTexts().at(3).indexOf("%") != -1)
                 b = b * 255 / 100;
             return QColor(r, g, b);
         }
@@ -1429,9 +1430,10 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
     foreach(QString trStr, trString.split(" ", QString::SkipEmptyParts))
     {
         //check pattern for strings like 'rotate(10)'
-        QRegExp regexp("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)");
-        if (regexp.exactMatch(trStr)) {
-            angle = regexp.capturedTexts().at(1).toDouble();
+        QRegularExpression regexp(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
+        QRegularExpressionMatch match = regexp.match(trStr);
+        if (match.hasMatch()) {
+            angle = match.capturedTexts().at(1).toDouble();
             if (item)
             {    
                 item->setTransformOriginPoint(QPointF(0, 0));
@@ -1441,11 +1443,12 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
         };
         
         //check pattern for strings like 'rotate(10,20,20)' or 'rotate(10.1,10.2,34.2)'
-        regexp.setPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)");
-        if (regexp.exactMatch(trStr)) {
-            angle = regexp.capturedTexts().at(1).toDouble();
-            dxr = regexp.capturedTexts().at(2).toDouble();
-            dyr = regexp.capturedTexts().at(3).toDouble();
+        regexp.setPattern(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
+        match = regexp.match(trStr);
+        if (match.hasMatch()) {
+            angle = match.capturedTexts().at(1).toDouble();
+            dxr = match.capturedTexts().at(2).toDouble();
+            dyr = match.capturedTexts().at(3).toDouble();
             if (item)
             {                
                 item->setTransformOriginPoint(QPointF(dxr, dyr)-item->pos());
@@ -1455,10 +1458,11 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
         }
 
         //check pattern for strings like 'translate(11.0, 12.34)'
-        regexp.setPattern("translate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *,*([-+]{0,1}[0-9]*\\.{0,1}[0-9]*)*\\)");
-        if (regexp.exactMatch(trStr)) {
-            dx = regexp.capturedTexts().at(1).toDouble();
-            dy = regexp.capturedTexts().at(2).toDouble();
+        regexp.setPattern(QRegularExpression::anchoredPattern("translate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *,*([-+]{0,1}[0-9]*\\.{0,1}[0-9]*)*\\)"));
+        match = regexp.match(trStr);
+        if (match.hasMatch()) {
+            dx = match.capturedTexts().at(1).toDouble();
+            dy = match.capturedTexts().at(2).toDouble();
             tr.translate(dx,dy);
             continue;
         }

--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -1394,7 +1394,7 @@ QColor UBCFFSubsetAdaptor::UBCFFSubsetReader::colorFromString(const QString& clr
 {
     //init regexp with pattern
     //pattern corresponds to strings like 'rgb(1,2,3) or rgb(10%,20%,30%)'
-    QRegularExpression regexp(QRegularExpression::anchoredPattern("rgb\\(([0-9]+%{0,1}),([0-9]+%{0,1}),([0-9]+%{0,1})\\)"));
+    static const QRegularExpression regexp(QRegularExpression::anchoredPattern("rgb\\(([0-9]+%{0,1}),([0-9]+%{0,1}),([0-9]+%{0,1})\\)"));
     QRegularExpressionMatch match = regexp.match(clrString);
     if (match.hasMatch())
     {
@@ -1430,8 +1430,8 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
     foreach(QString trStr, trString.split(" ", QString::SkipEmptyParts))
     {
         //check pattern for strings like 'rotate(10)'
-        QRegularExpression regexp(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
-        QRegularExpressionMatch match = regexp.match(trStr);
+        static const QRegularExpression rotate1(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
+        QRegularExpressionMatch match = rotate1.match(trStr);
         if (match.hasMatch()) {
             angle = match.capturedTexts().at(1).toDouble();
             if (item)
@@ -1443,8 +1443,8 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
         };
         
         //check pattern for strings like 'rotate(10,20,20)' or 'rotate(10.1,10.2,34.2)'
-        regexp.setPattern(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
-        match = regexp.match(trStr);
+        static const QRegularExpression rotate3(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *, *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
+        match = rotate3.match(trStr);
         if (match.hasMatch()) {
             angle = match.capturedTexts().at(1).toDouble();
             dxr = match.capturedTexts().at(2).toDouble();
@@ -1458,8 +1458,8 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
         }
 
         //check pattern for strings like 'translate(11.0, 12.34)'
-        regexp.setPattern(QRegularExpression::anchoredPattern("translate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *,*([-+]{0,1}[0-9]*\\.{0,1}[0-9]*)*\\)"));
-        match = regexp.match(trStr);
+        static const QRegularExpression translate2(QRegularExpression::anchoredPattern("translate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *,*([-+]{0,1}[0-9]*\\.{0,1}[0-9]*)*\\)"));
+        match = translate2.match(trStr);
         if (match.hasMatch()) {
             dx = match.capturedTexts().at(1).toDouble();
             dy = match.capturedTexts().at(2).toDouble();

--- a/src/adaptors/UBExportFullPDF.cpp
+++ b/src/adaptors/UBExportFullPDF.cpp
@@ -136,7 +136,8 @@ void UBExportFullPDF::saveOverlayPdf(UBDocumentProxy* pDocumentProxy, const QStr
                 sceneHasPDFBackground = false;
             }
 
-            pdfPrinter.setPaperSize(QSizeF(pageSize.width()*mScaleFactor, pageSize.height()*mScaleFactor), QPrinter::Point);
+            QPageSize size(QSizeF(pageSize.width()*mScaleFactor, pageSize.height()*mScaleFactor), QPageSize::Point);
+            pdfPrinter.setPageSize(size);
 
             if (!pdfPainter) pdfPainter = new QPainter(&pdfPrinter);
 

--- a/src/adaptors/UBImportCFF.cpp
+++ b/src/adaptors/UBImportCFF.cpp
@@ -272,7 +272,7 @@ UBDocumentProxy* UBImportCFF::importFile(const QFile& pFile, const QString& pGro
         dir.mkdir(destDocument->persistencePath());
         if (pGroup.length() > 0)
             destDocument->setMetaData(UBSettings::documentGroupName, pGroup);
-        if (fi.baseName() > 0)
+        if (!fi.baseName().isEmpty())
             destDocument->setMetaData(UBSettings::documentName, fi.baseName());
 
         destDocument->setMetaData(UBSettings::documentVersion, UBSettings::currentFileVersion);

--- a/src/adaptors/UBImportDocumentSetAdaptor.cpp
+++ b/src/adaptors/UBImportDocumentSetAdaptor.cpp
@@ -105,7 +105,7 @@ QFileInfoList UBImportDocumentSetAdaptor::importData(const QString &zipFile, con
 
         QString newFilePath = destination + "/" + newFileName;
         if (UBFileSystemUtils::copy(readDir.absoluteFilePath(), newFilePath, true)) {
-            result.append(newFilePath);
+            result.append(QFileInfo(newFilePath));
         }
     }
 

--- a/src/adaptors/UBMetadataDcSubsetAdaptor.cpp
+++ b/src/adaptors/UBMetadataDcSubsetAdaptor.cpp
@@ -165,29 +165,30 @@ QMap<QString, QVariant> UBMetadataDcSubsetAdaptor::load(QString pPath)
             if (xml.isStartElement())
             {
                 QString docVersion = "4.1"; // untagged doc version 4.1
+                QString name = xml.name().toString();
 
-                if (xml.name() == "title")
+                if (name == "title")
                 {
                     metadata.insert(UBSettings::documentName, xml.readElementText());
                 }
-                else if (xml.name() == "type")
+                else if (name == "type")
                 {
                     metadata.insert(UBSettings::documentGroupName, xml.readElementText());
                 }
-                else if (xml.name() == "date")
+                else if (name == "date")
                 {
                     date = xml.readElementText();
                 }
-                else if (xml.name() == "identifier") // introduced in UB 4.2
+                else if (name == "identifier") // introduced in UB 4.2
                 {
                         metadata.insert(UBSettings::documentIdentifer, xml.readElementText());
                 }
-                else if (xml.name() == "version" // introduced in UB 4.2
+                else if (name == "version" // introduced in UB 4.2
                         && xml.namespaceUri() == UBSettings::uniboardDocumentNamespaceUri)
                 {
                         docVersion = xml.readElementText();
                 }
-                else if (xml.name() == "size" // introduced in UB 4.2
+                else if (name == "size" // introduced in UB 4.2
                         && xml.namespaceUri() == UBSettings::uniboardDocumentNamespaceUri)
                 {
                     QString size = xml.readElementText();
@@ -218,7 +219,7 @@ QMap<QString, QVariant> UBMetadataDcSubsetAdaptor::load(QString pPath)
                     sizeFound = true;
 
                 }
-                else if (xml.name() == "updated-at" // introduced in UB 4.4
+                else if (name == "updated-at" // introduced in UB 4.4
                         && xml.namespaceUri() == UBSettings::uniboardDocumentNamespaceUri)
                 {
                     metadata.insert(UBSettings::documentUpdatedAt, xml.readElementText());

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2512,7 +2512,7 @@ void UBBoardController::processMimeData(const QMimeData* pMimeData, const QPoint
     {
         if("" != pMimeData->text()){
             // Sometimes, it is possible to have an URL as text. we check here if it is the case
-            QString qsTmp = pMimeData->text().remove(QRegularExpression("[\\0]"));
+            QString qsTmp = pMimeData->text().remove('\0');
             if(qsTmp.startsWith("http"))
                 downloadURL(QUrl(qsTmp), QString(), pPos);
             else{

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2512,7 +2512,7 @@ void UBBoardController::processMimeData(const QMimeData* pMimeData, const QPoint
     {
         if("" != pMimeData->text()){
             // Sometimes, it is possible to have an URL as text. we check here if it is the case
-            QString qsTmp = pMimeData->text().remove(QRegExp("[\\0]"));
+            QString qsTmp = pMimeData->text().remove(QRegularExpression("[\\0]"));
             if(qsTmp.startsWith("http"))
                 downloadURL(QUrl(qsTmp), QString(), pPos);
             else{

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2402,8 +2402,8 @@ void UBBoardController::copy()
 void UBBoardController::paste()
 {
     QClipboard *clipboard = QApplication::clipboard();
-    qreal xPosition = ((qreal)qrand()/(qreal)RAND_MAX) * 400;
-    qreal yPosition = ((qreal)qrand()/(qreal)RAND_MAX) * 200;
+    qreal xPosition = ((qreal)QRandomGenerator::global()->generate()/(qreal)RAND_MAX) * 400;
+    qreal yPosition = ((qreal)QRandomGenerator::global()->generate()/(qreal)RAND_MAX) * 200;
     QPointF pos(xPosition -200 , yPosition - 100);
     processMimeData(clipboard->mimeData(), pos);
 

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1244,9 +1244,9 @@ void UBBoardView::mouseMoveEvent (QMouseEvent *event)
                 }
             }
 
-            //          qDebug() << "| ==selected items count" << counter << endl
-            //                   << "| ==selection time" << testTime.msecsTo(QTime::currentTime()) << endl
-            //                   << "| =elapsed time " << startTime.msecsTo(QTime::currentTime()) << endl
+            //          qDebug() << "| ==selected items count" << counter << '\n'
+            //                   << "| ==selection time" << testTime.msecsTo(QTime::currentTime()) << '\n'
+            //                   << "| =elapsed time " << startTime.msecsTo(QTime::currentTime()) << '\n'
             //                   << "==================";
             //          QCoreApplication::removePostedEvents(scene(), 0);
         }

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -352,7 +352,11 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)dc->stylusTool ();
 
     if (event->type () == QEvent::TabletPress || event->type () == QEvent::TabletEnterProximity) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        if (event->pointerType () == QPointingDevice::PointerType::Eraser) {
+#else
         if (event->pointerType () == QTabletEvent::Eraser) {
+#endif
             dc->setStylusTool (UBStylusTool::Eraser);
             mUsingTabletEraser = true;
         }
@@ -1543,12 +1547,16 @@ void UBBoardView::mouseDoubleClickEvent (QMouseEvent *event)
 void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
 {
     // Zoom in/out when Ctrl is pressed
-    if (wheelEvent->modifiers() == Qt::ControlModifier && wheelEvent->orientation() == Qt::Vertical)
+    if (wheelEvent->modifiers() == Qt::ControlModifier && wheelEvent->angleDelta().x() == 0)
     {
         qreal angle = wheelEvent->angleDelta().y();
         qreal zoomBase = UBSettings::settings()->boardZoomBase->get().toDouble();
         qreal zoomFactor = qPow(zoomBase, angle);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        mController->zoom(zoomFactor, mapToScene(wheelEvent->position().toPoint()));
+#else
         mController->zoom(zoomFactor, mapToScene(wheelEvent->pos()));
+#endif
         wheelEvent->accept();
         return;
     }
@@ -1561,7 +1569,11 @@ void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
         QGraphicsItem * selItem = selItemsList[0];
 
         // get items list under mouse cursor
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QPointF scenePos = mapToScene(wheelEvent->position().toPoint());
+#else
         QPointF scenePos = mapToScene(wheelEvent->pos());
+#endif
         QList<QGraphicsItem *> itemsList = scene()->items(scenePos);
 
         bool isSelectedAndMouseHower = itemsList.contains(selItem);

--- a/src/board/UBFeaturesController.cpp
+++ b/src/board/UBFeaturesController.cpp
@@ -352,7 +352,7 @@ UBFeaturesController::UBFeaturesController(QWidget *pParentWidget) :
     //featuresModel->setSupportedDragActions(Qt::CopyAction | Qt::MoveAction);
 
     featuresProxyModel = new UBFeaturesProxyModel(this);
-    featuresProxyModel->setFilterFixedString(rootPath);
+    featuresProxyModel->setFilterRegularExpression(QRegularExpression::anchoredPattern(rootPath));
     featuresProxyModel->setSourceModel(featuresModel);
     featuresProxyModel->setFilterCaseSensitivity( Qt::CaseInsensitive );
 
@@ -585,7 +585,7 @@ QString UBFeaturesController::adjustName(const QString &str)
     }
 
     QString resultStr = str;
-    QRegExp invalidSymbols("[\\/\\s\\:\\?\\*\\|\\<\\>\\\"]+");
+    QRegularExpression invalidSymbols("[\\/\\s\\:\\?\\*\\|\\<\\>\\\"]+");
 
     return resultStr.replace(invalidSymbols, "_");
 }
@@ -951,7 +951,7 @@ void UBFeaturesController::rescanModel()
 
 void UBFeaturesController::siftElements(const QString &pSiftValue)
 {
-    featuresProxyModel->setFilterFixedString(pSiftValue);
+    featuresProxyModel->setFilterRegularExpression(QRegularExpression::anchoredPattern(pSiftValue));
     featuresProxyModel->invalidate();
 
     featuresPathModel->setPath(pSiftValue);
@@ -988,7 +988,7 @@ void UBFeaturesController::searchStarted(const QString &pattern, QListView *pOnV
     } else if ( pattern.size() > 1 ) {
 
         //        featuresSearchModel->setFilterPrefix(currentElement.getFullVirtualPath());
-        featuresSearchModel->setFilterWildcard( "*" + pattern + "*" );
+        featuresSearchModel->setFilterRegularExpression(QRegularExpression::wildcardToRegularExpression("*" + pattern + "*"));
         pOnView->setModel(featuresSearchModel );
         featuresSearchModel->invalidate();
         curListModel = featuresSearchModel;

--- a/src/board/UBFeaturesController.cpp
+++ b/src/board/UBFeaturesController.cpp
@@ -585,7 +585,7 @@ QString UBFeaturesController::adjustName(const QString &str)
     }
 
     QString resultStr = str;
-    QRegularExpression invalidSymbols("[\\/\\s\\:\\?\\*\\|\\<\\>\\\"]+");
+    static const QRegularExpression invalidSymbols("[\\/\\s\\:\\?\\*\\|\\<\\>\\\"]+");
 
     return resultStr.replace(invalidSymbols, "_");
 }

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -700,13 +700,13 @@ void UBApplication::cleanup()
 QString UBApplication::urlFromHtml(QString html)
 {
     QString _html;
-    QRegularExpression comments("\\<![ \r\n\t]*(--([^\\-]|[\r\n]|-[^\\-])*--[ \r\n\t]*)\\>");
+    static const QRegularExpression comments("\\<![ \r\n\t]*(--([^\\-]|[\r\n]|-[^\\-])*--[ \r\n\t]*)\\>");
     QString url;
     QDomDocument domDoc;
 
     //    We remove all the comments & CRLF of this html
     _html = html.remove(comments);
-    domDoc.setContent(_html.remove(QRegularExpression("[\\0]")));
+    domDoc.setContent(_html.remove('\0'));
     QDomElement rootElem = domDoc.documentElement();
 
     //  QUICKFIX: Here we have to check rootElem. Sometimes it can be a <meta> tag

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -700,13 +700,13 @@ void UBApplication::cleanup()
 QString UBApplication::urlFromHtml(QString html)
 {
     QString _html;
-    QRegExp comments("\\<![ \r\n\t]*(--([^\\-]|[\r\n]|-[^\\-])*--[ \r\n\t]*)\\>");
+    QRegularExpression comments("\\<![ \r\n\t]*(--([^\\-]|[\r\n]|-[^\\-])*--[ \r\n\t]*)\\>");
     QString url;
     QDomDocument domDoc;
 
     //    We remove all the comments & CRLF of this html
     _html = html.remove(comments);
-    domDoc.setContent(_html.remove(QRegExp("[\\0]")));
+    domDoc.setContent(_html.remove(QRegularExpression("[\\0]")));
     QDomElement rootElem = domDoc.documentElement();
 
     //  QUICKFIX: Here we have to check rootElem. Sometimes it can be a <meta> tag

--- a/src/core/UBDownloadManager.cpp
+++ b/src/core/UBDownloadManager.cpp
@@ -79,7 +79,7 @@ void UBAsyncLocalFileDownloader::run()
     if (mDesc.originalSrcUrl.isEmpty())
         mDesc.originalSrcUrl = mDesc.srcUrl;
 
-    QString uuid = QUuid::createUuid().toString();
+    QUuid uuid = QUuid::createUuid();
     UBPersistenceManager::persistenceManager()->addFileToDocument(UBApplication::boardController->selectedDocument(), 
         mDesc.srcUrl,
         destDirectory,

--- a/src/core/UBForeignObjectsHandler.cpp
+++ b/src/core/UBForeignObjectsHandler.cpp
@@ -61,12 +61,13 @@ static QString strIdFrom(const QString &filePath)
         return QString();
     }
 
-    QRegExp rx("\\{.(?!.*\\{).*\\}");
-    if (rx.indexIn(filePath) == -1) {
+    QRegularExpression rx("\\{.(?!.*\\{).*\\}");
+    QRegularExpressionMatch match = rx.match(filePath);
+    if (!match.hasMatch()) {
         return QString();
     }
 
-    return rx.cap();
+    return match.captured();
 }
 
 static bool rm_r(const QString &rmPath)
@@ -147,7 +148,7 @@ static QString thumbFileNameFrom(const QString &filePath)
     }
 
     QString thumbPath = filePath;
-    thumbPath.replace(QRegExp("[\\{\\}]"), "").replace(wgtSuff, thumbSuff);
+    thumbPath.replace(QRegularExpression("[\\{\\}]"), "").replace(wgtSuff, thumbSuff);
 
     return thumbPath;
 }
@@ -538,7 +539,7 @@ private:
                 if (ref.isEmpty()) {
                     return;
                 }
-                ref.replace(QRegExp("^(.*pdf\\#page\\=).*$"), QString("\\1%1").arg(mToIndex));
+                ref.replace(QRegularExpression("^(.*pdf\\#page\\=).*$"), QString("\\1%1").arg(mToIndex));
                 return;
             }
 
@@ -568,7 +569,7 @@ private:
         if (createNewUuid)
         {
             QUuid newUuid = QUuid::createUuid();
-            QString newPath = relative.replace(QRegExp("\\{.*\\}"), newUuid.toString());
+            QString newPath = relative.replace(QRegularExpression("\\{.*\\}"), newUuid.toString());
 
             cp_rf(mFromDir + "/" + relativePath, mToDir + "/" + newPath);
 

--- a/src/core/UBForeignObjectsHandler.cpp
+++ b/src/core/UBForeignObjectsHandler.cpp
@@ -183,14 +183,14 @@ static QDomDocument createDomFromSvg(const QString &svgUrl)
             if (xmlDom.setContent(domString, &errorStr, &errorLine, &errorColumn)) {
                 return xmlDom;
             } else {
-                qDebug() << "Error reading content of " << mFoldersXmlStorageName << endl
+                qDebug() << "Error reading content of " << mFoldersXmlStorageName << '\n'
                          << "Error:" << inFile.errorString()
                          << "Line:" << errorLine
                          << "Column:" << errorColumn;
             }
             inFile.close();
         } else {
-            qDebug() << "Error reading" << mFoldersXmlStorageName << endl
+            qDebug() << "Error reading" << mFoldersXmlStorageName << '\n'
                      << "Error:" << inFile.errorString();
         }
     }

--- a/src/core/UBForeignObjectsHandler.cpp
+++ b/src/core/UBForeignObjectsHandler.cpp
@@ -55,6 +55,12 @@ const QString thumbSuff = ".png";
 const QString scanDirs = "audios,images,videos,teacherGuideObjects,widgets";
 const QStringList trashFilter = QStringList() << "*.swf";
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
 static QString strIdFrom(const QString &filePath)
 {
     if ((filePath).isEmpty()) {
@@ -264,7 +270,7 @@ private:
     void fitIdsFromFileSystem()
     {
         QString absPrefix = mCurrentDir + "/";
-        QStringList dirsList = scanDirs.split(",", QString::SkipEmptyParts);
+        QStringList dirsList = scanDirs.split(",", SplitBehavior::SkipEmptyParts);
         foreach (QString dirName, dirsList) {
             QString absPath = absPrefix + dirName;
             if (!QFile::exists(absPath)) {

--- a/src/core/UBForeignObjectsHandler.cpp
+++ b/src/core/UBForeignObjectsHandler.cpp
@@ -61,7 +61,7 @@ static QString strIdFrom(const QString &filePath)
         return QString();
     }
 
-    QRegularExpression rx("\\{.(?!.*\\{).*\\}");
+    static const QRegularExpression rx("\\{.(?!.*\\{).*\\}");
     QRegularExpressionMatch match = rx.match(filePath);
     if (!match.hasMatch()) {
         return QString();
@@ -147,8 +147,9 @@ static QString thumbFileNameFrom(const QString &filePath)
         return QString();
     }
 
+    static const QRegularExpression braces("[\\{\\}]");
     QString thumbPath = filePath;
-    thumbPath.replace(QRegularExpression("[\\{\\}]"), "").replace(wgtSuff, thumbSuff);
+    thumbPath.replace(braces, "").replace(wgtSuff, thumbSuff);
 
     return thumbPath;
 }
@@ -539,7 +540,8 @@ private:
                 if (ref.isEmpty()) {
                     return;
                 }
-                ref.replace(QRegularExpression("^(.*pdf\\#page\\=).*$"), QString("\\1%1").arg(mToIndex));
+                static const QRegularExpression pdfReference("^(.*pdf\\#page\\=).*$");
+                ref.replace(pdfReference, QString("\\1%1").arg(mToIndex));
                 return;
             }
 
@@ -569,7 +571,8 @@ private:
         if (createNewUuid)
         {
             QUuid newUuid = QUuid::createUuid();
-            QString newPath = relative.replace(QRegularExpression("\\{.*\\}"), newUuid.toString());
+            static const QRegularExpression bracedUuid("\\{.*\\}");
+            QString newPath = relative.replace(bracedUuid, newUuid.toString());
 
             cp_rf(mFromDir + "/" + relativePath, mToDir + "/" + newPath);
 

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -186,7 +186,7 @@ void UBPersistenceManager::onSceneLoaded(QByteArray scene, UBDocumentProxy* prox
 {
     Q_UNUSED(scene);
     qDebug() << "scene loaded " << sceneIndex;
-    QTime time;
+    QElapsedTimer time;
     time.start();
     mSceneCache.insert(proxy, sceneIndex, loadDocumentScene(proxy, sceneIndex, false));
     qDebug() << "millisecond for sceneCache " << time.elapsed();
@@ -263,14 +263,14 @@ void UBPersistenceManager::createDocumentProxiesStructure(bool interactive)
             if (xmlDom.setContent(domString, &errorStr, &errorLine, &errorColumn)) {
                 loadFolderTreeFromXml("", xmlDom.firstChildElement());
             } else {
-                qDebug() << "Error reading content of " << mFoldersXmlStorageName << endl
+                qDebug() << "Error reading content of " << mFoldersXmlStorageName << '\n'
                          << "Error:" << inFile.errorString()
                          << "Line:" << errorLine
                          << "Column:" << errorColumn;
             }
             inFile.close();
         } else {
-            qDebug() << "Error reading" << mFoldersXmlStorageName << endl
+            qDebug() << "Error reading" << mFoldersXmlStorageName << '\n'
                      << "Error:" << inFile.errorString();
         }
     }
@@ -419,7 +419,7 @@ void UBPersistenceManager::closing()
 
         outFile.close();
     } else {
-        qDebug() << "failed to open document" <<  mFoldersXmlStorageName << "for writing" << endl
+        qDebug() << "failed to open document" <<  mFoldersXmlStorageName << "for writing" << '\n'
                  << "Error string:" << outFile.errorString();
     }
 }

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -77,6 +77,12 @@ const QString UBPersistenceManager::fFolders = "folders.xml";
 const QString UBPersistenceManager::tFolder = "folder";
 const QString UBPersistenceManager::aName = "name";
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
 UBPersistenceManager * UBPersistenceManager::sSingleton = 0;
 
 UBPersistenceManager::UBPersistenceManager(QObject *pParent)
@@ -380,7 +386,7 @@ QDialog::DialogCode UBPersistenceManager::processInteractiveReplacementDialog(UB
 
 QString UBPersistenceManager::adjustDocumentVirtualPath(const QString &str)
 {
-    QStringList pathList = str.split("/", QString::SkipEmptyParts);
+    QStringList pathList = str.split("/", SplitBehavior::SkipEmptyParts);
 
     if (pathList.isEmpty()) {
         pathList.append(myDocumentsName);

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -48,6 +48,12 @@
 
 #include "core/memcheck.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
 qreal UBPreferencesController::sSliderRatio = 10.0;
 qreal UBPreferencesController::sMinPenWidth = 0.5;
 qreal UBPreferencesController::sMaxPenWidth = 50.0;
@@ -776,7 +782,7 @@ void UBScreenListLineEdit::focusInEvent(QFocusEvent *focusEvent)
 
     if (mScreenLabels.empty())
     {
-        QStringList screenNames = text().split(',', QString::SkipEmptyParts);
+        QStringList screenNames = text().split(',', SplitBehavior::SkipEmptyParts);
 
         QList<QScreen*> screens = UBApplication::displayManager->availableScreens();
         QStringList availableScreenNames;
@@ -852,7 +858,7 @@ void UBScreenListLineEdit::addScreen()
 
 void UBScreenListLineEdit::onTextChanged(const QString &input)
 {
-    QStringList screenNames = input.split(',', QString::SkipEmptyParts);
+    QStringList screenNames = input.split(',', SplitBehavior::SkipEmptyParts);
 
     for (QPushButton* button : mScreenLabels)
     {
@@ -902,7 +908,7 @@ QValidator::State UBStringListValidator::validate(QString &input, int &) const
 
     bool ok = true;
     bool wasOk = false;
-    QStringList inputList = input.split(',', QString::SkipEmptyParts);
+    QStringList inputList = input.split(',', SplitBehavior::SkipEmptyParts);
 
     for (const QString& token : inputList)
     {

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -704,7 +704,7 @@ UBBrushPropertiesFrame::UBBrushPropertiesFrame(QFrame* owner, const QList<QColor
     for (int i = 1 ; i < UBSettings::settings()->colorPaletteSize ; i++)
     {
         UBColorPicker *picker = new UBColorPicker(lightBackgroundFrame);
-        picker->setObjectName(QString::fromUtf8("penLightBackgroundColor") + i);
+        picker->setObjectName(QString("penLightBackgroundColor%1").arg(i));
         picker->setMinimumSize(QSize(32, 32));
         picker->setFrameShape(QFrame::StyledPanel);
         picker->setFrameShadow(QFrame::Raised);
@@ -731,7 +731,7 @@ UBBrushPropertiesFrame::UBBrushPropertiesFrame(QFrame* owner, const QList<QColor
     for (int i = 1 ; i < UBSettings::settings()->colorPaletteSize ; i++)
     {
         UBColorPicker *picker = new UBColorPicker(darkBackgroundFrame);
-        picker->setObjectName(QString::fromUtf8("penDarkBackgroundColor") + i);
+        picker->setObjectName(QString("penDarkBackgroundColor%1").arg(i));
         picker->setMinimumSize(QSize(32, 32));
         picker->setFrameShape(QFrame::StyledPanel);
         picker->setFrameShadow(QFrame::Raised);

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -155,7 +155,9 @@ void UBPreferencesController::wire()
     connect(mPreferencesUI->emptyTrashDaysValue, SIGNAL(valueChanged(int)), settings->emptyTrashDaysValue,  SLOT(setInt(int)));
 
 
-    connect(mPreferencesUI->keyboardPaletteKeyButtonSize, SIGNAL(currentIndexChanged(const QString &)), settings->boardKeyboardPaletteKeyBtnSize, SLOT(setString(const QString &)));
+    connect(mPreferencesUI->keyboardPaletteKeyButtonSize, qOverload<int>(&QComboBox::currentIndexChanged), settings->boardKeyboardPaletteKeyBtnSize, [=](int index) {
+        settings->boardKeyboardPaletteKeyBtnSize->setString(mPreferencesUI->keyboardPaletteKeyButtonSize->itemText(index));
+    });
     connect(mPreferencesUI->startModeComboBox, SIGNAL(currentIndexChanged(int)), settings->appStartMode, SLOT(setInt(int)));
 
     connect(mPreferencesUI->useExternalBrowserCheckBox, SIGNAL(clicked(bool)), settings->webUseExternalBrowser, SLOT(setBool(bool)));

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -167,7 +167,9 @@ QSettings* UBSettings::getAppSettings()
         }
 
         UBSettings::sAppSettings = new QSettings(appSettings, QSettings::IniFormat, 0);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         UBSettings::sAppSettings->setIniCodec("utf-8");
+#endif
 
         qDebug() << "sAppSettings location: " << appSettings;
     }
@@ -945,7 +947,7 @@ QString UBSettings::userDataDirectory()
                 qCritical() << "Impossible to create datadirpath " << dataDirPath;
 
         }
-        dataDirPath = UBFileSystemUtils::normalizeFilePath(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+        dataDirPath = UBFileSystemUtils::normalizeFilePath(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
         if (qApp->organizationName().size() > 0)
             dataDirPath.replace(qApp->organizationName() + "/", "");
     }

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -28,7 +28,6 @@
 
 
 #include <QtGui>
-#include <QTextCodec>
 
 #include "frameworks/UBPlatformUtils.h"
 #include "frameworks/UBFileSystemUtils.h"

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -71,6 +71,12 @@
 
 #include "core/memcheck.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
 static bool lessThan(UBDocumentTreeNode *lValue, UBDocumentTreeNode *rValue)
 {
     if (lValue->nodeType() == UBDocumentTreeNode::Catalog) {
@@ -1091,7 +1097,7 @@ bool UBDocumentTreeModel::newNodeAllowed(const QModelIndex &pSelectedIndex)  con
 
 QModelIndex UBDocumentTreeModel::goTo(const QString &dir)
 {
-    QStringList pathList = dir.split("/", QString::SkipEmptyParts);
+    QStringList pathList = dir.split("/", SplitBehavior::SkipEmptyParts);
 
     if (pathList.isEmpty()) {
         return untitledDocumentsIndex();

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -1845,11 +1845,11 @@ void UBDocumentController::createNewDocument()
     QString documentName = "";
     if (docModel->isCatalog(selectedIndex))
     {
-        documentName = docModel->adjustNameForParentIndex(now.toString(Qt::SystemLocaleShortDate), selectedIndex);
+        documentName = docModel->adjustNameForParentIndex(QLocale::system().toString(now, QLocale::ShortFormat), selectedIndex);
     }
     else
     {
-        documentName = docModel->adjustNameForParentIndex(now.toString(Qt::SystemLocaleShortDate), selectedIndex.parent());
+        documentName = docModel->adjustNameForParentIndex(QLocale::system().toString(now, QLocale::ShortFormat), selectedIndex.parent());
     }
 
 

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -143,9 +143,9 @@ UBDocumentReplaceDialog::UBDocumentReplaceDialog(const QString &pIncommingName, 
     reactOnTextChanged(mIncommingName);
 }
 
-void UBDocumentReplaceDialog::setRegexp(const QRegExp pRegExp)
+void UBDocumentReplaceDialog::setRegexp(const QRegularExpression pRegExp)
 {
-    mValidator->setRegExp(pRegExp);
+    mValidator->setRegularExpression(pRegExp);
 }
 bool UBDocumentReplaceDialog::validString(const QString &pStr)
 {

--- a/src/document/UBDocumentController.h
+++ b/src/document/UBDocumentController.h
@@ -61,7 +61,7 @@ class UBDocumentReplaceDialog : public QDialog
 
 public:
     UBDocumentReplaceDialog(const QString &pIncommingName, const QStringList &pFileList, QWidget *parent = 0, Qt::WindowFlags pFlags = {});
-    void setRegexp(const QRegExp pRegExp);
+    void setRegexp(const QRegularExpression pRegExp);
     bool validString(const QString &pStr);
     void setFileNameAndList(const QString &fileName, const QStringList &pLst);
     QString  labelTextWithName(const QString &documentName) const;
@@ -79,7 +79,7 @@ private slots:
 
 private:
     QLineEdit *mLineEdit;
-    QRegExpValidator *mValidator;
+    QRegularExpressionValidator *mValidator;
     QStringList mFileNameList;
     QString mIncommingName;
     QPushButton *acceptButton;

--- a/src/document/UBDocumentProxy.cpp
+++ b/src/document/UBDocumentProxy.cpp
@@ -73,7 +73,7 @@ void UBDocumentProxy::init()
     setMetaData(UBSettings::documentGroupName, "");
 
     QDateTime now = QDateTime::currentDateTime();
-    setMetaData(UBSettings::documentName, now.toString(Qt::SystemLocaleShortDate));
+    setMetaData(UBSettings::documentName, QLocale::system().toString(now, QLocale::ShortFormat));
 
     setUuid(QUuid::createUuid());
 

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -279,7 +279,7 @@ void UBGraphicsDelegateFrame::setCursorFromAngle(QString angle)
         painter.end();
 
         pixCursor.setMask(bmpMask);
-        controlViewport->setCursor(pixCursor);
+        controlViewport->setCursor(QCursor(pixCursor));
     }
 }
 

--- a/src/domain/UBGraphicsItemDelegate.h
+++ b/src/domain/UBGraphicsItemDelegate.h
@@ -42,6 +42,7 @@
 #include <QtGui>
 #include <QtSvg>
 #include <QMimeData>
+#include <QGraphicsSvgItem>
 #include <QGraphicsVideoItem>
 
 #include "core/UB.h"

--- a/src/domain/UBGraphicsItemUndoCommand.cpp
+++ b/src/domain/UBGraphicsItemUndoCommand.cpp
@@ -148,7 +148,7 @@ void UBGraphicsItemUndoCommand::undo()
         }
     }
 
-    QMapIterator<UBGraphicsGroupContainerItem*, QUuid> curMapElement(mExcludedFromGroup);
+    GroupDataTableIterator curMapElement(mExcludedFromGroup);
     UBGraphicsGroupContainerItem *nextGroup = NULL;
     UBGraphicsGroupContainerItem *previousGroupItem = NULL;
     bool groupChanged = false;
@@ -194,7 +194,7 @@ void UBGraphicsItemUndoCommand::redo()
             return;
         }
 
-        QMapIterator<UBGraphicsGroupContainerItem*, QUuid> curMapElement(mExcludedFromGroup);
+        GroupDataTableIterator curMapElement(mExcludedFromGroup);
         UBGraphicsGroupContainerItem *nextGroup = NULL;
         UBGraphicsGroupContainerItem *previousGroupItem = NULL;
         bool groupChanged = false;

--- a/src/domain/UBGraphicsItemUndoCommand.h
+++ b/src/domain/UBGraphicsItemUndoCommand.h
@@ -43,6 +43,7 @@ class UBGraphicsItemUndoCommand : public UBUndoCommand
     public:
         typedef QMultiMap<UBGraphicsGroupContainerItem*, QUuid> GroupDataTable;
 
+
         UBGraphicsItemUndoCommand(UBGraphicsScene* pScene, const QSet<QGraphicsItem*>& pRemovedItems,
                                   const QSet<QGraphicsItem*>& pAddedItems, const GroupDataTable &groupsMap = GroupDataTable());
 
@@ -61,6 +62,11 @@ class UBGraphicsItemUndoCommand : public UBUndoCommand
         virtual void redo();
 
     private:
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        typedef QMultiMapIterator<UBGraphicsGroupContainerItem*, QUuid> GroupDataTableIterator;
+#else
+        typedef QMapIterator<UBGraphicsGroupContainerItem*, QUuid> GroupDataTableIterator;
+#endif
         UBGraphicsScene* mScene;
         QSet<QGraphicsItem*> mRemovedItems;
         QSet<QGraphicsItem*> mAddedItems;

--- a/src/domain/UBGraphicsMediaItem.h
+++ b/src/domain/UBGraphicsMediaItem.h
@@ -33,9 +33,7 @@
 #include <QtWidgets/QGraphicsView>
 
 #include <QAudioOutput>
-#include <QMediaObject>
 #include <QMediaPlayer>
-#include <QMediaService>
 
 #include <QtMultimediaWidgets/QVideoWidget>
 #include <QtMultimedia/QVideoFrame>
@@ -85,9 +83,16 @@ public:
     qint64 mediaDuration() const;
     qint64 mediaPosition() const;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMediaPlayer::PlaybackState playerState() const;
+    bool isPlaying() const { return (mMediaObject->playbackState() == QMediaPlayer::PlayingState); }
+    bool isPaused() const { return (mMediaObject->playbackState() == QMediaPlayer::PausedState); }
+#else
     QMediaPlayer::State playerState() const;
     bool isPlaying() const { return (mMediaObject->state() == QMediaPlayer::PlayingState); }
     bool isPaused() const { return (mMediaObject->state() == QMediaPlayer::PausedState); }
+#endif
+
     bool isStopped() const;
     bool firstLoad() const;
     void setFirstLoad(bool firstLoad);
@@ -201,7 +206,13 @@ public:
 public slots:
     void videoSizeChanged(QSizeF newSize);
     void hasVideoChanged(bool hasVideo);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    void mediaStateChanged(QMediaPlayer::PlaybackState state);
+#else
     void mediaStateChanged(QMediaPlayer::State state);
+#endif
+
     void activeSceneChanged();
 
 protected slots:

--- a/src/domain/UBGraphicsMediaItemDelegate.cpp
+++ b/src/domain/UBGraphicsMediaItemDelegate.cpp
@@ -268,7 +268,11 @@ void UBGraphicsMediaItemDelegate::mediaStatusChanged(QMediaPlayer::MediaStatus s
     updatePlayPauseState();
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+void UBGraphicsMediaItemDelegate::mediaStateChanged(QMediaPlayer::PlaybackState state)
+#else
 void UBGraphicsMediaItemDelegate::mediaStateChanged(QMediaPlayer::State state)
+#endif
 {
     Q_UNUSED(state);
     // Possible states are StoppedState, PlayingState and PausedState

--- a/src/domain/UBGraphicsMediaItemDelegate.h
+++ b/src/domain/UBGraphicsMediaItemDelegate.h
@@ -61,7 +61,11 @@ class UBGraphicsMediaItemDelegate :  public UBGraphicsItemDelegate
         virtual void showHide(bool show);
 
         void mediaStatusChanged(QMediaPlayer::MediaStatus status);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        void mediaStateChanged(QMediaPlayer::PlaybackState state);
+#else
         void mediaStateChanged(QMediaPlayer::State state);
+#endif
 
     protected slots:
 

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -169,7 +169,11 @@ qreal UBZLayerController::changeZLevelTo(QGraphicsItem *item, moveDestination de
         return item->data(UBGraphicsItemData::ItemOwnZValue).toReal();
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMultiMapIterator<qreal, QGraphicsItem*>iCurElement(sortedItems);
+#else
     QMapIterator<qreal, QGraphicsItem*>iCurElement(sortedItems);
+#endif
 
     if (dest == up) {
         qDebug() << "item data zvalue= " << item->data(UBGraphicsItemData::ItemOwnZValue).toReal();

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -444,7 +444,7 @@ void UBGraphicsTextItem::contentsChanged()
 
     if (toPlainText().isEmpty())
     {
-        resize(QFontMetrics(font()).width(mTypeTextHereLabel),QFontMetrics(font()).height());
+        resize(QFontMetrics(font()).horizontalAdvance(mTypeTextHereLabel),QFontMetrics(font()).height());
     }
 }
 

--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -1137,20 +1137,20 @@ QString UBGraphicsW3CWidgetItem::createHtmlWrapperInDir(const QString& html, con
 
     QTextStream outConfig(&configFile);
     outConfig.setCodec("UTF-8");
-    outConfig << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << endl;
-    outConfig << "<widget xmlns=\"http://www.w3.org/ns/widgets\"" << endl;
-    outConfig << "    xmlns:ub=\"http://uniboard.mnemis.com/widgets\"" << endl;
-    outConfig << "    id=\"http://uniboard.mnemis.com/" << pName << "\"" <<endl;
+    outConfig << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << '\n';
+    outConfig << "<widget xmlns=\"http://www.w3.org/ns/widgets\"" << '\n';
+    outConfig << "    xmlns:ub=\"http://uniboard.mnemis.com/widgets\"" << '\n';
+    outConfig << "    id=\"http://uniboard.mnemis.com/" << pName << "\"" <<'\n';
 
-    outConfig << "    version=\"2.0\"" << endl;
-    outConfig << "    width=\"" << sizeHint.width() << "\"" << endl;
-    outConfig << "    height=\"" << sizeHint.height() << "\"" << endl;
-    outConfig << "    ub:resizable=\"true\">" << endl;
+    outConfig << "    version=\"2.0\"" << '\n';
+    outConfig << "    width=\"" << sizeHint.width() << "\"" << '\n';
+    outConfig << "    height=\"" << sizeHint.height() << "\"" << '\n';
+    outConfig << "    ub:resizable=\"true\">" << '\n';
 
-    outConfig << "  <name>" << pName << "</name>" << endl;
-    outConfig << "  <content src=\"" << pName << ".html\"/>" << endl;
+    outConfig << "  <name>" << pName << "</name>" << '\n';
+    outConfig << "  <content src=\"" << pName << ".html\"/>" << '\n';
 
-    outConfig << "</widget>" << endl;
+    outConfig << "</widget>" << '\n';
 
     configFile.close();
 
@@ -1167,15 +1167,15 @@ QString UBGraphicsW3CWidgetItem::createHtmlWrapperInDir(const QString& html, con
     QTextStream outStartFile(&widgetHtmlFile);
     outStartFile.setCodec("UTF-8");
 
-    outStartFile << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">" << endl;
-    outStartFile << "<html>" << endl;
-    outStartFile << "<head>" << endl;
-    outStartFile << "    <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">" << endl;
-    outStartFile << "</head>" << endl;
-    outStartFile << "  <body>" << endl;
-    outStartFile << html << endl;
-    outStartFile << "  </body>" << endl;
-    outStartFile << "</html>" << endl;
+    outStartFile << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">" << '\n';
+    outStartFile << "<html>" << '\n';
+    outStartFile << "<head>" << '\n';
+    outStartFile << "    <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">" << '\n';
+    outStartFile << "</head>" << '\n';
+    outStartFile << "  <body>" << '\n';
+    outStartFile << html << '\n';
+    outStartFile << "  </body>" << '\n';
+    outStartFile << "</html>" << '\n';
 
     widgetHtmlFile.close();
 

--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -1092,7 +1092,9 @@ QString UBGraphicsW3CWidgetItem::createNPAPIWrapperInDir(const QString& pUrl, co
         }
 
         QTextStream outConfig(&configFile);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         outConfig.setCodec("UTF-8");
+#endif
 
         outConfig << configTemplate;
         configFile.close();
@@ -1105,7 +1107,9 @@ QString UBGraphicsW3CWidgetItem::createNPAPIWrapperInDir(const QString& pUrl, co
         }
 
         QTextStream outIndex(&indexFile);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         outIndex.setCodec("UTF-8");
+#endif
 
         outIndex << htmlTemplate;
         indexFile.close();
@@ -1136,7 +1140,9 @@ QString UBGraphicsW3CWidgetItem::createHtmlWrapperInDir(const QString& html, con
     }
 
     QTextStream outConfig(&configFile);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     outConfig.setCodec("UTF-8");
+#endif
     outConfig << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << '\n';
     outConfig << "<widget xmlns=\"http://www.w3.org/ns/widgets\"" << '\n';
     outConfig << "    xmlns:ub=\"http://uniboard.mnemis.com/widgets\"" << '\n';
@@ -1165,7 +1171,9 @@ QString UBGraphicsW3CWidgetItem::createHtmlWrapperInDir(const QString& html, con
     }
 
     QTextStream outStartFile(&widgetHtmlFile);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     outStartFile.setCodec("UTF-8");
+#endif
 
     outStartFile << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">" << '\n';
     outStartFile << "<html>" << '\n';

--- a/src/domain/UBSelectionFrame.cpp
+++ b/src/domain/UBSelectionFrame.cpp
@@ -465,7 +465,7 @@ void UBSelectionFrame::setCursorFromAngle(QString angle)
     painter.end();
 
     pixCursor.setMask(bmpMask);
-    controlViewport->setCursor(pixCursor);
+    controlViewport->setCursor(QCursor(pixCursor));
 }
 
 QList<QGraphicsItem*> UBSelectionFrame::sortedByZ(const QList<QGraphicsItem *> &pItems)

--- a/src/domain/UBWebEngineView.cpp
+++ b/src/domain/UBWebEngineView.cpp
@@ -85,7 +85,11 @@ void UBWebEngineView::closeInspector()
 
 void UBWebEngineView::contextMenuEvent(QContextMenuEvent *event)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMenu *menu = createStandardContextMenu();
+#else
     QMenu *menu = page()->createStandardContextMenu();
+#endif
 
     // suppress actions requiring a new window
     const QList<QWebEnginePage::WebAction> suppressed = {

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -77,9 +77,9 @@ QStringList UBPlatformUtils::availableTranslations()
 {
     QString translationsPath = applicationResourcesDirectory() + "/" + "i18n" + "/";
     QStringList translationsList = UBFileSystemUtils::allFiles(translationsPath);
-    QRegExp sankoreTranslationFiles(".*OpenBoard_.*.qm");
+    QRegularExpression sankoreTranslationFiles(".*OpenBoard_.*.qm");
     translationsList=translationsList.filter(sankoreTranslationFiles);
-    return translationsList.replaceInStrings(QRegExp("(.*)OpenBoard_(.*).qm"),"\\2");
+    return translationsList.replaceInStrings(QRegularExpression("(.*)OpenBoard_(.*).qm"),"\\2");
 }
 
 QString UBPlatformUtils::translationPath(QString pFilePrefix,QString pLanguage)

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -77,9 +77,9 @@ QStringList UBPlatformUtils::availableTranslations()
 {
     QString translationsPath = applicationResourcesDirectory() + "/" + "i18n" + "/";
     QStringList translationsList = UBFileSystemUtils::allFiles(translationsPath);
-    QRegularExpression sankoreTranslationFiles(".*OpenBoard_.*.qm");
-    translationsList=translationsList.filter(sankoreTranslationFiles);
-    return translationsList.replaceInStrings(QRegularExpression("(.*)OpenBoard_(.*).qm"),"\\2");
+    static const QRegularExpression sankoreTranslationFiles("(.*)OpenBoard_(.*).qm");
+    translationsList = translationsList.filter(sankoreTranslationFiles);
+    return translationsList.replaceInStrings(sankoreTranslationFiles, "\\2");
 }
 
 QString UBPlatformUtils::translationPath(QString pFilePrefix,QString pLanguage)

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -25,7 +25,7 @@
  */
 
 
-
+#define QT_IMPLICIT_QCHAR_CONSTRUCTION
 
 #include "UBPlatformUtils.h"
 

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -79,9 +79,9 @@ QStringList UBPlatformUtils::availableTranslations()
 {
     QString translationsPath = applicationResourcesDirectory() + "/" + "i18n" + "/";
     QStringList translationsList = UBFileSystemUtils::allFiles(translationsPath);
-    QRegExp sankoreTranslationFiles(".*OpenBoard_.*.qm");
+    QRegularExpression sankoreTranslationFiles(".*OpenBoard_.*.qm");
     translationsList=translationsList.filter(sankoreTranslationFiles);
-    return translationsList.replaceInStrings(QRegExp("(.*)OpenBoard_(.*).qm"),"\\2");
+    return translationsList.replaceInStrings(QRegularExpression("(.*)OpenBoard_(.*).qm"),"\\2");
 }
 
 QString UBPlatformUtils::translationPath(QString pFilePrefix,QString pLanguage)

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -79,9 +79,9 @@ QStringList UBPlatformUtils::availableTranslations()
 {
     QString translationsPath = applicationResourcesDirectory() + "/" + "i18n" + "/";
     QStringList translationsList = UBFileSystemUtils::allFiles(translationsPath);
-    QRegularExpression sankoreTranslationFiles(".*OpenBoard_.*.qm");
-    translationsList=translationsList.filter(sankoreTranslationFiles);
-    return translationsList.replaceInStrings(QRegularExpression("(.*)OpenBoard_(.*).qm"),"\\2");
+    static const QRegularExpression sankoreTranslationFiles("(.*)OpenBoard_(.*).qm");
+    translationsList = translationsList.filter(sankoreTranslationFiles);
+    return translationsList.replaceInStrings(sankoreTranslationFiles, "\\2");
 }
 
 QString UBPlatformUtils::translationPath(QString pFilePrefix,QString pLanguage)

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -25,7 +25,7 @@
  */
 
 
-
+#define QT_IMPLICIT_QCHAR_CONSTRUCTION
 
 #include "UBPlatformUtils.h"
 

--- a/src/frameworks/UBStringUtils.cpp
+++ b/src/frameworks/UBStringUtils.cpp
@@ -47,7 +47,7 @@ bool UBStringUtils::containsPrefix(const QStringList &prefixes, const QString &s
 QStringList UBStringUtils::sortByLastDigit(const QStringList& sourceList)
 {
     // we look for a set of digit after non digits and before a .
-    QRegularExpression rx("\\D(\\d+)\\.");
+    static const QRegularExpression rx("\\D(\\d+)\\.");
 
     QMultiMap<int, QString> elements;
 
@@ -90,7 +90,7 @@ QString UBStringUtils::nextDigitizedName(const QString& source)
 {
 
     // we look for a set of digit after non digits and at the end
-    QRegularExpression rx("\\D(\\d+)");
+    static const QRegularExpression rx("\\D(\\d+)");
 
     int pos = source.lastIndexOf(rx);
 

--- a/src/frameworks/UBStringUtils.cpp
+++ b/src/frameworks/UBStringUtils.cpp
@@ -47,19 +47,20 @@ bool UBStringUtils::containsPrefix(const QStringList &prefixes, const QString &s
 QStringList UBStringUtils::sortByLastDigit(const QStringList& sourceList)
 {
     // we look for a set of digit after non digits and before a .
-    QRegExp rx("\\D(\\d+)\\.");
+    QRegularExpression rx("\\D(\\d+)\\.");
 
     QMultiMap<int, QString> elements;
 
     foreach(QString source, sourceList)
     {
-        int pos = rx.lastIndexIn(source);
+        int pos = source.lastIndexOf(rx);
 
         int digit = -1;
 
         if (pos >= 0)
         {
-            digit = rx.cap(1).toInt();
+            QRegularExpressionMatch match = rx.match(source, pos);
+            digit = match.captured(1).toInt();
         }
 
         elements.insert(digit, source);
@@ -89,15 +90,17 @@ QString UBStringUtils::nextDigitizedName(const QString& source)
 {
 
     // we look for a set of digit after non digits and at the end
-    QRegExp rx("\\D(\\d+)");
+    QRegularExpression rx("\\D(\\d+)");
 
-    int pos = rx.lastIndexIn(source);
+    int pos = source.lastIndexOf(rx);
 
     int digit = -1;
+    QRegularExpressionMatch match;
 
     if (pos >= 0)
     {
-        digit = rx.cap(1).toInt();
+        match = rx.match(source, pos);
+        digit = match.captured(1).toInt();
     }
 
     QString ret(source);
@@ -110,7 +113,7 @@ QString UBStringUtils::nextDigitizedName(const QString& source)
     {
         QString s("%1");
         s = s.arg(digit + 1);
-        return ret.replace(rx.cap(1), s);
+        return ret.replace(match.captured(1), s);
     }
 }
 

--- a/src/frameworks/UBVersion.cpp
+++ b/src/frameworks/UBVersion.cpp
@@ -54,7 +54,7 @@ uint UBVersion::toUInt() const
     */
 
     uint result = 0;
-    QStringList list = mString.split(QRegExp("[-\\.]"));
+    QStringList list = mString.split(QRegularExpression("[-\\.]"));
     switch (list.count()) {
     case 2:
         //short version  1.0

--- a/src/frameworks/UBVersion.cpp
+++ b/src/frameworks/UBVersion.cpp
@@ -54,7 +54,8 @@ uint UBVersion::toUInt() const
     */
 
     uint result = 0;
-    QStringList list = mString.split(QRegularExpression("[-\\.]"));
+    static const QRegularExpression minusOrDot("[-\\.]");
+    QStringList list = mString.split(minusOrDot);
     switch (list.count()) {
     case 2:
         //short version  1.0

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -163,7 +163,8 @@ void UBActionPalette::groupActions()
         ++i;
     }
 
-    connect(mButtonGroup, SIGNAL(buttonClicked(int)), this, SIGNAL(buttonGroupClicked(int)));
+    connect(mButtonGroup, qOverload<QAbstractButton *>(&QButtonGroup::buttonClicked),
+            this, &UBActionPalette::buttonGroupClicked);
 }
 
 

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -83,7 +83,7 @@ class UBActionPalette : public UBFloatingPalette
 
     signals:
         void closed();
-        void buttonGroupClicked(int id);
+        void buttonGroupClicked(QAbstractButton *button);
         void customMouseReleased();
 
     protected:

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -669,7 +669,7 @@ UBTabDockPalette::~UBTabDockPalette()
 
 void UBTabDockPalette::mousePressEvent(QMouseEvent *event)
 {
-    dock->mClickTime = QTime::currentTime();
+    dock->mClickTime.start();
     // The goal here is to verify if the user can resize the widget.
     // It is only possible to resize it if the border is selected
     QPoint p = event->pos();

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -38,7 +38,7 @@ class UBDocumentProxy;
 #include <QPaintEvent>
 #include <QResizeEvent>
 #include <QEvent>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QPoint>
 #include <QPixmap>
 #include <QMap>
@@ -179,7 +179,7 @@ protected:
     /** The last width of the palette */
     int mLastWidth;
     /** The click time*/
-    QTime mClickTime;
+    QElapsedTimer mClickTime;
     /** The mouse pressed position */
     QPoint mMousePressPos;
     /** The tab orientation */

--- a/src/gui/UBDownloadWidget.cpp
+++ b/src/gui/UBDownloadWidget.cpp
@@ -29,7 +29,7 @@
 
 #include <QDebug>
 #include <QHeaderView>
-#include <QStyleOptionProgressBarV2>
+#include <QStyleOptionProgressBar>
 #include <QApplication>
 
 #include "UBDownloadWidget.h"
@@ -231,7 +231,7 @@ UBDownloadProgressDelegate::UBDownloadProgressDelegate(QObject *parent):QItemDel
 
 void UBDownloadProgressDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QStyleOptionProgressBarV2 opt;
+    QStyleOptionProgressBar opt;
     opt.rect = option.rect;
     opt.minimum = 0;
     opt.maximum = index.data(Qt::UserRole + 1).toInt();

--- a/src/gui/UBFeaturesWidget.cpp
+++ b/src/gui/UBFeaturesWidget.cpp
@@ -645,7 +645,7 @@ UBFeaturesNewFolderDialog::UBFeaturesNewFolderDialog(QWidget *parent) : QWidget(
 
     mLineEdit = new QLineEdit(this);
 
-    mValidator = new QRegExpValidator(QRegExp("[^\\/\\:\\?\\*\\|\\<\\>\\\"]{2,}"), this);
+    mValidator = new QRegularExpressionValidator(QRegularExpression("[^\\/\\:\\?\\*\\|\\<\\>\\\"]{2,}"), this);
     mLineEdit->setValidator(mValidator);
     labelLayout->addWidget(mLabel);
     labelLayout->addWidget(mLineEdit);
@@ -669,9 +669,9 @@ UBFeaturesNewFolderDialog::UBFeaturesNewFolderDialog(QWidget *parent) : QWidget(
     reactOnTextChanged(QString());
 }
 
-void UBFeaturesNewFolderDialog::setRegexp(const QRegExp pRegExp)
+void UBFeaturesNewFolderDialog::setRegexp(const QRegularExpression pRegExp)
 {
-    mValidator->setRegExp(pRegExp);
+    mValidator->setRegularExpression(pRegExp);
 }
 bool UBFeaturesNewFolderDialog::validString(const QString &pStr)
 {
@@ -1391,7 +1391,7 @@ bool UBFeaturesProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex & 
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
     QString path = index.data( Qt::UserRole ).toString();
 
-    return filterRegExp().exactMatch(path);
+    return filterRegularExpression().match(path).hasMatch();
 }
 
 bool UBFeaturesSearchProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex & sourceParent )const
@@ -1410,7 +1410,7 @@ bool UBFeaturesSearchProxyModel::filterAcceptsRow( int sourceRow, const QModelIn
 
     return isFile
             && feature.getFullVirtualPath().contains(mFilterPrefix)
-            && filterRegExp().exactMatch( feature.getName() );
+            && filterRegularExpression().match( feature.getName() ).hasMatch();
 }
 
 bool UBFeaturesPathProxyModel::filterAcceptsRow( int sourceRow, const QModelIndex & sourceParent )const

--- a/src/gui/UBFeaturesWidget.cpp
+++ b/src/gui/UBFeaturesWidget.cpp
@@ -485,7 +485,7 @@ UBFeaturesNavigatorWidget::UBFeaturesNavigatorWidget(QWidget *parent, const char
 
     mainLayer->addWidget(mListView, 1);
     mainLayer->addWidget(mListSlider, 0);
-    mainLayer->setMargin(0);
+    mainLayer->setContentsMargins(0, 0, 0, 0);
 
     connect(mListSlider, SIGNAL(valueChanged(int)), mListView, SLOT(thumbnailSizeChanged(int)));
 }
@@ -783,7 +783,7 @@ UBFeaturesWebView::UBFeaturesWebView(QWidget* parent, const char* name):QWidget(
     UBWebController::injectScripts(mpView);
 
     mpLayout->addWidget(mpView);
-    mpLayout->setMargin(0);
+    mpLayout->setContentsMargins(0, 0, 0, 0);
 }
 
 UBFeaturesWebView::~UBFeaturesWebView()
@@ -894,7 +894,7 @@ UBFeatureProperties::UBFeatureProperties( QWidget *parent, const char *name ) : 
     mpObjInfos->setObjectName("DockPaletteWidgetBox");
     mpObjInfos->setStyleSheet("background:white;");
     mpLayout->addWidget(mpObjInfos, 1);
-    mpLayout->setMargin(0);
+    mpLayout->setContentsMargins(0, 0, 0, 0);
 
     connect( mpAddPageButton, SIGNAL(clicked()), this, SLOT(onAddToPage()) );
     connect( mpAddToLibButton, SIGNAL( clicked() ), this, SLOT(onAddToLib() ) );
@@ -1063,11 +1063,11 @@ void UBFeatureProperties::onAddToLib()
         QString str2 = mpElement->getFullPath().toString().normalized(QString::NormalizationForm_D);
         QString str3 = mpElement->getFullPath().toString().normalized(QString::NormalizationForm_KC);
         QString str4 = mpElement->getFullPath().toString().normalized(QString::NormalizationForm_KD);
-        qDebug() << desc.srcUrl << endl
-                    << "str1" << str1 << endl
-                    << "str2" << str2 << endl
-                    << "str3" << str3 << endl
-                    << "str4" << str4 << endl;
+        qDebug() << desc.srcUrl << '\n'
+                    << "str1" << str1 << '\n'
+                    << "str2" << str2 << '\n'
+                    << "str3" << str3 << '\n'
+                    << "str4" << str4 << '\n';
         UBDownloadManager::downloadManager()->addFileToDownload(desc);
     }
 }

--- a/src/gui/UBFeaturesWidget.h
+++ b/src/gui/UBFeaturesWidget.h
@@ -258,7 +258,7 @@ class UBFeaturesNewFolderDialog : public QWidget
 
 public:
     UBFeaturesNewFolderDialog(QWidget *parent = 0);
-    void setRegexp(const QRegExp pRegExp);
+    void setRegexp(const QRegularExpression pRegExp);
     bool validString(const QString &pStr);
 
 signals:
@@ -273,7 +273,7 @@ private slots:
 
 private:
     QLineEdit *mLineEdit;
-    QRegExpValidator *mValidator;
+    QRegularExpressionValidator *mValidator;
     QStringList mFileNameList;
     QPushButton *acceptButton;
     const QString acceptText;

--- a/src/gui/UBMagnifer.cpp
+++ b/src/gui/UBMagnifer.cpp
@@ -374,7 +374,7 @@ void UBMagnifier::slot_refresh()
 
 void UBMagnifier::grabPoint()
 {
-    QMatrix transM = UBApplication::boardController->controlView()->matrix();
+    QTransform transM = UBApplication::boardController->controlView()->transform();
     QPointF itemPos = gView->mapFromGlobal(updPointGrab);
 
     qreal zWidth = width() / (params.zoom * transM.m11());
@@ -407,7 +407,7 @@ void UBMagnifier::grabPoint()
 
 void UBMagnifier::grabPoint(const QPoint &pGrab)
 {
-    QMatrix transM = UBApplication::boardController->controlView()->matrix();
+    QTransform transM = UBApplication::boardController->controlView()->transform();
     updPointGrab = pGrab;
     QPointF itemPos = gView->mapFromGlobal(pGrab);
 

--- a/src/gui/UBMagnifer.cpp
+++ b/src/gui/UBMagnifer.cpp
@@ -65,10 +65,10 @@ UBMagnifier::UBMagnifier(QWidget *parent, bool isInteractive)
     mResizeItem = new QPixmap(":/images/resize.svg");
     sChangeModePixmap = new QPixmap();
 
-    qDebug() << "sClosePixmap" << sClosePixmap->size() << endl
-             << "sIncreasePixmap" << sIncreasePixmap->size() << endl
-             << "sDecreasePixmap" << sDecreasePixmap->size() << endl
-             << "mResizeItem" << mResizeItem->size() << endl;
+    qDebug() << "sClosePixmap" << sClosePixmap->size() << '\n'
+             << "sIncreasePixmap" << sIncreasePixmap->size() << '\n'
+             << "sDecreasePixmap" << sDecreasePixmap->size() << '\n'
+             << "mResizeItem" << mResizeItem->size() << '\n';
 
 
     setDrawingMode(UBSettings::settings()->magnifierDrawingMode->get().toInt());
@@ -194,11 +194,11 @@ void UBMagnifier::calculateButtonsPositions()
     sDecreasePixmapButtonRect = QRect(sChangeModePixmapButtonRect.x() - sChangeModePixmap->width() - m_iButtonInterval, size().height() - sDecreasePixmap->height(), sDecreasePixmap->width(), sDecreasePixmap->height());
     sIncreasePixmapButtonRect = QRect(sDecreasePixmapButtonRect.x() - sChangeModePixmap->width() - m_iButtonInterval, size().height() - sIncreasePixmap->height(), sIncreasePixmap->width(), sIncreasePixmap->height());
 
-    qDebug() << "mResizeItemButtonRect" << mResizeItemButtonRect << endl
-             << "sClosePixmapButtonRect" << sClosePixmapButtonRect << endl
-             << "sChangeModePixmapButtonRect" << sChangeModePixmapButtonRect << endl
-             << "sDecreasePixmapButtonRect" << sDecreasePixmapButtonRect << endl
-             << "sIncreasePixmapButtonRect" << sIncreasePixmapButtonRect << endl;
+    qDebug() << "mResizeItemButtonRect" << mResizeItemButtonRect << '\n'
+             << "sClosePixmapButtonRect" << sClosePixmapButtonRect << '\n'
+             << "sChangeModePixmapButtonRect" << sChangeModePixmapButtonRect << '\n'
+             << "sDecreasePixmapButtonRect" << sDecreasePixmapButtonRect << '\n'
+             << "sIncreasePixmapButtonRect" << sIncreasePixmapButtonRect << '\n';
 }
 
 void UBMagnifier::paintEvent(QPaintEvent * event)

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -83,7 +83,8 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
         {
             mButtonGroup->addButton(mButtons[i], i);
         }
-        connect(mButtonGroup, SIGNAL(buttonClicked(int)), this, SIGNAL(buttonGroupClicked(int)));
+        connect(mButtonGroup, qOverload<QAbstractButton *>(&QButtonGroup::buttonClicked),
+                this, &UBActionPalette::buttonGroupClicked);
     }
 
     adjustSizeAndPosition();

--- a/src/gui/UBWidgetMirror.cpp
+++ b/src/gui/UBWidgetMirror.cpp
@@ -32,7 +32,7 @@
 #include "core/memcheck.h"
 
 UBWidgetMirror::UBWidgetMirror(QWidget* sourceWidget, QWidget* parent)
-    : QWidget(parent, 0)
+    : QWidget(parent)
     , mSourceWidget(sourceWidget)
 {
     mSourceWidget->installEventFilter(this);

--- a/src/network/UBAutoSaver.cpp
+++ b/src/network/UBAutoSaver.cpp
@@ -92,7 +92,7 @@ UBAutoSaver::~UBAutoSaver()
 
 void UBAutoSaver::changeOccurred()
 {
-    if (mFirstChange.isNull())
+    if (!mFirstChange.isValid())
         mFirstChange.start();
 
     if (mFirstChange.elapsed() > MAXWAIT)
@@ -123,7 +123,7 @@ void UBAutoSaver::saveIfNeccessary()
         return;
 
     mTimer.stop();
-    mFirstChange = QTime();
+    mFirstChange.invalidate();
 
     if (!QMetaObject::invokeMethod(parent(), "save", Qt::DirectConnection))
     {

--- a/src/network/UBAutoSaver.h
+++ b/src/network/UBAutoSaver.h
@@ -95,7 +95,7 @@ class UBAutoSaver : public QObject {
 
     private:
         QBasicTimer mTimer;
-        QTime mFirstChange;
+        QElapsedTimer mFirstChange;
 
 };
 

--- a/src/network/UBNetworkAccessManager.cpp
+++ b/src/network/UBNetworkAccessManager.cpp
@@ -88,8 +88,6 @@ UBNetworkAccessManager::UBNetworkAccessManager(QObject *parent)
 
 QNetworkReply *UBNetworkAccessManager::get(const QNetworkRequest &request)
 {
-    QTime loadStartTime;
-    loadStartTime.start();
     QNetworkReply *networkReply = QNetworkAccessManager::get(request);
     return networkReply;
 }
@@ -152,7 +150,7 @@ void UBNetworkAccessManager::proxyAuthenticationRequired(const QNetworkProxy &pr
 void UBNetworkAccessManager::sslErrors(QNetworkReply *reply, const QList<QSslError> &error)
 {
     // check if SSL certificate has been trusted already
-    QString replyHost = reply->url().host() + ":" + reply->url().port();
+    QString replyHost = reply->url().host() + QString(":%1").arg(reply->url().port());
     if(!sslTrustedHostList.contains(replyHost))
     {
         QWidget *mainWindow = QApplication::activeWindow();

--- a/src/podcast/ffmpeg/UBMicrophoneInput.h
+++ b/src/podcast/ffmpeg/UBMicrophoneInput.h
@@ -25,6 +25,11 @@
 #include <QtCore>
 #include <QAudioInput>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QAudioDevice>
+#include <QAudioSource>
+#endif
+
 /**
  * @brief The UBMicrophoneInput class captures uncompressed sound from a microphone.
  *
@@ -49,7 +54,6 @@ public:
     int sampleRate();
     int sampleSize();
     int sampleFormat();
-    QString codec();
 
 signals:
     /// Send the new audio level, between 0 and 255
@@ -69,9 +73,15 @@ private:
     quint8 audioLevel(const QByteArray& data);
     QString getErrorString(QAudio::Error errorCode);
 
-    QAudioInput* mAudioInput;
-    QIODevice * mIODevice;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QAudioDevice mAudioDeviceInfo;
+    QAudioSource* mAudioInput;
+#else
     QAudioDeviceInfo mAudioDeviceInfo;
+    QAudioInput* mAudioInput;
+#endif
+
+    QIODevice* mIODevice;
     QAudioFormat mAudioFormat;
 
     qint64 mSeekPos;

--- a/src/tools/UBGraphicsAxes.cpp
+++ b/src/tools/UBGraphicsAxes.cpp
@@ -224,9 +224,9 @@ void UBGraphicsAxes::paintGraduations(QPainter *painter)
         {
             QString text = QString("%1").arg(centimeters);
 
-            if (graduationX + fontMetrics.width(text) / 2 < xAxis().x2())
+            if (graduationX + fontMetrics.horizontalAdvance(text) / 2 < xAxis().x2())
             {
-                qreal textWidth = fontMetrics.width(text);
+                qreal textWidth = fontMetrics.horizontalAdvance(text);
                 qreal textHeight = fontMetrics.tightBoundingRect(text).height();
                 QRectF textRect(graduationX - textWidth / 2, textHeight - 5, textWidth, textHeight);
 
@@ -255,7 +255,7 @@ void UBGraphicsAxes::paintGraduations(QPainter *painter)
         {
             QString text = QString("%1").arg(centimeters);
 
-            qreal textWidth = fontMetrics.width(text);
+            qreal textWidth = fontMetrics.horizontalAdvance(text);
             qreal textHeight = fontMetrics.tightBoundingRect(text).height();
             QRectF textRect(- textWidth - 10, graduationY - textHeight / 2, textWidth, textHeight);
 

--- a/src/tools/UBGraphicsCompass.cpp
+++ b/src/tools/UBGraphicsCompass.cpp
@@ -413,9 +413,9 @@ void UBGraphicsCompass::paintAngleDisplay(QPainter *painter)
     painter->rotate(angle);
         painter->drawText(
         QRectF(
-            - fm.width(angleText) / 2,
+            - fm.horizontalAdvance(angleText) / 2,
             - fm.height() / 2,
-            fm.width(angleText),
+            fm.horizontalAdvance(angleText),
             fm.height()),
         Qt::AlignTop,
         angleText);
@@ -438,7 +438,7 @@ void UBGraphicsCompass::paintRadiusDisplay(QPainter *painter)
     QPointF textCenter;
 
     if (onPencilArm)
-        textCenter = QPointF(rect().right() - sPencilBaseLength - sPencilLength - fm.width(radiusText) / 2 - 24 - 8, rect().center().y());
+        textCenter = QPointF(rect().right() - sPencilBaseLength - sPencilLength - fm.horizontalAdvance(radiusText) / 2 - 24 - 8, rect().center().y());
     else
         textCenter = QPointF((rect().left() + sNeedleLength + sNeedleBaseLength + hingeRect().left()) / 2, rect().center().y());
 
@@ -452,9 +452,9 @@ void UBGraphicsCompass::paintRadiusDisplay(QPainter *painter)
         painter->rotate(180);
     painter->drawText(
         QRectF(
-            - fm.width(radiusText) / 2,
+            - fm.horizontalAdvance(radiusText) / 2,
             - rect().height() / 2,
-            fm.width(radiusText),
+            fm.horizontalAdvance(radiusText),
             rect().height()),
         Qt::AlignVCenter,
         radiusText);

--- a/src/tools/UBGraphicsProtractor.cpp
+++ b/src/tools/UBGraphicsProtractor.cpp
@@ -448,15 +448,15 @@ void UBGraphicsProtractor::paintGraduations(QPainter *painter)
             QString grad = QString("%1").arg((int)(angle));
             QString grad2 = QString("%1").arg((int)(mSpan - angle));
 
-            painter->drawText(QRectF(center.x() + (rad - graduationLength*1.5)*co  - fm1.width(grad)/2,
+            painter->drawText(QRectF(center.x() + (rad - graduationLength*1.5)*co  - fm1.horizontalAdvance(grad)/2,
                                      center.y() - (rad - graduationLength*1.5)*si - fm1.height()/2,
-                                     fm1.width(grad), fm1.height()), Qt::AlignTop, grad);
+                                     fm1.horizontalAdvance(grad), fm1.height()), Qt::AlignTop, grad);
 
             //internal arc
             painter->setFont(font2);
-            painter->drawText(QRectF(center.x() + (rad/2 + graduationLength*1.5)*co  - fm2.width(grad2)/2,
+            painter->drawText(QRectF(center.x() + (rad/2 + graduationLength*1.5)*co  - fm2.horizontalAdvance(grad2)/2,
                                      center.y() - (rad/2 + graduationLength*1.5)*si - fm2.height()/2,
-                                     fm2.width(grad2), fm2.height()), Qt::AlignTop, grad2);
+                                     fm2.horizontalAdvance(grad2), fm2.height()), Qt::AlignTop, grad2);
             painter->setFont(font1);
 
         }
@@ -543,9 +543,9 @@ void UBGraphicsProtractor::paintAngleMarker(QPainter *painter)
 
         co = cos((mStartAngle + angle) * PI/180);
         si = sin((mStartAngle + angle) * PI/180);
-        painter->drawText(QRectF(rect().center().x() + (rad*2.5/10)*co  - fm2.width(ang)/2,
+        painter->drawText(QRectF(rect().center().x() + (rad*2.5/10)*co  - fm2.horizontalAdvance(ang)/2,
                                  rect().center().y() - (rad*2.5/10)*si - fm2.height()/2,
-                                 fm2.width(ang), fm2.height()), Qt::AlignTop, ang);
+                                 fm2.horizontalAdvance(ang), fm2.height()), Qt::AlignTop, ang);
     }
 
     painter->restore();

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -184,7 +184,7 @@ void UBGraphicsRuler::paintGraduations(QPainter *painter)
     int rulerLengthInMillimeters = (rect().width() - sLeftEdgeMargin - sRoundingRadius)/pixelsPerMillimeter;
 
     // When a "centimeter" is too narrow, we only display every 5th number, and every 5th millimeter mark
-    double numbersWidth = fontMetrics.width("00");
+    double numbersWidth = fontMetrics.horizontalAdvance("00");
     bool shouldDisplayAllNumbers = (numbersWidth <= (sPixelsPerCentimeter - 5));
 
     for (int millimeters(0); millimeters < rulerLengthInMillimeters; millimeters++) {
@@ -213,8 +213,8 @@ void UBGraphicsRuler::paintGraduations(QPainter *painter)
         {
             QString text = QString("%1").arg((int)(millimeters / UBGeometryUtils::millimetersPerCentimeter));
 
-            if (graduationX + fontMetrics.width(text) / 2 < rect().right()) {
-                qreal textWidth = fontMetrics.width(text);
+            if (graduationX + fontMetrics.horizontalAdvance(text) / 2 < rect().right()) {
+                qreal textWidth = fontMetrics.horizontalAdvance(text);
                 qreal textHeight = fontMetrics.tightBoundingRect(text).height() + 5;
                 painter->drawText(
                     QRectF(graduationX - textWidth / 2, rect().top() + 5 + UBGeometryUtils::centimeterGraduationHeight, textWidth, textHeight),

--- a/src/tools/UBGraphicsTriangle.cpp
+++ b/src/tools/UBGraphicsTriangle.cpp
@@ -394,7 +394,7 @@ void UBGraphicsTriangle::paintGraduations(QPainter *painter)
     double pixelsPerMillimeter = sPixelsPerCentimeter/10.0;
 
     // When a "centimeter" is too narrow, we only display every 5th number, and every 5th millimeter mark
-    double numbersWidth = fontMetrics.width("00");
+    double numbersWidth = fontMetrics.horizontalAdvance("00");
     bool shouldDisplayAllNumbers = (numbersWidth <= (sPixelsPerCentimeter - 5));
 
     for (int millimeters = 0; millimeters < (rect().width() - sLeftEdgeMargin - sRoundingRadius) / pixelsPerMillimeter; millimeters++)
@@ -450,7 +450,7 @@ void UBGraphicsTriangle::paintGraduations(QPainter *painter)
             || millimeters % (UBGeometryUtils::millimetersPerCentimeter*5) == 0)
         {
             QString text = QString("%1").arg((int)(millimeters / UBGeometryUtils::millimetersPerCentimeter));
-            qreal textWidth = fontMetrics.width(text);
+            qreal textWidth = fontMetrics.horizontalAdvance(text);
             qreal textHeight = fontMetrics.tightBoundingRect(text).height();
 
             requiredSpace = graduationHeight + textHeight + textWidth + SEPARATOR ;

--- a/src/tools/UBGraphicsTriangle.h
+++ b/src/tools/UBGraphicsTriangle.h
@@ -77,7 +77,7 @@ class UBGraphicsTriangle : public UBAbstractDrawRuler, public QGraphicsPolygonIt
                 TopRight
         };
 
-        static UBGraphicsTriangleOrientation orientationFromStr(QStringRef& str)
+        static UBGraphicsTriangleOrientation orientationFromStr(const QString& str)
         {
             if (str == "BottomLeft") return BottomLeft;
             if (str == "BottomRight") return BottomRight;

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -322,7 +322,9 @@ void UBEmbedController::generateConfig(int pWidth, int pHeight, const QString& p
     }
 
     QTextStream out(&configFile);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     out.setCodec("UTF-8");
+#endif
     out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << '\n';
     out << "<widget xmlns=\"http://www.w3.org/ns/widgets\"" << '\n';
     out << "        xmlns:ub=\"http://uniboard.mnemis.com/widgets\"" << '\n';

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -110,17 +110,17 @@ void UBEmbedController::textChanged(const QString &newText)
 
 #ifdef Q_OS_WIN // Defined on Windows.
     QString illegalCharList("      < > : \" / \\ | ? * ");
-    QRegExp regExp("[<>:\"/\\\\|?*]");
+    QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
 #ifdef Q_OS_OSX // Defined on Mac OS X.
     QString illegalCharList("      < > : \" / \\ | ? * ");
-    QRegExp regExp("[<>:\"/\\\\|?*]");
+    QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
 #ifdef Q_OS_LINUX // Defined on X11.
     QString illegalCharList("      < > : \" / \\ | ? * ");
-    QRegExp regExp("[<>:\"/\\\\|?*]");
+    QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
     if (new_text.indexOf(regExp) > -1)

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -323,20 +323,20 @@ void UBEmbedController::generateConfig(int pWidth, int pHeight, const QString& p
 
     QTextStream out(&configFile);
     out.setCodec("UTF-8");
-    out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << endl;
-    out << "<widget xmlns=\"http://www.w3.org/ns/widgets\"" << endl;
-    out << "        xmlns:ub=\"http://uniboard.mnemis.com/widgets\"" << endl;
-    out << "        id=\"http://uniboard.mnemis.com/" << mTrapFlashUi->widgetNameLineEdit->text() << "\"" <<endl;
+    out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << '\n';
+    out << "<widget xmlns=\"http://www.w3.org/ns/widgets\"" << '\n';
+    out << "        xmlns:ub=\"http://uniboard.mnemis.com/widgets\"" << '\n';
+    out << "        id=\"http://uniboard.mnemis.com/" << mTrapFlashUi->widgetNameLineEdit->text() << "\"" <<'\n';
 
-    out << "        version=\"2.0\"" << endl;
-    out << "        width=\"" << pWidth << "\"" << endl;
-    out << "        height=\"" << pHeight << "\"" << endl;
-    out << "        ub:resizable=\"true\">" << endl;
+    out << "        version=\"2.0\"" << '\n';
+    out << "        width=\"" << pWidth << "\"" << '\n';
+    out << "        height=\"" << pHeight << "\"" << '\n';
+    out << "        ub:resizable=\"true\">" << '\n';
 
-    out << "    <name>" << mTrapFlashUi->widgetNameLineEdit->text() << "</name>" << endl;
-    out << "    <content src=\"" << mTrapFlashUi->widgetNameLineEdit->text() << ".html\"/>" << endl;
+    out << "    <name>" << mTrapFlashUi->widgetNameLineEdit->text() << "</name>" << '\n';
+    out << "    <content src=\"" << mTrapFlashUi->widgetNameLineEdit->text() << ".html\"/>" << '\n';
 
-    out << "</widget>" << endl;
+    out << "</widget>" << '\n';
 
 
     configFile.close();

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -110,17 +110,17 @@ void UBEmbedController::textChanged(const QString &newText)
 
 #ifdef Q_OS_WIN // Defined on Windows.
     QString illegalCharList("      < > : \" / \\ | ? * ");
-    QRegularExpression regExp("[<>:\"/\\\\|?*]");
+    static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
 #ifdef Q_OS_OSX // Defined on Mac OS X.
     QString illegalCharList("      < > : \" / \\ | ? * ");
-    QRegularExpression regExp("[<>:\"/\\\\|?*]");
+    static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
 #ifdef Q_OS_LINUX // Defined on X11.
     QString illegalCharList("      < > : \" / \\ | ? * ");
-    QRegularExpression regExp("[<>:\"/\\\\|?*]");
+    static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
     if (new_text.indexOf(regExp) > -1)

--- a/src/web/UBEmbedParser.cpp
+++ b/src/web/UBEmbedParser.cpp
@@ -98,7 +98,7 @@ void UBEmbedParser::parse(const QString& html)
     mParsedTitles.clear();
 
     // extract all <link> and <iframe> tags upto but not including the final >
-    QRegularExpression exp("(<|&lt;)(link|iframe)([^>]*)");
+    static const QRegularExpression exp("(<|&lt;)(link|iframe)([^>]*)");
     QStringList results;
     int count = 0;
     QRegularExpressionMatchIterator matches = exp.globalMatch(html);
@@ -376,7 +376,7 @@ UBEmbedContent UBEmbedParser::createIframeContent(const QString &html) const
 
     // DOM parsing is not possible, as iframes contain boolean attributes
     // eg "allowfullscreen", which are not XML conformant
-    QRegularExpression matchAttribute("(\\w+)(=\"([^\"]*)\")?");
+    static const QRegularExpression matchAttribute("(\\w+)(=\"([^\"]*)\")?");
 
     int pos = 7;    // size of initial <iframe
     QRegularExpressionMatchIterator matches = matchAttribute.globalMatch(html, pos);

--- a/src/web/UBEmbedParser.cpp
+++ b/src/web/UBEmbedParser.cpp
@@ -27,7 +27,7 @@
 
 #include "UBEmbedParser.h"
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QDomAttr>
 #include <QDomDocument>
@@ -98,16 +98,16 @@ void UBEmbedParser::parse(const QString& html)
     mParsedTitles.clear();
 
     // extract all <link> and <iframe> tags upto but not including the final >
-    QRegExp exp("(<|&lt;)(link|iframe)([^>]*)");
+    QRegularExpression exp("(<|&lt;)(link|iframe)([^>]*)");
     QStringList results;
     int count = 0;
-    int pos = 0;
+    QRegularExpressionMatchIterator matches = exp.globalMatch(html);
 
-    while ((pos = exp.indexIn(html, pos)) != -1)
+    while (matches.hasNext())
     {
+        QRegularExpressionMatch match = matches.next();
         ++count;
-        pos += exp.matchedLength();
-        QStringList res = exp.capturedTexts();
+        QStringList res = match.capturedTexts();
 
         if ("" != res.at(0))
         {
@@ -376,14 +376,15 @@ UBEmbedContent UBEmbedParser::createIframeContent(const QString &html) const
 
     // DOM parsing is not possible, as iframes contain boolean attributes
     // eg "allowfullscreen", which are not XML conformant
-    QRegExp matchAttribute("(\\w+)(=\"([^\"]*)\")?");
+    QRegularExpression matchAttribute("(\\w+)(=\"([^\"]*)\")?");
 
     int pos = 7;    // size of initial <iframe
+    QRegularExpressionMatchIterator matches = matchAttribute.globalMatch(html, pos);
 
-    while ((pos = matchAttribute.indexIn(html, pos)) != -1)
+    while (matches.hasNext())
     {
-        pos += matchAttribute.matchedLength();
-        QStringList res = matchAttribute.capturedTexts();
+        QRegularExpressionMatch match = matches.next();
+        QStringList res = match.capturedTexts();
 
         if (res.size() >= 4)
         {

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -98,7 +98,7 @@ UBWebController::UBWebController(UBMainWindow* mainWindow)
 
     // compute a system specific user agent string
     QString originalUserAgent = mWebProfile->httpUserAgent();
-    QRegularExpression exp("\\(([^;]*);([^)]*)\\)");
+    static const QRegularExpression exp("\\(([^;]*);([^)]*)\\)");
 
     QString p1;
     QString p2;
@@ -585,7 +585,7 @@ void UBWebController::showTabAtTop(bool attop)
 QUrl UBWebController::guessUrlFromString(const QString &string)
 {
     QString urlStr = string.trimmed();
-    QRegularExpression test(QRegularExpression::anchoredPattern("^[a-zA-Z]+\\:.*"));
+    static const QRegularExpression test(QRegularExpression::anchoredPattern("^[a-zA-Z]+\\:.*"));
 
     // Check if it looks like a qualified URL. Try parsing it and see.
     QRegularExpressionMatch match = test.match(urlStr);

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -585,10 +585,11 @@ void UBWebController::showTabAtTop(bool attop)
 QUrl UBWebController::guessUrlFromString(const QString &string)
 {
     QString urlStr = string.trimmed();
-    QRegExp test(QLatin1String("^[a-zA-Z]+\\:.*"));
+    QRegularExpression test(QRegularExpression::anchoredPattern("^[a-zA-Z]+\\:.*"));
 
     // Check if it looks like a qualified URL. Try parsing it and see.
-    bool hasSchema = test.exactMatch(urlStr);
+    QRegularExpressionMatch match = test.match(urlStr);
+    bool hasSchema = match.hasMatch();
     if (hasSchema)
     {
         int dotCount = urlStr.count(".");

--- a/src/web/simplebrowser/WBModelMenu.cpp
+++ b/src/web/simplebrowser/WBModelMenu.cpp
@@ -237,7 +237,7 @@ QAction *WBModelMenu::makeAction(const QIcon &icon, const QString &text, QObject
 {
     QFontMetrics fm(font());
     if (-1 == m_maxWidth)
-        m_maxWidth = fm.width(QLatin1Char('m')) * 30;
+        m_maxWidth = fm.horizontalAdvance(QLatin1Char('m')) * 30;
     QString smallText = fm.elidedText(text, Qt::ElideMiddle, m_maxWidth);
     return new QAction(icon, smallText, parent);
 }

--- a/src/web/simplebrowser/browserwindow.cpp
+++ b/src/web/simplebrowser/browserwindow.cpp
@@ -339,7 +339,7 @@ void BrowserWindow::handleReturnPressed()
     QString input = m_urlLineEdit->text().trimmed();
 
     // get first word
-    int wordEnd = input.indexOf(QRegExp("\\s"));
+    int wordEnd = input.indexOf(QRegularExpression("\\s"));
     QString firstWord = wordEnd < 0 ? input : input.left(wordEnd);
     bool search = false;
 

--- a/src/web/simplebrowser/browserwindow.cpp
+++ b/src/web/simplebrowser/browserwindow.cpp
@@ -339,7 +339,8 @@ void BrowserWindow::handleReturnPressed()
     QString input = m_urlLineEdit->text().trimmed();
 
     // get first word
-    int wordEnd = input.indexOf(QRegularExpression("\\s"));
+    static const QRegularExpression whitespace("\\s");
+    int wordEnd = input.indexOf(whitespace);
     QString firstWord = wordEnd < 0 ? input : input.left(wordEnd);
     bool search = false;
 

--- a/src/web/simplebrowser/browserwindow.cpp
+++ b/src/web/simplebrowser/browserwindow.cpp
@@ -88,7 +88,7 @@ BrowserWindow::BrowserWindow(QWidget *parent, QWebEngineProfile *profile, bool f
 
     QVBoxLayout *layout = new QVBoxLayout;
     layout->setSpacing(0);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
 
     if (!forDevTools) {
         m_progressBar = new QProgressBar(this);

--- a/src/web/simplebrowser/downloadmanagerwidget.h
+++ b/src/web/simplebrowser/downloadmanagerwidget.h
@@ -54,9 +54,14 @@
 #include "ui_downloadmanagerwidget.h"
 
 #include <QWidget>
+#include <QtWebEngineWidgetsVersion>
 
 QT_BEGIN_NAMESPACE
+#if QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+class QWebEngineDownloadRequest;
+#else
 class QWebEngineDownloadItem;
+#endif
 QT_END_NAMESPACE
 
 class DownloadWidget;
@@ -71,7 +76,13 @@ public:
     // Prompts user with a "Save As" dialog. If the user doesn't cancel it, then
     // the QWebEngineDownloadItem will be accepted and the DownloadManagerWidget
     // will be shown on the screen.
+#include <QtWebEngineWidgetsVersion>
+
+#if QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void downloadRequested(QWebEngineDownloadRequest *webItem);
+#else
     void downloadRequested(QWebEngineDownloadItem *webItem);
+#endif
 
 private:
     void add(DownloadWidget *downloadWidget);

--- a/src/web/simplebrowser/downloadwidget.h
+++ b/src/web/simplebrowser/downloadwidget.h
@@ -54,10 +54,15 @@
 #include "ui_downloadwidget.h"
 
 #include <QFrame>
-#include <QTime>
+#include <QElapsedTimer>
+#include <QtWebEngineWidgetsVersion>
 
 QT_BEGIN_NAMESPACE
+#if QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+class QWebEngineDownloadRequest;
+#else
 class QWebEngineDownloadItem;
+#endif
 QT_END_NAMESPACE
 
 // Displays one ongoing or finished download (QWebEngineDownloadItem).
@@ -66,7 +71,11 @@ class DownloadWidget final : public QFrame, public Ui::DownloadWidget
     Q_OBJECT
 public:
     // Precondition: The QWebEngineDownloadItem has been accepted.
+#if QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    explicit DownloadWidget(QWebEngineDownloadRequest *download, QWidget *parent = nullptr);
+#else
     explicit DownloadWidget(QWebEngineDownloadItem *download, QWidget *parent = nullptr);
+#endif
 
 signals:
     // This signal is emitted when the user indicates that they want to remove
@@ -79,8 +88,12 @@ private slots:
 private:
     QString withUnit(qreal bytes);
 
+#if QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QWebEngineDownloadRequest *m_download;
+#else
     QWebEngineDownloadItem *m_download;
-    QTime m_timeAdded;
+#endif
+    QElapsedTimer m_timeAdded;
 };
 
 #endif // DOWNLOADWIDGET_H

--- a/src/web/simplebrowser/tabwidget.cpp
+++ b/src/web/simplebrowser/tabwidget.cpp
@@ -81,8 +81,13 @@ TabWidget::TabWidget(QWebEngineProfile *profile, QWidget *parent)
         QLabel *icon = new QLabel(this);
         QPixmap pixmap(QStringLiteral(":ninja.png"));
         icon->setPixmap(pixmap.scaledToHeight(tabBar->height()));
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        setStyleSheet(QStringLiteral("QTabWidget::tab-bar { left: %1px; }").
+                      arg(icon->pixmap().width()));
+#else
         setStyleSheet(QStringLiteral("QTabWidget::tab-bar { left: %1px; }").
                       arg(icon->pixmap()->width()));
+#endif
     }
 }
 

--- a/src/web/simplebrowser/webpage.h
+++ b/src/web/simplebrowser/webpage.h
@@ -51,6 +51,7 @@
 #ifndef WEBPAGE_H
 #define WEBPAGE_H
 
+#include <QWebEngineCertificateError>
 #include <QWebEnginePage>
 #include <QWebEngineRegisterProtocolHandlerRequest>
 #include <QtWebEngineWidgetsVersion>
@@ -62,8 +63,13 @@ class WebPage : public QWebEnginePage
 public:
     WebPage(QWebEngineProfile *profile, QObject *parent = nullptr);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+private slots:
+    void handleCertificateError(QWebEngineCertificateError error);
+#else
 protected:
     bool certificateError(const QWebEngineCertificateError &error) override;
+#endif
 
 private slots:
     void handleAuthenticationRequired(const QUrl &requestUrl, QAuthenticator *auth);

--- a/src/web/simplebrowser/webpopupwindow.cpp
+++ b/src/web/simplebrowser/webpopupwindow.cpp
@@ -66,7 +66,7 @@ WebPopupWindow::WebPopupWindow(QWebEngineProfile *profile)
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
     QVBoxLayout *layout = new QVBoxLayout;
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
     layout->addWidget(m_urlLineEdit);
     layout->addWidget(m_view);

--- a/src/web/simplebrowser/webview.cpp
+++ b/src/web/simplebrowser/webview.cpp
@@ -60,7 +60,13 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QTimer>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QWebEngineContextMenuRequest>
+#else
 #include <QWebEngineContextMenuData>
+#endif
+
 #include <QWebEngineProfile>
 
 #include "board/UBBoardController.h"
@@ -218,7 +224,12 @@ QWebEngineView *WebView::createWindow(QWebEnginePage::WebWindowType type)
 
 void WebView::contextMenuEvent(QContextMenuEvent *event)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMenu *menu = createStandardContextMenu();
+#else
     QMenu *menu = page()->createStandardContextMenu();
+#endif
+
     const QList<QAction *> actions = menu->actions();
     auto inspectElement = std::find(actions.cbegin(), actions.cend(), page()->action(QWebEnginePage::InspectElement));
     if (inspectElement == actions.cend()) {
@@ -240,8 +251,14 @@ void WebView::contextMenuEvent(QContextMenuEvent *event)
     QUrl contentUrl;
 
     QUrl pageUrl = page()->url();
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QUrl linkUrl = lastContextMenuRequest()->linkUrl();
+    auto mediaType = lastContextMenuRequest()->mediaType();
+#else
     QUrl linkUrl = page()->contextMenuData().linkUrl();
     auto mediaType = page()->contextMenuData().mediaType();
+#endif
 
     if (pageUrl.scheme() == "chrome-extension" && pageUrl.query().endsWith(".pdf", Qt::CaseInsensitive))
     {
@@ -253,11 +270,19 @@ void WebView::contextMenuEvent(QContextMenuEvent *event)
         // on PDF link
         contentUrl = linkUrl;
     }
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    else if (mediaType == QWebEngineContextMenuRequest::MediaTypeImage)
+    {
+        // on image
+        contentUrl = lastContextMenuRequest()->mediaUrl();
+    }
+#else
     else if (mediaType == QWebEngineContextMenuData::MediaTypeImage)
     {
         // on image
         contentUrl = page()->contextMenuData().mediaUrl();
     }
+#endif
 
     if (contentUrl.isValid())
     {


### PR DESCRIPTION
This pull request refactors OpenBoard for compilation with Qt 6.2. It aims to create a project which can be compiled with Qt 5.12, Qt 5.15 and Qt 6.2.

The commits of this pull request each address a specific issue. The most complex refactoring were necessary due to the completely reworked media framework. But also the WebEngine APIs have undergone some restructuring. Most of the other things are minor, but often incompatible API changes.

The branch can be compiled with Qt 6.2. However as I'm currently missing `quazip6` for my platform, the files using `quazip` could not be compiled and I'm currently also not able to test it. This will probably change with the upcoming release of openSUSE Leap 15.4 in June 2022 (I'm using Leap as my development platform).

This pull request is still a draft as long as I'm not able to test and verify it. Any comments and experiences on other platforms are welcome!