### PR TITLE
Fix font handling

### DIFF
--- a/src/domain/UBGraphicsTextItemDelegate.cpp
+++ b/src/domain/UBGraphicsTextItemDelegate.cpp
@@ -263,12 +263,24 @@ void UBGraphicsTextItemDelegate::customize(QFontDialog &fontDialog)
 
             QStringList customFontList =  UBResources::resources()->customFontList();
             int index = 0;
-            foreach (QString dialogFontName, dialogFontNames){
-                if (safeWebFontNames.contains(dialogFontName, Qt::CaseInsensitive) || customFontList.contains(dialogFontName, Qt::CaseSensitive))
+            int remove = 0;
+
+            for (const QString& dialogFontName : dialogFontNames)
+            {
+                if (UBStringUtils::containsPrefix(safeWebFontNames, dialogFontName, Qt::CaseInsensitive) ||
+                        UBStringUtils::containsPrefix(customFontList, dialogFontName, Qt::CaseSensitive))
+                {
+                    stringListModel->removeRows(index, remove);
+                    remove = 0;
                     index++;
+                }
                 else
-                    stringListModel->removeRow(index);
+                {
+                    ++remove;
+                }
             }
+
+            stringListModel->removeRows(index, remove);
         }
     }
     QList<QComboBox*> comboBoxes = fontDialog.findChildren<QComboBox*>();

--- a/src/frameworks/UBStringUtils.cpp
+++ b/src/frameworks/UBStringUtils.cpp
@@ -31,6 +31,19 @@
 
 #include "core/memcheck.h"
 
+bool UBStringUtils::containsPrefix(const QStringList &prefixes, const QString &string, Qt::CaseSensitivity cs)
+{
+    for (const QString& prefix : prefixes)
+    {
+        if (string.startsWith(prefix, cs))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 QStringList UBStringUtils::sortByLastDigit(const QStringList& sourceList)
 {
     // we look for a set of digit after non digits and before a .
@@ -72,7 +85,7 @@ QStringList UBStringUtils::sortByLastDigit(const QStringList& sourceList)
 }
 
 
-QString UBStringUtils::netxDigitizedName(const QString& source)
+QString UBStringUtils::nextDigitizedName(const QString& source)
 {
 
     // we look for a set of digit after non digits and at the end

--- a/src/frameworks/UBStringUtils.h
+++ b/src/frameworks/UBStringUtils.h
@@ -41,9 +41,10 @@ class UBStringUtils
         ~UBStringUtils() {}
 
     public:
+        static bool containsPrefix(const QStringList& prefixes, const QString& string, Qt::CaseSensitivity cs);
         static QStringList sortByLastDigit(const QStringList& source);
 
-        static QString netxDigitizedName(const QString& source);
+        static QString nextDigitizedName(const QString& source);
 
         static QString toCanonicalUuid(const QUuid& uuid);
 

--- a/src/gui/UBResources.cpp
+++ b/src/gui/UBResources.cpp
@@ -88,4 +88,6 @@ void UBResources::buildFontList()
         int fontId = QFontDatabase::addApplicationFont(fontFile);
         mCustomFontList << QFontDatabase::applicationFontFamilies(fontId);
     }
+
+    mCustomFontList.removeDuplicates();
 }


### PR DESCRIPTION
This patch fixes issues with font selection for the text tool:

- Huge performance improvement when building the fonts list by
  - removing fonts from the models in chunks instead individually. This is important, as removing a single item from the model using `removeRow` takes nearly the same time as removing many items using `removeRows`. On my system with about 750 system fonts installed this reduced the time needed to build the fonts list from about 30 seconds to some 100 ms,
  - removing duplicates from the custom fonts list. This speeds-up comparison.
- Prefix matching to find all fonts.
  - The custom font list contains a prefix only, e.g. "Ecriture A", while the `dialogFontNames` contain e.g. "Ecriture A", "Ecriture A Ligne", "Ecriture A Orne" and "Ecriture A Orne Ligne". The check for equality dropped all but the first from this list.

Note that it is still necessary to add the fonts to the `INSTALLS` list in `OpenBoard.pro`. I think currently the fonts are missing in nearly all community builds, including mine for openSUSE. For the time being I will do this in a patch in my builds (see [0008-install-fonts.patch](https://build.opensuse.org/package/view_file/home:letsfindaway:experimental/OpenBoard/0008-install-fonts.patch?expand=1)), but in the end this should be addressed in a common cleanup of `OpenBoard.pro`, including considering #638. This patch will also be important for the Flatpack version maintained by @JBBgameich and necessary to resolve #474 for this version.

Additional remark: OpenBoard has font files in the directories

- `resources/fonts` and
- `resources/customization/fonts`.

Only the latter is used for the text tool. The first directory is addressed in the source code of `XPDFRenderer`, but in fact these files are not packaged in the official Ubuntu builds, so it is questionable whether they serve any actual purpose.