### PR TITLE
Desktop Palette disappears before screen capture

### DIFF
--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -448,8 +448,8 @@ void UBDesktopAnnotationController::customCapture()
 
     if (customCaptureWindow.execute(getScreenPixmap()) == QDialog::Accepted)
     {
-       QPixmap selectedPixmap = customCaptureWindow.getSelectedPixmap();
-       emit imageCaptured(selectedPixmap, false);
+        QPixmap selectedPixmap = customCaptureWindow.getSelectedPixmap();
+        emit imageCaptured(selectedPixmap, false);
     }
 
     mDesktopPalette->show();

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -435,24 +435,28 @@ void UBDesktopAnnotationController::customCapture()
     mIsFullyTransparent = true;
     updateBackground();
 
-    mDesktopPalette->disappearForCapture();
-    UBCustomCaptureWindow customCaptureWindow(mDesktopPalette);
-    // need to show the window before execute it to avoid some glitch on windows.
+    mDesktopPalette->hide();
 
-#ifndef Q_OS_WIN // Working only without this call on win32 desktop mode
-    UBPlatformUtils::showFullScreen(&customCaptureWindow);
-#endif
+    QTimer::singleShot(1000, [this]() {
 
-    if (customCaptureWindow.execute(getScreenPixmap()) == QDialog::Accepted)
-    {
-        QPixmap selectedPixmap = customCaptureWindow.getSelectedPixmap();
-        emit imageCaptured(selectedPixmap, false);
-    }
+        UBCustomCaptureWindow customCaptureWindow(mDesktopPalette);
+        // need to show the window before execute it to avoid some glitch on windows.
 
-    mDesktopPalette->appear();
+    #ifndef Q_OS_WIN // Working only without this call on win32 desktop mode
+        UBPlatformUtils::showFullScreen(&customCaptureWindow);
+    #endif
 
-    mIsFullyTransparent = false;
-    updateBackground();
+        if (customCaptureWindow.execute(getScreenPixmap()) == QDialog::Accepted)
+        {
+            QPixmap selectedPixmap = customCaptureWindow.getSelectedPixmap();
+            emit imageCaptured(selectedPixmap, false);
+        }
+
+        mDesktopPalette->show();
+
+        mIsFullyTransparent = false;
+        updateBackground();
+    });
 }
 
 
@@ -462,17 +466,21 @@ void UBDesktopAnnotationController::screenCapture()
     mIsFullyTransparent = true;
     updateBackground();
 
-    mDesktopPalette->disappearForCapture();
+    mDesktopPalette->hide();
 
-    QPixmap originalPixmap = getScreenPixmap();
+    QTimer::singleShot(1000, [this]() {
 
-    mDesktopPalette->appear();
+        QPixmap originalPixmap = getScreenPixmap();
 
-    emit imageCaptured(originalPixmap, false);
+        mDesktopPalette->show();
 
-    mIsFullyTransparent = false;
+        emit imageCaptured(originalPixmap, false);
 
-    updateBackground();
+        mIsFullyTransparent = false;
+
+        updateBackground();
+
+    });
 }
 
 

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -439,23 +439,23 @@ void UBDesktopAnnotationController::customCapture()
 
     QTimer::singleShot(1000, [this]() {
 
-        UBCustomCaptureWindow customCaptureWindow(mDesktopPalette);
-        // need to show the window before execute it to avoid some glitch on windows.
+    UBCustomCaptureWindow customCaptureWindow(mDesktopPalette);
+    // need to show the window before execute it to avoid some glitch on windows.
 
-    #ifndef Q_OS_WIN // Working only without this call on win32 desktop mode
-        UBPlatformUtils::showFullScreen(&customCaptureWindow);
-    #endif
+#ifndef Q_OS_WIN // Working only without this call on win32 desktop mode
+    UBPlatformUtils::showFullScreen(&customCaptureWindow);
+#endif
 
-        if (customCaptureWindow.execute(getScreenPixmap()) == QDialog::Accepted)
-        {
-            QPixmap selectedPixmap = customCaptureWindow.getSelectedPixmap();
-            emit imageCaptured(selectedPixmap, false);
-        }
+    if (customCaptureWindow.execute(getScreenPixmap()) == QDialog::Accepted)
+    {
+       QPixmap selectedPixmap = customCaptureWindow.getSelectedPixmap();
+       emit imageCaptured(selectedPixmap, false);
+    }
 
-        mDesktopPalette->show();
+    mDesktopPalette->show();
+    mIsFullyTransparent = false;
+    updateBackground();
 
-        mIsFullyTransparent = false;
-        updateBackground();
     });
 }
 
@@ -470,15 +470,15 @@ void UBDesktopAnnotationController::screenCapture()
 
     QTimer::singleShot(1000, [this]() {
 
-        QPixmap originalPixmap = getScreenPixmap();
+    QPixmap originalPixmap = getScreenPixmap();
 
-        mDesktopPalette->show();
+    mDesktopPalette->show();
 
-        emit imageCaptured(originalPixmap, false);
+    emit imageCaptured(originalPixmap, false);
 
-        mIsFullyTransparent = false;
+    mIsFullyTransparent = false;
 
-        updateBackground();
+    updateBackground();
 
     });
 }


### PR DESCRIPTION
There is a function in Open Board that the desktop palette disappears before screen capture. This does not work on my System (Debian Linux). I made a fix, that works. Please don't consider it as a pull request yet. Before continuing with it I need your feedback. There are a few things that I want to have clarified before completing the fix:

1. I think, with my fix, the variable mIsFullyTransparent and the logic of it is no longer required. I would remove it. But I would like to know If you see anything against it?
2. I think, I also don't have to update the background any more.
3. Would my lambda function an acceptable programming style? Not everybody likes them. Of course the formatting would be different. I did it so that you can compare it with the original code.
4. I think, the 1 second timer will be no 100% reliable solution. We would need a synchronization with the hideEvent, so that we can do the capture right after the widget is hidden. I can do this. But on the other hand, waiting 1 second is not such a bad solution.