### PR TITLE
1.7 dev desktop palette hide event

### DIFF
--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -183,22 +183,11 @@ UBDesktopAnnotationController::~UBDesktopAnnotationController()
     delete mTransparentDrawingView;
 }
 
-void setPaletteIconsWithoutArrows(){
-    QIcon penIcon;
-    QIcon markerIcon;
-    QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    //UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
-}
-
-void setPaletteIconsWithArrows(){
+/**
+ * @brief setPenMarkerEraserIconsWithArrows adds small arrows onto the action icons of the pen,
+ * the marker and the eraser. These have the purpose to open sub palettes in the desktop mode.
+ */
+void setPenMarkerEraserIconsWithArrows(){
     QIcon penIcon;
     QIcon markerIcon;
     QIcon eraserIcon;
@@ -213,6 +202,24 @@ void setPaletteIconsWithArrows(){
     UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
 }
 
+/**
+ * @brief setPenMarkerEraserIconsWithoutArrows removes the small arrows of the action icons of the
+ * pen, the marker and the eraser. These arrow icons are only used in the desktop mode.
+ */
+void setPenMarkerEraserIconsWithoutArrows(){
+    QIcon penIcon;
+    QIcon markerIcon;
+    QIcon eraserIcon;
+    penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
+    penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
+    //UBApplication::mainWindow->actionPen->setIcon(penIcon);
+    markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
+    markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
+    eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
+    eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
+}
 void UBDesktopAnnotationController::updateColors(){
     if(UBApplication::boardController->activeScene()->isDarkBackground()){
         mTransparentDrawingScene->setBackground(true, UBPageBackground::plain);
@@ -336,7 +343,7 @@ UBBoardView* UBDesktopAnnotationController::drawingView()
 void UBDesktopAnnotationController::showWindow()
 {
     mDesktopPalette->setDisplaySelectButtonVisible(true);
-    setPaletteIconsWithArrows();
+    setPenMarkerEraserIconsWithArrows();
 
     connect(UBApplication::applicationController, SIGNAL(desktopMode(bool))
             , mDesktopPalette, SLOT(setDisplaySelectButtonVisible(bool)));
@@ -455,7 +462,7 @@ void UBDesktopAnnotationController::hideWindow()
 
 void UBDesktopAnnotationController::goToUniboard()
 {
-    setPaletteIconsWithoutArrows();
+    setPenMarkerEraserIconsWithoutArrows();
     UBApplication::applicationController->showBoard();
 }
 

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -183,6 +183,36 @@ UBDesktopAnnotationController::~UBDesktopAnnotationController()
     delete mTransparentDrawingView;
 }
 
+void setPaletteIconsWithoutArrows(){
+    QIcon penIcon;
+    QIcon markerIcon;
+    QIcon eraserIcon;
+    penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
+    penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
+    //UBApplication::mainWindow->actionPen->setIcon(penIcon);
+    markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
+    markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
+    eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
+    eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
+}
+
+void setPaletteIconsWithArrows(){
+    QIcon penIcon;
+    QIcon markerIcon;
+    QIcon eraserIcon;
+    penIcon.addFile(":images/stylusPalette/penArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
+    penIcon.addFile(":images/stylusPalette/penOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionPen->setIcon(penIcon);
+    markerIcon.addFile(":images/stylusPalette/markerArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
+    markerIcon.addFile(":images/stylusPalette/markerOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
+    eraserIcon.addFile(":images/stylusPalette/eraserArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
+    eraserIcon.addFile(":images/stylusPalette/eraserOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
+    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
+}
+
 void UBDesktopAnnotationController::updateColors(){
     if(UBApplication::boardController->activeScene()->isDarkBackground()){
         mTransparentDrawingScene->setBackground(true, UBPageBackground::plain);
@@ -306,6 +336,7 @@ UBBoardView* UBDesktopAnnotationController::drawingView()
 void UBDesktopAnnotationController::showWindow()
 {
     mDesktopPalette->setDisplaySelectButtonVisible(true);
+    setPaletteIconsWithArrows();
 
     connect(UBApplication::applicationController, SIGNAL(desktopMode(bool))
             , mDesktopPalette, SLOT(setDisplaySelectButtonVisible(bool)));
@@ -422,9 +453,9 @@ void UBDesktopAnnotationController::hideWindow()
     UBDrawingController::drawingController()->setStylusTool(mBoardStylusTool);
 }
 
-
 void UBDesktopAnnotationController::goToUniboard()
 {
+    setPaletteIconsWithoutArrows();
     UBApplication::applicationController->showBoard();
 }
 

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -212,7 +212,7 @@ void setPenMarkerEraserIconsWithoutArrows(){
     QIcon eraserIcon;
     penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
     penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    //UBApplication::mainWindow->actionPen->setIcon(penIcon);
+    UBApplication::mainWindow->actionPen->setIcon(penIcon);
     markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
     markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
     UBApplication::mainWindow->actionMarker->setIcon(markerIcon);

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -211,37 +211,7 @@ void UBDesktopPalette::maximizeMe()
 void UBDesktopPalette::showEvent(QShowEvent *event)
 {
     Q_UNUSED(event);
-    QIcon penIcon;
-    QIcon markerIcon;
-    QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/penArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/markerArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraserArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
-
     adjustPosition();
-}
-
-void UBDesktopPalette::hideEvent(QHideEvent *event)
-{
-    Q_UNUSED(event);
-    QIcon penIcon;
-    QIcon markerIcon;
-    QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
 }
 
 QPoint UBDesktopPalette::buttonPos(QAction *action)

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -72,8 +72,6 @@ class UBDesktopPalette : public UBActionPalette
 
 protected:
         void showEvent(QShowEvent *event);
-        void hideEvent(QHideEvent *event);
-
         virtual int getParentRightOffset();
 
 private:

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -71,7 +71,7 @@ class UBDesktopPalette : public UBActionPalette
         void parentResized();
 
 protected:
-        void showEvent(QShowEvent *event);
+        virtual void showEvent(QShowEvent *event);
         virtual int getParentRightOffset();
 
 private:


### PR DESCRIPTION
A small refactoring activity:

UBDesktopPalette::showEvent and hideEvent should not have a side effect to the palette of the main drawing board. It is relatively unexpected when going through the code that the icons of the main drawing board change magically. So that should be a bit more clear. That is the purpose of this pull request. The method hideEvent is then not even needed any more.

Note: The procedures setPenMarkerEraserIconsWithArrows and setPenMarkerEraserIconsWithoutArrows are no member functions because there is no need of beeing member functions. Everything is defined statically. In principle it should be a static member of UBApplication because there the actions are defined or even a helper outside that class. But the responsibility of this mechanism is in UBDesktopAnnotationController. So it makes sense to group all what belongs to it there.