### PR TITLE
The show and hide events in UBDesktopPalette have no purpose.

### DIFF
--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -208,42 +208,6 @@ void UBDesktopPalette::maximizeMe()
 #endif
 }
 
-void UBDesktopPalette::showEvent(QShowEvent *event)
-{
-    Q_UNUSED(event);
-    QIcon penIcon;
-    QIcon markerIcon;
-    QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/penArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/markerArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraserArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
-
-    adjustPosition();
-}
-
-void UBDesktopPalette::hideEvent(QHideEvent *event)
-{
-    Q_UNUSED(event);
-    QIcon penIcon;
-    QIcon markerIcon;
-    QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
-}
-
 QPoint UBDesktopPalette::buttonPos(QAction *action)
 {
     QPoint p;

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -72,8 +72,6 @@ class UBDesktopPalette : public UBActionPalette
         void parentResized();
 
 protected:
-        void showEvent(QShowEvent *event);
-        void hideEvent(QHideEvent *event);
 
         virtual int getParentRightOffset();
 


### PR DESCRIPTION
I think, these two events have no purpose. The events are activated when Open Board is minimised by the window manager. But there are a few things, with this code:
* Open Board in the desktop mode cannot be minimised.
* It does not matter if in minimsed mode the arrorws are there or not.
* I see no reason at all why in certain situations the arrows should not be invisble. I could imagine that the author had something like a kiosk mode in mind or some things that are specific to certain use cases. But at the moment I don't see such a reason. If there is a reason, we should have a comment in the code.