### PR TITLE
Fix syntax error message when executing qmake

### DIFF
--- a/src/podcast/podcast.pri
+++ b/src/podcast/podcast.pri
@@ -67,7 +67,7 @@ linux-g++* {
             -lxcb-xfixes \
             -lxcb-render -lxcb-shape -lxcb -lX11 -lasound -lSDL -lx264 -lpthread -lvpx -lvorbisenc -lvorbis -ltheoraenc -ltheoradec -logg -lopus -lmp3lame -lfreetype -lfdk-aac -lass -llzma -lbz2 -lz -ldl -lswresample -lswscale -lavutil -lm
 
-    FFMPEG_VERSION = $$system(ffmpeg --version|& grep -oP "version.*?\K[0-9]\.[0-9]")
+    FFMPEG_VERSION = $$system(ffmpeg --version 2>&1 | grep -oP "version.*?\K[0-9]\.[0-9]")
     equals(FFMPEG_VERSION, 2.8) {
         LIBS -= -lswresample
         LIBS += -lavresample


### PR DESCRIPTION
On Debian 11 when executing `qmake OpenBoard.org`, one gets the following
error message:

```
qmake OpenBoard.pro
sh: 1: Syntax error: "&" unexpected
sh: 1: Syntax error: "&" unexpected
sh: 1: Syntax error: "&" unexpected
```

The cause is the use of bash-specific `|&` pipe operator in `podcast.pri` line 70
to determine the `FFMPEG_VERSION`.