### PR TITLE
fix bug 628: ruler effective after removal

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1104,7 +1104,7 @@ void UBBoardView::mousePressEvent (QMouseEvent *event)
             break;
 
         default:
-            if(UBDrawingController::drawingController()->mActiveRuler==NULL) {
+            if (UBDrawingController::drawingController()->activeRuler() == nullptr) {
                 viewport()->setCursor (QCursor (Qt::BlankCursor));
             }
             if (scene () && !mTabletStylusIsPressed) {

--- a/src/board/UBDrawingController.cpp
+++ b/src/board/UBDrawingController.cpp
@@ -34,6 +34,7 @@
 
 #include "domain/UBGraphicsScene.h"
 #include "board/UBBoardController.h"
+#include "tools/UBAbstractDrawRuler.h"
 
 #include "gui/UBMainWindow.h"
 #include "core/memcheck.h"
@@ -58,7 +59,6 @@ void UBDrawingController::destroy()
 
 UBDrawingController::UBDrawingController(QObject * parent)
     : QObject(parent)
-    , mActiveRuler(NULL)
     , mStylusTool((UBStylusTool::Enum)-1)
     , mLatestDrawingTool((UBStylusTool::Enum)-1)
     , mIsDesktopMode(false)
@@ -320,6 +320,23 @@ void UBDrawingController::setMarkerAlpha(qreal alpha)
     UBSettings::settings()->boardMarkerAlpha->set(alpha);
 
     emit colorPaletteChanged();
+}
+
+void UBDrawingController::setActiveRuler(UBAbstractDrawRuler* ruler)
+{
+    mActiveRuler = ruler;
+}
+
+UBAbstractDrawRuler* UBDrawingController::activeRuler() const
+{
+    QGraphicsItem* item = dynamic_cast<QGraphicsItem*>(mActiveRuler.data());
+
+    if (item && item->isVisible())
+    {
+        return mActiveRuler;
+    }
+
+    return nullptr;
 }
 
 

--- a/src/board/UBDrawingController.h
+++ b/src/board/UBDrawingController.h
@@ -64,7 +64,8 @@ class UBDrawingController : public QObject
         void setMarkerColor(bool onDarkBackground, const QColor& color, int pIndex);
         void setMarkerAlpha(qreal alpha);
 
-        UBAbstractDrawRuler* mActiveRuler;
+        void setActiveRuler(UBAbstractDrawRuler* ruler);
+        UBAbstractDrawRuler* activeRuler() const;
 
         void setInDesktopMode(bool mode){
             mIsDesktopMode = mode;
@@ -89,6 +90,7 @@ class UBDrawingController : public QObject
         void colorIndexChanged(int index);
 
     private:
+        QPointer<UBAbstractDrawRuler> mActiveRuler;
         UBStylusTool::Enum mStylusTool;
         UBStylusTool::Enum mLatestDrawingTool;
         bool mIsDesktopMode;

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -451,8 +451,8 @@ bool UBGraphicsScene::inputDevicePress(const QPointF& scenePos, const qreal& pre
             mAddedItems.clear();
             mRemovedItems.clear();
 
-            if (UBDrawingController::drawingController()->mActiveRuler)
-                UBDrawingController::drawingController()->mActiveRuler->StartLine(scenePos, width);
+            if (UBDrawingController::drawingController()->activeRuler())
+                UBDrawingController::drawingController()->activeRuler()->StartLine(scenePos, width);
             else {
                 moveTo(scenePos);
                 drawLineTo(scenePos, width, UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Line);
@@ -539,7 +539,7 @@ bool UBGraphicsScene::inputDeviceMove(const QPointF& scenePos, const qreal& pres
             width /= UBApplication::boardController->systemScaleFactor();
             width /= UBApplication::boardController->currentZoom();
 
-            if (currentTool == UBStylusTool::Line || dc->mActiveRuler)
+            if (currentTool == UBStylusTool::Line || dc->activeRuler())
             {
                 if (UBDrawingController::drawingController()->stylusTool() != UBStylusTool::Marker)
                 if(NULL != mpLastPolygon && NULL != mCurrentStroke && mAddedItems.size() > 0){
@@ -573,8 +573,8 @@ bool UBGraphicsScene::inputDeviceMove(const QPointF& scenePos, const qreal& pres
             if (!mCurrentStroke)
                 mCurrentStroke = new UBGraphicsStroke(this);
 
-            if(dc->mActiveRuler){
-                dc->mActiveRuler->DrawLine(position, width);
+            if(dc->activeRuler()){
+                dc->activeRuler()->DrawLine(position, width);
             }
 
             else if (currentTool == UBStylusTool::Line) {
@@ -859,7 +859,7 @@ void UBGraphicsScene::drawPenCircle(const QPointF &pPoint)
         cursor = UBResources::resources()->penCursor;
     }
 
-    if (!UBDrawingController::drawingController()->mActiveRuler)
+    if (!UBDrawingController::drawingController()->activeRuler())
     {
         // set cursor only if no active ruler
         if (controlView() && controlView()->viewport())

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -420,9 +420,6 @@ void UBGraphicsRuler::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)UBDrawingController::drawingController ()->stylusTool ();
 
-    if (UBDrawingController::drawingController()->mActiveRuler == nullptr)
-        UBDrawingController::drawingController()->mActiveRuler = this;
-
     if (currentTool == UBStylusTool::Selector ||
         currentTool == UBStylusTool::Play)
     {
@@ -453,6 +450,7 @@ void UBGraphicsRuler::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
     else if (UBDrawingController::drawingController()->isDrawingTool())
     {
         setCursor(drawRulerLineCursor());
+        UBDrawingController::drawingController()->mActiveRuler = this;
         event->accept();
     }
 }

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -450,7 +450,7 @@ void UBGraphicsRuler::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
     else if (UBDrawingController::drawingController()->isDrawingTool())
     {
         setCursor(drawRulerLineCursor());
-        UBDrawingController::drawingController()->mActiveRuler = this;
+        UBDrawingController::drawingController()->setActiveRuler(this);
         event->accept();
     }
 }
@@ -462,7 +462,7 @@ void UBGraphicsRuler::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
     mCloseSvgItem->setVisible(mShowButtons);
     mResizeSvgItem->setVisible(mShowButtons);
     mRotateSvgItem->setVisible(mShowButtons);
-    UBDrawingController::drawingController()->mActiveRuler = nullptr;
+    UBDrawingController::drawingController()->setActiveRuler(nullptr);
     event->accept();
     update();
 }

--- a/src/tools/UBGraphicsTriangle.cpp
+++ b/src/tools/UBGraphicsTriangle.cpp
@@ -886,7 +886,7 @@ void UBGraphicsTriangle::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 
     } else if (UBDrawingController::drawingController()->isDrawingTool())  {
             setCursor(drawRulerLineCursor());
-            UBDrawingController::drawingController()->mActiveRuler = this;
+            UBDrawingController::drawingController()->setActiveRuler(this);
             event->accept();
     }
 
@@ -904,7 +904,7 @@ void UBGraphicsTriangle::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
     mVFlipSvgItem->setVisible(false);
     mHFlipSvgItem->setVisible(false);
     mRotateSvgItem->setVisible(false);
-    UBDrawingController::drawingController()->mActiveRuler = NULL;
+    UBDrawingController::drawingController()->setActiveRuler(nullptr);
     event->accept();
     update();
 }


### PR DESCRIPTION
This pull request fixes #628.

Indeed there were two problems: a more obvious one and a hidden one, which also existed in previous versions.

The obvious problem:

The `UBDrawingController::mActiveRuler` variable is used to indicate an active ruler. It is set when the pointer enters the area of the ruler **with an active drawing tool** and reset when it leaves the area of the ruler. The problem was, that the bold condition was not observed for the ruler. It was however correct for the triangle. So when closing the ruler, you were actually entering the area to move to the close button. `mActiveRuler` was set and stayed effective, as the cursor could never "leave" the area of a no longer visible ruler.

The hidden problem:

Even with 1.6.1 or probably earlier versions you could provoke this problem as follows:

- Add a ruler or triangle
- Select the pointer tool, move to the ruler and remember the position of the close button
- Select the pen tool
- Enter the ruler area
- Press `Ctrl-F` to switch to the pointer tool while the cursor is within the ruler area
- Click at the position where you know that the close button should be (it is not visible in this situation)
- The ruler hides, and the problem described in #628 also occurs here

So the "trick" is to close the ruler without leaving the ruler area, so that `mActiveRuler` is still set.

The obvious problem is solved in the first commit of this PR.

The hidden problem is solved in the second commit of this PR as follows:

- Make `mActiveRuler` a private member variable and provide public accessor functions.
- Use a guarded pointer (`QPointer`) for `mAcrivePointer` to avoid referencing a deleted object. This was not actually a problem, but in such a situation, i.e. managing a pointer to an object whose lifetime is unknown, a guarded pointer is always a good idea.
- In the `activeRuler()` access function not only check for existence of the pointer, but also for visibility of the pointed object. <br>**Note:** when closing a ruler, the object still exists in memory until the scene is deleted. It is just hidden. Such hidden objects should however never be considered an "active Ruler".