### PR TITLE
fix: scaling of background PDF during export

### DIFF
--- a/src/adaptors/UBExportFullPDF.cpp
+++ b/src/adaptors/UBExportFullPDF.cpp
@@ -201,7 +201,20 @@ bool UBExportFullPDF::persistsDocument(UBDocumentProxy* pDocumentProxy, const QS
 
             // If the PDF was scaled when added to the scene (e.g if it was loaded from a document with a different DPI
             // than the current one), it should also be scaled here.
+#define UB_MINOR(version) EXTRACT_UB_MINOR(version)
+#define EXTRACT_UB_MINOR(major,minor,patch,type,build) minor
+#define UB_MAJOR(version) EXTRACT_UB_MAJOR(version)
+#define EXTRACT_UB_MAJOR(major,minor,patch,type,build) major
+
+#if UB_MAJOR(UBVERSION_RC) == 1 && UB_MINOR(UBVERSION_RC) == 6
+            QDesktopWidget* desktop = UBApplication::desktop();
+            qreal currentDpi = (desktop->physicalDpiX() + desktop->physicalDpiY()) / 2;
+#elif UB_MAJOR(UBVERSION_RC) == 1 && UB_MINOR(UBVERSION_RC) >= 7
             qreal currentDpi = UBApplication::displayManager->logicalDpi(ScreenRole::Control);
+#else
+#error Version UBVERSION_RC not supported by this code
+#endif
+
             qreal pdfScale = qreal(pDocumentProxy->pageDpi())/currentDpi;
 
             int existingPageCount = pDocumentProxy->pageCount();

--- a/src/adaptors/UBExportFullPDF.cpp
+++ b/src/adaptors/UBExportFullPDF.cpp
@@ -199,6 +199,11 @@ bool UBExportFullPDF::persistsDocument(UBDocumentProxy* pDocumentProxy, const QS
 
             MergeDescription mergeInfo;
 
+            // If the PDF was scaled when added to the scene (e.g if it was loaded from a document with a different DPI
+            // than the current one), it should also be scaled here.
+            qreal currentDpi = UBApplication::displayManager->logicalDpi(ScreenRole::Control);
+            qreal pdfScale = qreal(pDocumentProxy->pageDpi())/currentDpi;
+
             int existingPageCount = pDocumentProxy->pageCount();
 
             for(int pageIndex = 0 ; pageIndex < existingPageCount; pageIndex++)
@@ -237,10 +242,6 @@ bool UBExportFullPDF::persistsDocument(UBDocumentProxy* pDocumentProxy, const QS
                     // Now we align the items
                     xPdfOffset += (xPdf - xAnnotation) * scaleFactor * mScaleFactor;
                     yPdfOffset -= (yPdf - yAnnotation) * scaleFactor * mScaleFactor;
-
-                    // If the PDF was scaled when added to the scene (e.g if it was loaded from a document with a different DPI
-                    // than the current one), it should also be scaled here.
-                    qreal pdfScale = pdfItem->scale();
 
                     TransformationDescription pdfTransform(xPdfOffset, yPdfOffset, scaleFactor * pdfScale, 0);
                     TransformationDescription annotationTransform(xAnnotationsOffset, yAnnotationsOffset, 1, 0);


### PR DESCRIPTION
This PR tries to fix a scaling issue during PDF export using the PDF merger, where the overlay and the base PDF document where not correctly aligned. See https://github.com/letsfindaway/OpenBoard/issues/93 for an analysis of this problem.

I tested the patch also for cases where the annotations cover areas outside of the PDF document size. In these cases the PDF document and the annotations are scaled, so that everything fits on the page. Still the annotations are at the correct place.