### PR TITLE
Improve displaymanager

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -152,7 +152,9 @@ void UBBoardController::init()
 
     setActiveDocumentScene(doc);
 
-    initBackgroundGridSize();
+    connect(UBApplication::displayManager, &UBDisplayManager::screenRolesAssigned, [this](){
+        initBackgroundGridSize();
+    });
 
     undoRedoStateChange(true);
 

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -133,7 +133,7 @@ void UBBoardController::init()
     connect(UBApplication::undoStack, SIGNAL(canUndoChanged(bool))
             , this, SLOT(undoRedoStateChange(bool)));
 
-    connect(UBApplication::undoStack, SIGNAL(canRedoChanged (bool))
+    connect(UBApplication::undoStack, SIGNAL(canRedoChanged(bool))
             , this, SLOT(undoRedoStateChange(bool)));
 
     connect(UBDrawingController::drawingController(), SIGNAL(stylusToolChanged(int))
@@ -152,7 +152,7 @@ void UBBoardController::init()
 
     setActiveDocumentScene(doc);
 
-    connect(UBApplication::displayManager, &UBDisplayManager::screenRolesAssigned, [this](){
+    connect(UBApplication::displayManager, &UBDisplayManager::screenRolesAssigned, this, [this](){
         initBackgroundGridSize();
     });
 

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1546,6 +1546,13 @@ void UBBoardView::mouseDoubleClickEvent (QMouseEvent *event)
 
 void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
 {
+    if (!isInteractive())
+    {
+        // ignore event on non-interactive views
+        wheelEvent->accept();
+        return;
+    }
+
     // Zoom in/out when Ctrl is pressed
     if (wheelEvent->modifiers() == Qt::ControlModifier && wheelEvent->angleDelta().x() == 0)
     {

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -97,7 +97,10 @@ UBApplicationController::UBApplicationController(UBBoardView *pControlView,
     connect(displayManager, SIGNAL(screenLayoutChanged()), this, SLOT(screenLayoutChanged()));
     connect(displayManager, SIGNAL(screenLayoutChanged()), mUninoteController, SLOT(screenLayoutChanged()));
     connect(displayManager, SIGNAL(screenLayoutChanged()), UBApplication::webController, SLOT(screenLayoutChanged()));
-    connect(displayManager, SIGNAL(adjustDisplayViewsRequired()), UBApplication::boardController, SLOT(adjustDisplayViews()));
+    connect(displayManager, &UBDisplayManager::availableScreenCountChanged, [this](){
+        initPreviousViews();
+        UBApplication::displayManager->setPreviousDisplaysWidgets(mPreviousViews);
+    });
     connect(mUninoteController, SIGNAL(imageCaptured(const QPixmap &, bool)), this, SLOT(addCapturedPixmap(const QPixmap &, bool)));
     connect(mUninoteController, SIGNAL(restoreUniboard()), this, SLOT(hideDesktop()));
 
@@ -141,6 +144,8 @@ void UBApplicationController::initViewState(int horizontalPosition, int vertical
 
 void UBApplicationController::initScreenLayout(bool useMultiscreen)
 {
+    initPreviousViews();
+
     UBDisplayManager* displayManager = UBApplication::displayManager;
 
     displayManager->setControlWidget(mMainWindow);
@@ -159,11 +164,9 @@ void UBApplicationController::screenLayoutChanged()
     initViewState(mControlView->horizontalScrollBar()->value(),
             mControlView->verticalScrollBar()->value());
 
-    initPreviousViews();
-
     adaptToolBar();
 
-    adjustDisplayView();
+    UBApplication::boardController->adjustDisplayViews();
 
     if (UBApplication::displayManager->hasDisplay())
     {
@@ -173,8 +176,6 @@ void UBApplicationController::screenLayoutChanged()
     {
        UBApplication::boardController->setBoxing(QRect());
     }
-
-    adjustPreviousViews(0, 0);
 
     // update mirror if necessary
     UBDisplayManager* displayManager = UBApplication::displayManager;

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -539,14 +539,21 @@ void UBApplicationController::updateRequestFinished(QNetworkReply * reply)
 
 void UBApplicationController::initPreviousViews()
 {
-    qDeleteAll(mPreviousViews);
-    mPreviousViews.clear();
+    int numPreviousViews = UBApplication::displayManager->numPreviousViews();
 
-    for(int i = 0; i < UBApplication::displayManager->numPreviousViews(); i++)
+    // create the missing views
+    for (int i = mPreviousViews.count(); i < numPreviousViews; i++)
     {
         UBBoardView *previousView = new UBBoardView(UBApplication::boardController, UBItemLayerType::FixedBackground, UBItemLayerType::Tool, 0);
         previousView->setInteractive(false);
         mPreviousViews.append(previousView);
+    }
+
+    // delete the superfluous views
+    while (mPreviousViews.count() > numPreviousViews)
+    {
+        UBBoardView* view = mPreviousViews.takeLast();
+        delete view;
     }
 }
 

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -101,13 +101,6 @@ UBApplicationController::UBApplicationController(UBBoardView *pControlView,
     connect(mUninoteController, SIGNAL(imageCaptured(const QPixmap &, bool)), this, SLOT(addCapturedPixmap(const QPixmap &, bool)));
     connect(mUninoteController, SIGNAL(restoreUniboard()), this, SLOT(hideDesktop()));
 
-    for(int i = 0; i < displayManager->numPreviousViews(); i++)
-    {
-        UBBoardView *previousView = new UBBoardView(UBApplication::boardController, UBItemLayerType::FixedBackground, UBItemLayerType::Tool, 0);
-        previousView->setInteractive(false);
-        mPreviousViews.append(previousView);
-    }
-
     mBlackScene = new UBGraphicsScene(0); // deleted by UBApplicationController::destructor
     mBlackScene->setBackground(true, UBPageBackground::plain);
 
@@ -165,6 +158,8 @@ void UBApplicationController::screenLayoutChanged()
 {
     initViewState(mControlView->horizontalScrollBar()->value(),
             mControlView->verticalScrollBar()->value());
+
+    initPreviousViews();
 
     adaptToolBar();
 
@@ -538,6 +533,19 @@ void UBApplicationController::updateRequestFinished(QNetworkReply * reply)
         reply->deleteLater();
 
         downloadJsonFinished(responseString);
+    }
+}
+
+void UBApplicationController::initPreviousViews()
+{
+    qDeleteAll(mPreviousViews);
+    mPreviousViews.clear();
+
+    for(int i = 0; i < UBApplication::displayManager->numPreviousViews(); i++)
+    {
+        UBBoardView *previousView = new UBBoardView(UBApplication::boardController, UBItemLayerType::FixedBackground, UBItemLayerType::Tool, 0);
+        previousView->setInteractive(false);
+        mPreviousViews.append(previousView);
     }
 }
 

--- a/src/core/UBApplicationController.h
+++ b/src/core/UBApplicationController.h
@@ -150,6 +150,7 @@ class UBApplicationController : public QObject
 
 
     protected:
+        void initPreviousViews();
 
         UBDesktopAnnotationController *mUninoteController;
 

--- a/src/core/UBDisplayManager.cpp
+++ b/src/core/UBDisplayManager.cpp
@@ -406,7 +406,7 @@ void UBDisplayManager::positionScreens()
 
 void UBDisplayManager::blackout()
 {
-    for (auto screen : mScreensByRole)
+    for (auto& screen : mScreensByRole)
     {
         UBBlackoutWidget* blackoutWidget = new UBBlackoutWidget(); //deleted in UBDisplayManager::unBlackout
         Ui::BlackoutWidget* blackoutUi = new Ui::BlackoutWidget();
@@ -423,11 +423,12 @@ void UBDisplayManager::blackout()
         blackoutWidget->setGeometry(screen->geometry());
 
         mBlackoutWidgets << blackoutWidget;
+        mBlackoutUiList << blackoutUi;
     }
 
     UBPlatformUtils::fadeDisplayOut();
 
-    for (UBBlackoutWidget* blackoutWidget : mBlackoutWidgets)
+    for (UBBlackoutWidget* blackoutWidget : qAsConst(mBlackoutWidgets))
     {
         UBPlatformUtils::showFullScreen(blackoutWidget);
     }
@@ -440,6 +441,9 @@ void UBDisplayManager::unBlackout()
         // the widget is also destroyed thanks to its Qt::WA_DeleteOnClose attribute
         mBlackoutWidgets.takeFirst()->close();
     }
+
+    qDeleteAll(mBlackoutUiList);
+    mBlackoutUiList.clear();
 
     UBPlatformUtils::fadeDisplayIn();
 
@@ -454,7 +458,7 @@ void UBDisplayManager::addOrRemoveScreen(QScreen *screen)
     assignRoles();
 
     // positioning must be delayed, because OS also tries to position the widgets
-    QTimer::singleShot(3000, [this](){
+    QTimer::singleShot(3000, this, [this](){
         positionScreens();
     });
 }

--- a/src/core/UBDisplayManager.cpp
+++ b/src/core/UBDisplayManager.cpp
@@ -262,7 +262,7 @@ void UBDisplayManager::setDisplayWidget(QWidget* pDisplayWidget)
         if (mScreensByRole.contains(ScreenRole::Display))
         {
             mWidgetsByRole[ScreenRole::Display]->setGeometry(mScreensByRole[ScreenRole::Display]->geometry());
-            mWidgetsByRole[ScreenRole::Display]->showFullScreen();
+            UBPlatformUtils::showFullScreen(mWidgetsByRole[ScreenRole::Display]);
         }
     }
 }
@@ -336,7 +336,7 @@ void UBDisplayManager::positionScreens()
     {
         mWidgetsByRole[ScreenRole::Display]->showNormal();
         mWidgetsByRole[ScreenRole::Display]->setGeometry(mScreensByRole[ScreenRole::Display]->geometry());
-        mWidgetsByRole[ScreenRole::Display]->showFullScreen();
+        UBPlatformUtils::showFullScreen(mWidgetsByRole[ScreenRole::Display]);
     }
     else if(mWidgetsByRole.contains(ScreenRole::Display))
     {
@@ -351,7 +351,7 @@ void UBDisplayManager::positionScreens()
                 QWidget* previous = mWidgetsByRole[role];
                 previous->showNormal();
                 previous->setGeometry(mScreensByRole[role]->geometry());
-                previous->showFullScreen();
+                UBPlatformUtils::showFullScreen(previous);
             }
             else
             {
@@ -388,9 +388,9 @@ void UBDisplayManager::blackout()
 
     UBPlatformUtils::fadeDisplayOut();
 
-    foreach(UBBlackoutWidget *blackoutWidget, mBlackoutWidgets)
+    for (UBBlackoutWidget* blackoutWidget : mBlackoutWidgets)
     {
-        blackoutWidget->showFullScreen();
+        UBPlatformUtils::showFullScreen(blackoutWidget);
     }
 }
 
@@ -405,7 +405,6 @@ void UBDisplayManager::unBlackout()
     UBPlatformUtils::fadeDisplayIn();
 
     UBApplication::boardController->freezeW3CWidgets(false);
-
 }
 
 

--- a/src/core/UBDisplayManager.h
+++ b/src/core/UBDisplayManager.h
@@ -73,20 +73,23 @@ class UBDisplayManager : public QObject
 
         bool hasControl()
         {
-            return mScreensByRole.contains(ScreenRole::Control);
+            return mScreensByRole.value(ScreenRole::Control);
         }
 
         bool hasDisplay()
         {
-            return mScreensByRole.contains(ScreenRole::Display);
+            return mScreensByRole.value(ScreenRole::Display);
         }
 
         bool hasPrevious()
         {
-            return mScreensByRole.contains(ScreenRole::Previous1);
+            return mScreensByRole.value(ScreenRole::Previous1);
         }
 
-        bool useMultiScreen() { return mUseMultiScreen; }
+        bool useMultiScreen()
+        {
+            return mUseMultiScreen;
+        }
 
         void setUseMultiScreen(bool pUse);
 
@@ -124,11 +127,10 @@ class UBDisplayManager : public QObject
         QList<UBBlackoutWidget*> mBlackoutWidgets;
 
         QList<QScreen*> mAvailableScreens;
-        QMap<ScreenRole, QScreen*> mScreensByRole;
-        QMap<ScreenRole, QWidget*> mWidgetsByRole;
+        QMap<ScreenRole, QPointer<QScreen>> mScreensByRole;
+        QMap<ScreenRole, QPointer<QWidget>> mWidgetsByRole;
 
         bool mUseMultiScreen;
-
 };
 
 #endif /* UBDISPLAYMANAGER_H_ */

--- a/src/core/UBDisplayManager.h
+++ b/src/core/UBDisplayManager.h
@@ -106,7 +106,6 @@ class UBDisplayManager : public QObject
 
         void screenLayoutChanged();
         void availableScreenCountChanged(int screenCount);
-        void adjustDisplayViewsRequired();
 
    public slots:
 

--- a/src/core/UBDisplayManager.h
+++ b/src/core/UBDisplayManager.h
@@ -67,7 +67,8 @@ class UBDisplayManager : public QObject
 
         void setPreviousDisplaysWidgets(QList<UBBoardView*> pPreviousViews);
 
-        QWidget* widget(ScreenRole role);
+        QWidget* widget(ScreenRole role) const;
+        QScreen* screen(ScreenRole role) const;
 
         QList<QScreen*> availableScreens() const;
 
@@ -103,7 +104,7 @@ class UBDisplayManager : public QObject
         QPixmap grabGlobal(QRect rect) const;
 
    signals:
-
+        void screenRolesAssigned();
         void screenLayoutChanged();
         void availableScreenCountChanged(int screenCount);
 
@@ -115,13 +116,15 @@ class UBDisplayManager : public QObject
 
         void unBlackout();
 
+    private slots:
+
         void addOrRemoveScreen(QScreen* screen);
 
     private:
 
-        void positionScreens();
-
         void initScreenIndexes();
+        void assignRoles();
+        void positionScreens();
 
         QList<UBBlackoutWidget*> mBlackoutWidgets;
 

--- a/src/core/UBDisplayManager.h
+++ b/src/core/UBDisplayManager.h
@@ -36,6 +36,11 @@
 class UBBlackoutWidget;
 class UBBoardView;
 
+namespace Ui
+{
+    class BlackoutWidget;
+}
+
 enum class ScreenRole : int
 {
     None = 0, Control, Display, Desktop, Previous1, Previous2, Previous3, Previous4, Previous5
@@ -127,6 +132,7 @@ class UBDisplayManager : public QObject
         void positionScreens();
 
         QList<UBBlackoutWidget*> mBlackoutWidgets;
+        QList<Ui::BlackoutWidget*> mBlackoutUiList;
 
         QList<QScreen*> mAvailableScreens;
         QMap<ScreenRole, QPointer<QScreen>> mScreensByRole;

--- a/src/core/UBPersistenceWorker.cpp
+++ b/src/core/UBPersistenceWorker.cpp
@@ -62,7 +62,7 @@ void UBPersistenceWorker::saveMetadata(UBDocumentProxy *proxy)
 
 void UBPersistenceWorker::applicationWillClose()
 {
-    qDebug() << "applicaiton Will close signal received";
+    qDebug() << "application Will close signal received";
     mReceivedApplicationClosing = true;
     mSemaphore.release();
 }

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -38,6 +38,8 @@
 #include "core/UBApplicationController.h"
 #include "core/UBDisplayManager.h"
 
+#include "frameworks/UBStringUtils.h"
+
 #include "board/UBBoardController.h"
 #include "document/UBDocumentController.h"
 #include "domain/UBGraphicsScene.h"
@@ -57,21 +59,6 @@ typedef QString::SplitBehavior SplitBehavior;
 qreal UBPreferencesController::sSliderRatio = 10.0;
 qreal UBPreferencesController::sMinPenWidth = 0.5;
 qreal UBPreferencesController::sMaxPenWidth = 50.0;
-
-// convenience function to split a comma separated list of tokens to a QStringList
-QStringList trimmedTokens(const QString& input)
-{
-    QStringList tokens = input.split(',');
-
-    for (QString& entry : tokens)
-    {
-        entry = entry.trimmed();
-    }
-
-    tokens.removeAll("");
-
-    return tokens;
-}
 
 
 UBPreferencesDialog::UBPreferencesDialog(UBPreferencesController* prefController, QWidget* parent,Qt::WindowFlags f)
@@ -821,7 +808,7 @@ void UBScreenListLineEdit::focusInEvent(QFocusEvent *focusEvent)
 
     if (mScreenLabels.empty())
     {
-        QStringList screenList = trimmedTokens(text());
+        QStringList screenList = UBStringUtils::trimmed(text().split(','));
 
         QList<QScreen*> screens = UBApplication::displayManager->availableScreens();
         QStringList availableScreenIndexes;
@@ -892,7 +879,7 @@ void UBScreenListLineEdit::addScreen()
 
 void UBScreenListLineEdit::onTextChanged(const QString &input)
 {
-    QStringList screenList = trimmedTokens(input);
+    QStringList screenList = UBStringUtils::trimmed(input.split(','));
 
     for (QPushButton* button : mScreenLabels)
     {
@@ -934,7 +921,7 @@ UBStringListValidator::UBStringListValidator(QObject *parent)
 void UBStringListValidator::fixup(QString &input) const
 {
     // remove invalid tokens from list, trim tokens
-    QStringList inputList = trimmedTokens(input);
+    QStringList inputList = UBStringUtils::trimmed(input.split(','));
     QStringList outputList;
 
     for (const QString& token : inputList)
@@ -951,7 +938,7 @@ void UBStringListValidator::fixup(QString &input) const
 QValidator::State UBStringListValidator::validate(QString &input, int &) const
 {
     bool ok = true;
-    QStringList inputList = trimmedTokens(input);
+    QStringList inputList = UBStringUtils::trimmed(input.split(','));
     // number of commas must match number of list items - 1
     int commas = input.count(',');
 

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -123,7 +123,7 @@ void UBPreferencesController::adjustScreens()
 
     auto availableScreens = UBApplication::displayManager->availableScreens();
     QStringList screenNames;
-    QRegularExpression specialChars("[^a-zA-Z0-9]+");
+    static QRegularExpression specialChars("[^a-zA-Z0-9]+");
 
     for (QScreen* screen : availableScreens)
     {
@@ -161,7 +161,7 @@ void UBPreferencesController::wire()
     connect(mPreferencesUI->closeButton, SIGNAL(released()), this, SLOT(close()));
     connect(mPreferencesUI->defaultSettingsButton, SIGNAL(released()), this, SLOT(defaultSettings()));
 
-    connect(mPreferencesUI->screenList, &UBScreenListLineEdit::screenListChanged, [this,settings](const QStringList screenList){
+    connect(mPreferencesUI->screenList, &UBScreenListLineEdit::screenListChanged, this, [this,settings](const QStringList screenList){
         settings->appScreenList->set(screenList);
 
         if (!mScreenConfigurationPath.isEmpty())
@@ -879,9 +879,9 @@ void UBScreenListLineEdit::addScreen()
 
 void UBScreenListLineEdit::onTextChanged(const QString &input)
 {
-    QStringList screenList = UBStringUtils::trimmed(input.split(','));
+    const QStringList screenList = UBStringUtils::trimmed(input.split(','));
 
-    for (QPushButton* button : mScreenLabels)
+    for (QPushButton* button : qAsConst(mScreenLabels))
     {
         button->setDisabled(screenList.contains(button->text()));
     }
@@ -891,7 +891,7 @@ void UBScreenListLineEdit::onTextChanged(const QString &input)
         // create and attach a new QCompleter
         QStringList model;
 
-        for (QPushButton* button : mScreenLabels)
+        for (QPushButton* button : qAsConst(mScreenLabels))
         {
             if (button->isEnabled())
             {

--- a/src/core/UBPreferencesController.h
+++ b/src/core/UBPreferencesController.h
@@ -86,6 +86,7 @@ class UBPreferencesController : public QObject
         UBBrushPropertiesFrame* mMarkerProperties;
         UBColorPicker* mDarkBackgroundGridColorPicker;
         UBColorPicker* mLightBackgroundGridColorPicker;
+        QString mScreenConfigurationPath;
 
     protected slots:
 
@@ -136,10 +137,14 @@ public:
     virtual ~UBScreenListLineEdit() = default;
 
     void setDefault();
+    void loadScreenList(const QStringList& screenList);
 
 protected:
     virtual void focusInEvent(QFocusEvent* focusEvent) override;
     virtual void focusOutEvent(QFocusEvent* focusEvent) override;
+
+signals:
+    void screenListChanged(QStringList screenList);
 
 private slots:
     void addScreen();
@@ -149,7 +154,6 @@ private:
     QList<QPushButton*> mScreenLabels;
     QValidator* mValidator;
     QCompleter* mCompleter;
-    QTimer* mFadeOutTimer;
 };
 
 class UBStringListValidator : public QValidator

--- a/src/core/UBPreferencesController.h
+++ b/src/core/UBPreferencesController.h
@@ -128,6 +128,9 @@ class UBBrushPropertiesFrame : public Ui::brushProperties
 
 };
 
+// forward
+class UBStringListValidator;
+
 class UBScreenListLineEdit : public QLineEdit
 {
     Q_OBJECT;
@@ -152,7 +155,7 @@ private slots:
 
 private:
     QList<QPushButton*> mScreenLabels;
-    QValidator* mValidator;
+    UBStringListValidator* mValidator;
 };
 
 class UBStringListValidator : public QValidator
@@ -160,11 +163,13 @@ class UBStringListValidator : public QValidator
     Q_OBJECT;
 
 public:
-    UBStringListValidator(QStringList list, QObject* parent = nullptr);
+    UBStringListValidator(QObject* parent = nullptr);
     virtual ~UBStringListValidator() = default;
 
     virtual void fixup(QString& input) const;
     virtual QValidator::State validate(QString& input, int& pos) const;
+
+    void setValidationStringList(const QStringList& list);
 
 private:
     QStringList mList;

--- a/src/core/UBPreferencesController.h
+++ b/src/core/UBPreferencesController.h
@@ -153,7 +153,6 @@ private slots:
 private:
     QList<QPushButton*> mScreenLabels;
     QValidator* mValidator;
-    QCompleter* mCompleter;
 };
 
 class UBStringListValidator : public QValidator

--- a/src/core/UBPreferencesController.h
+++ b/src/core/UBPreferencesController.h
@@ -160,7 +160,8 @@ public:
     UBStringListValidator(QStringList list, QObject* parent = nullptr);
     virtual ~UBStringListValidator() = default;
 
-    virtual QValidator::State validate(QString &input, int &pos) const;
+    virtual void fixup(QString& input) const;
+    virtual QValidator::State validate(QString& input, int& pos) const;
 
 private:
     QStringList mList;

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -245,9 +245,11 @@ void UBSettings::init()
     appEnableAutomaticSoftwareUpdates = new UBSetting(this, "App", "EnableAutomaticSoftwareUpdates", false);
     appSoftwareUpdateURL = new UBSetting(this, "App", "SoftwareUpdateURL", "http://www.openboard.ch/update.json");
     appHideCheckForSoftwareUpdate = new UBSetting(this, "App", "HideCheckForSoftwareUpdate", false);
-    appHideSwapDisplayScreens = new UBSetting(this, "App", "HideSwapDisplayScreens", true);
     appToolBarOrientationVertical = new UBSetting(this, "App", "ToolBarOrientationVertical", false);
     appPreferredLanguage = new UBSetting(this,"App","PreferredLanguage", "");
+
+    // removed in version 1.7.0
+    mUserSettings->remove("App/HideSwapDisplayScreens");
 
     rightLibPaletteBoardModeWidth = new UBSetting(this, "Board", "RightLibPaletteBoardModeWidth", 270);
     rightLibPaletteBoardModeIsCollapsed = new UBSetting(this,"Board", "RightLibPaletteBoardModeIsCollapsed",true);
@@ -262,7 +264,7 @@ void UBSettings::init()
     appLastSessionDocumentUUID = new UBSetting(this, "App", "LastSessionDocumentUUID", "");
     appLastSessionPageIndex = new UBSetting(this, "App", "LastSessionPageIndex", 0);
     appUseMultiscreen = new UBSetting(this, "App", "UseMultiscreenMode", true);
-    appScreenList = new UBSetting(this, "App", "ScreenList", QStringList());
+    appScreenList = new UBSetting(this, "App", "ScreenList", QVariant());
 
     appStartupHintsEnabled = new UBSetting(this,"App","EnableStartupHints",false);
 

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -259,7 +259,6 @@ class UBSettings : public QObject
         UBSetting* appEnableAutomaticSoftwareUpdates;
         UBSetting* appSoftwareUpdateURL;
         UBSetting* appHideCheckForSoftwareUpdate;
-        UBSetting* appHideSwapDisplayScreens;
         UBSetting* appToolBarOrientationVertical;
         UBSetting* appPreferredLanguage;
         UBSetting* appRunInWindow;

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -36,6 +36,8 @@
 #include <X11/keysym.h>
 
 #include "frameworks/UBFileSystemUtils.h"
+#include "core/UBApplication.h"
+#include "core/UBDisplayManager.h"
 #include "core/UBSettings.h"
 
 
@@ -440,7 +442,8 @@ void UBPlatformUtils::setFrontProcess()
 
 void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 {
-    if (UBSettings::settings()->appRunInWindow->get().toBool()) {
+    if (UBSettings::settings()->appRunInWindow->get().toBool() &&
+            pWidget == UBApplication::displayManager->widget(ScreenRole::Control)) {
         pWidget->show();
     } else {
         pWidget->showFullScreen();

--- a/src/frameworks/UBPlatformUtils_mac.mm
+++ b/src/frameworks/UBPlatformUtils_mac.mm
@@ -29,6 +29,7 @@
 #include "MacUtils.h"
 #include "UBPlatformUtils.h"
 #include "core/UBApplication.h"
+#include "core/UBDisplayManager.h"
 #include "core/UBSettings.h"
 #include "frameworks/UBFileSystemUtils.h"
 #include "gui/UBMainWindow.h"
@@ -607,17 +608,22 @@ void UBPlatformUtils::showFullScreen(QWidget *pWidget)
      * Since it is impossible to later set different presentation options (i.e Hide dock & menu bar)
      * to NSApplication, we have to avoid calling QWidget::showFullScreen on OSX.
     */
-    
-    pWidget->showMaximized();
 
-    /* Bit of a hack. On OS X 10.10, showMaximized() resizes the widget to full screen (if the dock and
-     * menu bar are hidden); but on 10.9, it is placed in the "available" screen area (i.e the
-     * screen area minus the menu bar and dock area). So we have to manually resize it to the
-     * total screen height, and move it up to the top of the screen (y=0 position). */
+    if (UBSettings::settings()->appRunInWindow->get().toBool() &&
+            pWidget == UBApplication::displayManager->widget(ScreenRole::Control)) {
+        pWidget->show();
+    } else {
+        pWidget->showMaximized();
 
-    QRect currentScreenRect = QApplication::desktop()->screenGeometry(pWidget);
-    pWidget->resize(currentScreenRect.width(), currentScreenRect.height());
-    pWidget->move(currentScreenRect.left(), currentScreenRect.top());
+        /* Bit of a hack. On OS X 10.10, showMaximized() resizes the widget to full screen (if the dock and
+         * menu bar are hidden); but on 10.9, it is placed in the "available" screen area (i.e the
+         * screen area minus the menu bar and dock area). So we have to manually resize it to the
+         * total screen height, and move it up to the top of the screen (y=0 position). */
+
+        QRect currentScreenRect = QGuiApplication::screenAt(pWidget->geometry().topLeft())->geometry();
+        pWidget->resize(currentScreenRect.width(), currentScreenRect.height());
+        pWidget->move(currentScreenRect.left(), currentScreenRect.top());
+    }
 }
 
 

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -36,6 +36,8 @@
 
 #include "frameworks/UBFileSystemUtils.h"
 #include "core/memcheck.h"
+#include "core/UBApplication.h"
+#include "core/UBDisplayManager.h"
 #include "core/UBSettings.h"
 
 void UBPlatformUtils::init()
@@ -437,7 +439,8 @@ void UBPlatformUtils::setFrontProcess()
 
 void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 {
-    if (UBSettings::settings()->appRunInWindow->get().toBool()) {
+    if (UBSettings::settings()->appRunInWindow->get().toBool() &&
+            pWidget == UBApplication::displayManager->widget(ScreenRole::Control)) {
         pWidget->show();
     } else {
         pWidget->showFullScreen();

--- a/src/frameworks/UBStringUtils.cpp
+++ b/src/frameworks/UBStringUtils.cpp
@@ -143,6 +143,28 @@ QDateTime UBStringUtils::fromUtcIsoDate(const QString& dateString)
     return date.toLocalTime();
 }
 
+/**
+ * @brief Create a list of trimmed, non-empty strings
+ * @param list input list of strings
+ * @return list of trimmed, nonempty strings
+ */
+QStringList UBStringUtils::trimmed(const QStringList &list)
+{
+    QStringList output;
+
+    for (const QString& entry : list)
+    {
+        QString trimmedEntry = entry.trimmed();
+
+        if (!trimmedEntry.isEmpty())
+        {
+            output << trimmedEntry;
+        }
+    }
+
+    return output;
+}
+
 
 
 

--- a/src/frameworks/UBStringUtils.h
+++ b/src/frameworks/UBStringUtils.h
@@ -51,7 +51,7 @@ class UBStringUtils
         static QString toUtcIsoDateTime(const QDateTime& dateTime);
         static QDateTime fromUtcIsoDate(const QString& dateString);
 
-
+        static QStringList trimmed(const QStringList& list);
 };
 
 #endif // UBSTRINGUTILS_H

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -37,10 +37,12 @@
 
 #include "core/UBSettings.h"
 #include "core/UBApplication.h"
+#include "core/UBDisplayManager.h"
 #include "core/UBPreferencesController.h"
 #include "core/UBDownloadManager.h"
 
 #include "board/UBBoardController.h"
+#include "board/UBBoardView.h"
 
 #include "core/memcheck.h"
 
@@ -101,6 +103,9 @@ UBDockPalette::UBDockPalette(eUBDockPaletteType paletteType, QWidget *parent, co
 
     connect(UBApplication::boardController,SIGNAL(documentSet(UBDocumentProxy*)),this,SLOT(onDocumentSet(UBDocumentProxy*)));
     connect(this,SIGNAL(pageSelectionChangedRequired()),UBApplication::boardController,SLOT(selectionChanged()));
+
+    connect(UBApplication::displayManager, SIGNAL(screenLayoutChanged()), this, SLOT(onResizeRequest()));
+    connect(UBApplication::boardController->controlView(), SIGNAL(resized(QResizeEvent*)), this, SLOT(onResizeRequest()));
 }
 
 /**
@@ -411,12 +416,12 @@ void UBDockPalette::removeTab(UBDockPaletteWidget* widget)
 }
 
 /**
- * \brief Handle the resize request
- * @param event as the given resize request
+ * \brief Reposition the dock palette
  */
-void UBDockPalette::onResizeRequest(QResizeEvent *event)
+void UBDockPalette::onResizeRequest()
 {
-    resizeEvent(event);
+    // it is possible to pass a nullptr because the handler does not use this argument
+    UBDockPalette::resizeEvent(nullptr);
 }
 
 /**

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -203,7 +203,7 @@ protected:
 
 private slots:
     void onToolbarPosUpdated();
-    void onResizeRequest(QResizeEvent* event);
+    void onResizeRequest();
 
 private:
     void tabClicked(int tabIndex);


### PR DESCRIPTION
This pull request continues work on the `UBDisplayManager` and related classes. I want to thank all discussion partners and testers for their input and hope that most of them found its way to this PR.

The most noticeable improvement is the screen configuration by index instead of name. Names are too platform specific and volatile, so a simple index is the better choice. But much more has changed. Here a list in the order as the files appear below:

### UBBoardController

- The background grid size is calculated when the display manager has defined the roles of the screens.
- The boxing in window mode is calculated as if the control screen would be full screen.
- Boxing is recalculated when the window is resized.

### UBBoardView

Wheel events on "Previous" screens are no longer handled.

### UBApplicationController

- The initialization and adjustment of previous screens is now dynamically adapting to the screen configuration

### UBDisplayManager

- Screen indexes, roles and positions are now processed in three separate phases.
- Each phase is linked to the proper events and also emits an event when finished.
- This avoids duplicate processing and makes the timed positioning (hopefully) unnecessary, except for attaching or removing a monitor.
- The configurable screen list now contains a list of indexes.
- A lot of formatting and style.
- Improved pointer checks.

### UBPersistenceWorker

- Simple typo.

### PreferencesController

- As explained above, use a list of indexes for configuration.
- Store the screen list per monitor configuration.
- Remove the `QCompleter`, it makes no sense for indexes.
- Don't allow the screen labels to take focus.
- No invalid input, but make incomplete input user visible with background color.
- Remove the fade-out timer, it is no longer necessary.
- Emit signal when screen list changed.

### UBPlatformUtils (all platforms)

- Apply window mode to control widget only.

### UBDockPalette

- Reposition docks when screen was resized.