### PR TITLE
Draw dashed and dotted lines

### DIFF
--- a/resources/OpenBoard.qrc
+++ b/resources/OpenBoard.qrc
@@ -126,6 +126,9 @@
         <file>images/toolbar/eraserTool.png</file>
         <file>images/toolbar/lineTool.png</file>
         <file>images/toolbar/tools.png</file>
+        <file>images/toolbar/solidLine.svg</file>
+        <file>images/toolbar/dashedLine.svg</file>
+        <file>images/toolbar/dottedLine.svg</file>
         <file>images/stylusPalette/arrow.png</file>
         <file>images/stylusPalette/arrowOn.png</file>
         <file>images/stylusPalette/handPlay.png</file>

--- a/resources/forms/mainWindow.ui
+++ b/resources/forms/mainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1342</width>
-    <height>223</height>
+    <height>268</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1700,6 +1700,54 @@
    </property>
    <property name="toolTip">
     <string>Draw intermediate grid lines</string>
+   </property>
+  </action>
+  <action name="actionLineSolid">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../OpenBoard.qrc">
+     <normaloff>:/images/toolbar/solidLine.svg</normaloff>:/images/toolbar/solidLine.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Line Style</string>
+   </property>
+   <property name="toolTip">
+    <string>Solid Style</string>
+   </property>
+  </action>
+  <action name="actionLineDashed">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../OpenBoard.qrc">
+     <normaloff>:/images/toolbar/dashedLine.svg</normaloff>:/images/toolbar/dashedLine.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Line Style</string>
+   </property>
+   <property name="toolTip">
+    <string>Dashed Style</string>
+   </property>
+  </action>
+  <action name="actionLineDotted">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../OpenBoard.qrc">
+     <normaloff>:/images/toolbar/dottedLine.svg</normaloff>:/images/toolbar/dottedLine.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Line Style</string>
+   </property>
+   <property name="toolTip">
+    <string>Dotted Style</string>
    </property>
   </action>
  </widget>

--- a/resources/images/toolbar/dashedLine.svg
+++ b/resources/images/toolbar/dashedLine.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="42"
+   height="42"
+   viewBox="0 0 42 42"
+   version="1.1"
+   id="svg38508"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="dashedLine.svg"
+   inkscape:export-filename="/home/dmitry/git/OpenBoard/resources/images/stylusPalette/arrow_svg.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview38510"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:zoom="11.313708"
+     inkscape:cx="18.870913"
+     inkscape:cy="20.903845"
+     inkscape:window-width="1920"
+     inkscape:window-height="1003"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g965"
+     inkscape:document-rotation="0"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid7387"
+       dotted="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs38505">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter37990-9-5"
+       inkscape:label="shadowFilter"
+       x="-0.067811772"
+       y="-0.07751945"
+       width="1.1356235"
+       height="1.1873387">
+      <feGaussianBlur
+         stdDeviation="0.29999999999999999"
+         id="feGaussianBlur37992-3-6" />
+      <feOffset
+         dx="0"
+         dy="0.29999999999999999"
+         id="feOffset37994-2-2" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter37990-9-5-3"
+       inkscape:label="shadowFilter"
+       x="-0.067811772"
+       y="-0.07751945"
+       width="1.1356235"
+       height="1.1873387">
+      <feGaussianBlur
+         stdDeviation="0.29999999999999999"
+         id="feGaussianBlur37992-3-6-6" />
+      <feOffset
+         dx="0"
+         dy="0.29999999999999999"
+         id="feOffset37994-2-2-7" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-152.84748,-194.2822)">
+    <g
+       id="g965"
+       inkscape:label="line">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:3.6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.8,10.8;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 154.68586,234.52153 38.80777,-38.81827"
+         id="path963"
+         sodipodi:nodetypes="cc" />
+    </g>
+  </g>
+  <metadata
+     id="metadata854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/resources/images/toolbar/dottedLine.svg
+++ b/resources/images/toolbar/dottedLine.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   inkscape:export-ydpi="96"
+   inkscape:export-xdpi="96"
+   inkscape:export-filename="/home/dmitry/git/OpenBoard/resources/images/stylusPalette/arrow_svg.png"
+   sodipodi:docname="dottedLine.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   id="svg38508"
+   version="1.1"
+   viewBox="0 0 42 42"
+   height="42"
+   width="42"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview38510"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:zoom="7.9999996"
+     inkscape:cx="41.437502"
+     inkscape:cy="-10.0625"
+     inkscape:window-width="1920"
+     inkscape:window-height="1003"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g965"
+     inkscape:document-rotation="0"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid7387"
+       dotted="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs38505">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter37990-9-5"
+       inkscape:label="shadowFilter"
+       x="-0.067811772"
+       y="-0.07751945"
+       width="1.1356235"
+       height="1.1873387">
+      <feGaussianBlur
+         stdDeviation="0.29999999999999999"
+         id="feGaussianBlur37992-3-6" />
+      <feOffset
+         dx="0"
+         dy="0.29999999999999999"
+         id="feOffset37994-2-2" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter37990-9-5-3"
+       inkscape:label="shadowFilter"
+       x="-0.067811772"
+       y="-0.07751945"
+       width="1.1356235"
+       height="1.1873387">
+      <feGaussianBlur
+         stdDeviation="0.29999999999999999"
+         id="feGaussianBlur37992-3-6-6" />
+      <feOffset
+         dx="0"
+         dy="0.29999999999999999"
+         id="feOffset37994-2-2-7" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-152.84748,-194.2822)">
+    <g
+       id="g965"
+       inkscape:label="line">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.53588;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.878431;paint-order:stroke fill markers"
+         id="circle2549"
+         cx="157.40373"
+         cy="231.92728"
+         r="3.4577076" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.53588;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.878431;paint-order:stroke fill markers"
+         id="circle2587"
+         cx="168.27238"
+         cy="221.2583"
+         r="3.4577076" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.53588;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.878431;paint-order:stroke fill markers"
+         id="circle2589"
+         cx="179.28416"
+         cy="210.2368"
+         r="3.4577076" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.53588;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.878431;paint-order:stroke fill markers"
+         id="circle2591"
+         cx="190.15662"
+         cy="199.18091"
+         r="3.4577076" />
+    </g>
+  </g>
+  <metadata
+     id="metadata854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/resources/images/toolbar/solidLine.svg
+++ b/resources/images/toolbar/solidLine.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="42"
+   height="42"
+   viewBox="0 0 42 42"
+   version="1.1"
+   id="svg38508"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="solidLine.svg"
+   inkscape:export-filename="/home/dmitry/git/OpenBoard/resources/images/stylusPalette/arrow_svg.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview38510"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:zoom="11.313708"
+     inkscape:cx="18.870913"
+     inkscape:cy="20.903845"
+     inkscape:window-width="1920"
+     inkscape:window-height="1003"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g965"
+     inkscape:document-rotation="0"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid7387"
+       dotted="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs38505">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter37990-9-5"
+       inkscape:label="shadowFilter"
+       x="-0.067811772"
+       y="-0.07751945"
+       width="1.1356235"
+       height="1.1873387">
+      <feGaussianBlur
+         stdDeviation="0.29999999999999999"
+         id="feGaussianBlur37992-3-6" />
+      <feOffset
+         dx="0"
+         dy="0.29999999999999999"
+         id="feOffset37994-2-2" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter37990-9-5-3"
+       inkscape:label="shadowFilter"
+       x="-0.067811772"
+       y="-0.07751945"
+       width="1.1356235"
+       height="1.1873387">
+      <feGaussianBlur
+         stdDeviation="0.29999999999999999"
+         id="feGaussianBlur37992-3-6-6" />
+      <feOffset
+         dx="0"
+         dy="0.29999999999999999"
+         id="feOffset37994-2-2-7" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="icon"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-152.84748,-194.2822)">
+    <g
+       id="g965"
+       inkscape:label="line">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 155.10847,234.22611 192.7862,196.30525"
+         id="path963"
+         sodipodi:nodetypes="cc" />
+    </g>
+  </g>
+  <metadata
+     id="metadata854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/adaptors/UBCFFSubsetAdaptor.h
+++ b/src/adaptors/UBCFFSubsetAdaptor.h
@@ -110,6 +110,7 @@ private:
         inline bool parseSvgEllipse(const QDomElement &element);
         inline bool parseSvgPolygon(const QDomElement &element);
         inline bool parseSvgPolyline(const QDomElement &element);
+        inline bool parseSvgLine(const QDomElement &element);
         inline bool parseSvgText(const QDomElement &element);
         inline bool parseSvgTextarea(const QDomElement &element);
         inline bool parseSvgImage(const QDomElement &element);

--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -38,6 +38,7 @@
 
 class UBGraphicsSvgItem;
 class UBGraphicsPolygonItem;
+class UBGraphicsLineItem;
 class UBGraphicsPixmapItem;
 class UBGraphicsPDFItem;
 class UBGraphicsWidgetItem;
@@ -125,6 +126,8 @@ class UBSvgSubsetAdaptor
 
                 QList<UBGraphicsPolygonItem*> polygonItemsFromPolylineSvg(const QColor& pDefaultColor);
 
+                UBGraphicsLineItem* lineItemFromLineSvg(const QColor& pDefaultPenColor);
+
                 UBGraphicsPixmapItem* pixmapItemFromSvg();
 
                 UBGraphicsSvgItem* svgItemFromSvg();
@@ -195,6 +198,7 @@ class UBSvgSubsetAdaptor
                 void persistStrokeToDom(QGraphicsItem *strokeItem, QDomElement *curParent, QDomDocument *curDomDocument);
                 void polygonItemToSvgPolygon(UBGraphicsPolygonItem* polygonItem, bool groupHoldsInfo);
                 void polygonItemToSvgLine(UBGraphicsPolygonItem* polygonItem, bool groupHoldsInfo);
+                void lineItemToSvgLine(UBGraphicsLineItem* lineItem, bool groupHoldsInfo);
                 void strokeToSvgPolyline(UBGraphicsStroke* stroke, bool groupHoldsInfo);
                 void strokeToSvgPolygon(UBGraphicsStroke* stroke, bool groupHoldsInfo);
 

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -322,6 +322,15 @@ class UBBoardController : public UBDocumentContainer
 
         QTimer *mAutosaveTimer;
 
+        enum PropertyPalette
+        {
+            color,
+            lineWidth,
+            eraserWidth,
+            lineStyle
+        };
+        QMap<PropertyPalette, QAction*> mPropertyPaletteWidgets;
+
     private slots:
         void stylusToolDoubleClicked(int tool);
         void boardViewResized(QResizeEvent* event);

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -67,6 +67,7 @@
 #include "domain/UBGraphicsWidgetItem.h"
 #include "domain/UBGraphicsPDFItem.h"
 #include "domain/UBGraphicsPolygonItem.h"
+#include "domain/UBGraphicsLineItem.h"
 #include "domain/UBItem.h"
 #include "domain/UBGraphicsMediaItem.h"
 #include "domain/UBGraphicsSvgItem.h"
@@ -1210,7 +1211,8 @@ void UBBoardView::mouseMoveEvent (QMouseEvent *event)
                             || item->type() == UBGraphicsSvgItem::Type
                             || item->type() == UBGraphicsTextItem::Type
                             || item->type() == UBGraphicsStrokesGroup::Type
-                            || item->type() == UBGraphicsGroupContainerItem::Type) {
+                            || item->type() == UBGraphicsGroupContainerItem::Type
+                            || item->type() == UBGraphicsLineItem::Type) {
 
 
                         if (!mJustSelectedItems.contains(item)) {

--- a/src/board/UBDrawingController.cpp
+++ b/src/board/UBDrawingController.cpp
@@ -279,6 +279,11 @@ void UBDrawingController::setEraserWidthIndex(int index)
     UBSettings::settings()->setEraserWidthIndex(index);
 }
 
+void UBDrawingController::setLineStyleIndex(int index)
+{
+    UBSettings::settings()->setLineStyleIndex(index);
+}
+
 void UBDrawingController::setPenColor(bool onDarkBackground, const QColor& color, int pIndex)
 {
     if (onDarkBackground)

--- a/src/board/UBDrawingController.h
+++ b/src/board/UBDrawingController.h
@@ -81,6 +81,7 @@ class UBDrawingController : public QObject
         void setLineWidthIndex(int index);
         void setColorIndex(int index);
         void setEraserWidthIndex(int index);
+        void setLineStyleIndex(int index);
 
     signals:
         void stylusToolChanged(int tool, int previousTool = -1);

--- a/src/core/UB.h
+++ b/src/core/UB.h
@@ -84,6 +84,16 @@ struct UBWidth
     };
 };
 
+struct UBLineStyle
+{
+    enum Enum
+    {
+        Solid = 0,
+        Dashed = 1,
+        Dotted = 2
+    };
+};
+
 struct UBZoom
 {
     enum Enum
@@ -173,6 +183,7 @@ struct UBGraphicsItemType
         GraphicsWidgetItemType,                         //65556
         UserTypesCount,                                 //65557
         AxesItemType,                                   //65558
+        LineItemType,                                   //65559
         SelectionFrameType                              // this line must be the last line in this enum because it is types counter.
     };
 };

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -785,6 +785,41 @@ qreal UBSettings::currentEraserWidth()
     return width;
 }
 
+//----------------------------------------//
+// line
+int UBSettings::lineStyleIndex()
+{
+    return value("Board/LineStyleIndex", 0).toInt();
+}
+
+void UBSettings::setLineStyleIndex(int index)
+{
+    setValue("Board/LineStyleIndex", index);
+}
+Qt::PenStyle UBSettings::currentLineStyle()
+{
+    Qt::PenStyle style = Qt::SolidLine;
+
+    switch (lineStyleIndex())
+    {
+        case UBLineStyle::Solid:
+            style = Qt::SolidLine;
+            break;
+        case UBLineStyle::Dotted:
+            style = Qt::DotLine;
+            break;
+        case UBLineStyle::Dashed:
+            style = Qt::DashLine;
+            break;
+        default:
+            Q_ASSERT(false);
+            style = Qt::SolidLine;
+            break;
+    }
+
+    return style;
+}
+
 bool UBSettings::isDarkBackground()
 {
     return value("Board/DarkBackground", 0).toBool();

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -85,6 +85,10 @@ class UBSettings : public QObject
         qreal eraserStrongWidth();
         qreal currentEraserWidth();
 
+        // Line related
+        int lineStyleIndex();
+        Qt::PenStyle currentLineStyle();
+
         // Background related
         bool isDarkBackground();
         UBPageBackground pageBackground();
@@ -442,6 +446,8 @@ class UBSettings : public QObject
         void setEraserFineWidth(qreal width);
         void setEraserMediumWidth(qreal width);
         void setEraserStrongWidth(qreal width);
+
+        void setLineStyleIndex(int index);
 
          void setStylusPaletteVisible(bool visible);
 

--- a/src/domain/UBGraphicsLineItem.cpp
+++ b/src/domain/UBGraphicsLineItem.cpp
@@ -1,0 +1,191 @@
+#include "UBGraphicsLineItem.h"
+
+#include "frameworks/UBGeometryUtils.h"
+#include "UBGraphicsScene.h"
+#include "core/memcheck.h"
+
+
+UBGraphicsLineItem::UBGraphicsLineItem (QGraphicsItem * parent)
+    : QGraphicsLineItem(parent)
+    , mHasAlpha(false)
+    , mOriginalWidth(-1)
+    , mIsNominalLine(false)
+{
+    // NOOP
+    initialize();
+}
+
+UBGraphicsLineItem::UBGraphicsLineItem (const QLineF & line, QGraphicsItem * parent)
+    : QGraphicsLineItem(line, parent)
+    , mOriginalWidth(-1)
+    , mIsNominalLine(false)
+{
+    // NOOP
+    initialize();
+}
+
+
+UBGraphicsLineItem::UBGraphicsLineItem (const QLineF& pLine, qreal pWidth)
+    : QGraphicsLineItem(pLine)
+    , mOriginalLine(pLine)
+    , mOriginalWidth(pWidth)
+    , mIsNominalLine(true)
+{
+    // NOOP
+    initialize();
+}
+
+UBGraphicsLineItem::UBGraphicsLineItem (const QLineF& pLine, qreal pStartWidth, qreal pEndWidth)
+    : QGraphicsLineItem(pLine)
+    , mOriginalLine(pLine)
+    , mOriginalWidth(pEndWidth)
+    , mIsNominalLine(true)
+{
+    // NOOP
+    initialize();
+}
+
+
+void UBGraphicsLineItem::initialize()
+{
+    //setData(UBGraphicsItemData::itemLayerType, QVariant(itemLayerType::DrawingItem)); //Necessary to set if we want z value to be assigned correctly
+    setDelegate(new UBGraphicsItemDelegate(this, 0, GF_COMMON
+                                           | GF_RESPECT_RATIO
+                                           | GF_REVOLVABLE
+                                           | GF_FLIPPABLE_ALL_AXIS));
+    setUuid(QUuid::createUuid());
+    setData(UBGraphicsItemData::itemLayerType, QVariant(itemLayerType::ObjectItem)); //Necessary to set if we want z value to be assigned correctly
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setFlag(QGraphicsItem::ItemIsMovable, true);
+}
+
+void UBGraphicsLineItem::setUuid(const QUuid &pUuid)
+{
+    UBItem::setUuid(pUuid);
+    setData(UBGraphicsItemData::ItemUuid, QVariant(pUuid)); //store item uuid inside the QGraphicsItem to fast operations with Items on the scene
+}
+
+UBGraphicsLineItem::~UBGraphicsLineItem()
+{
+
+}
+
+void UBGraphicsLineItem::setColor(const QColor& pColor)
+{
+    QPen pen = QPen(pColor);
+    pen.setStyle(style());
+    if (style()==Qt::PenStyle::DotLine)
+    {
+        pen.setCapStyle(Qt::PenCapStyle::RoundCap);
+    }
+    pen.setWidth(mOriginalWidth);
+    QGraphicsLineItem::setPen(pen);
+
+    mHasAlpha = (pColor.alphaF() < 1.0);
+}
+
+
+QColor UBGraphicsLineItem::color() const
+{
+    return QGraphicsLineItem::pen().color();
+}
+
+void UBGraphicsLineItem::setStyle(const Qt::PenStyle& style)
+{
+    QPen pen = QPen(color());
+    pen.setStyle(style);
+    if (style==Qt::PenStyle::DotLine)
+    {
+        pen.setCapStyle(Qt::PenCapStyle::RoundCap);
+    }
+    pen.setWidth(mOriginalWidth);
+    QGraphicsLineItem::setPen(pen);
+}
+
+Qt::PenStyle UBGraphicsLineItem::style() const
+{
+    return QGraphicsLineItem::pen().style();
+}
+
+QList<QPointF> UBGraphicsLineItem::linePoints()
+{
+    QList<QPointF> points = QList<QPointF>();
+    qreal incr = 1/line().length();
+    if (incr<0) incr*=-1;
+    if (incr>0)
+    {
+       for (qreal t = 0; t <= 1; t+=incr)
+       {
+           points.push_back(line().pointAt(t));
+       }
+    }
+    return points;
+}
+
+UBItem* UBGraphicsLineItem::deepCopy() const
+{
+    UBGraphicsLineItem* copy = new UBGraphicsLineItem(line());
+    copyItemParameters(copy);
+    return copy;
+}
+
+
+void UBGraphicsLineItem::copyItemParameters(UBItem *copy) const
+{
+    UBGraphicsLineItem *cp = dynamic_cast<UBGraphicsLineItem*>(copy);
+    if (cp)
+    {
+        cp->mOriginalLine = this->mOriginalLine;
+        cp->mOriginalWidth = this->mOriginalWidth;
+        cp->mIsNominalLine = this->mIsNominalLine;
+
+        cp->setTransform(transform());
+        cp->setPos(pos());
+        cp->setPen(this->pen());
+        cp->mHasAlpha = this->mHasAlpha;
+
+        cp->setColorOnDarkBackground(this->colorOnDarkBackground());
+        cp->setColorOnLightBackground(this->colorOnLightBackground());
+
+        cp->setFlag(QGraphicsItem::ItemIsMovable, true);
+        cp->setFlag(QGraphicsItem::ItemIsSelectable, true);
+        cp->setZValue(this->zValue());
+        cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
+        cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
+    }
+}
+
+void UBGraphicsLineItem::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget)
+{
+    QStyleOptionGraphicsItem styleOption = QStyleOptionGraphicsItem(*option);
+    if(mHasAlpha && scene() && scene()->isLightBackground())
+        painter->setCompositionMode(QPainter::CompositionMode_SourceOver);
+
+    painter->setRenderHints(QPainter::Antialiasing);
+
+    QGraphicsLineItem::paint(painter, option, widget);
+    Delegate()->postpaint(painter, &styleOption, widget);
+}
+
+UBGraphicsScene* UBGraphicsLineItem::scene()
+{
+    return qobject_cast<UBGraphicsScene*>(QGraphicsLineItem::scene());
+}
+
+void UBGraphicsLineItem::SetDelegate()
+{
+    Delegate()->createControls();
+}
+
+QVariant UBGraphicsLineItem::itemChange(GraphicsItemChange change, const QVariant &value)
+{
+    QVariant newValue = Delegate()->itemChange(change, value);
+        UBGraphicsItem *item = dynamic_cast<UBGraphicsItem*>(this);
+        if (item)
+        {
+            item->Delegate()->positionHandles();
+        }
+
+    return QGraphicsItem::itemChange(change, newValue);
+}

--- a/src/domain/UBGraphicsLineItem.h
+++ b/src/domain/UBGraphicsLineItem.h
@@ -1,0 +1,100 @@
+#ifndef UBGRAPHICSLINEITEM_H
+#define UBGRAPHICSLINEITEM_H
+
+#include <QtGui>
+#include "core/UB.h"
+#include "UBItem.h"
+
+class UBItem;
+class UBGraphicsScene;
+
+class UBGraphicsLineItem : public QGraphicsLineItem, public UBItem, public UBGraphicsItem
+{
+
+    public:
+
+        UBGraphicsLineItem(QGraphicsItem * parent = 0 );
+        UBGraphicsLineItem(const QLineF& line, qreal pWidth);
+        UBGraphicsLineItem(const QLineF& pLine, qreal pStartWidth, qreal pEndWidth);
+        UBGraphicsLineItem(const QLineF & line, QGraphicsItem * parent = 0);
+
+        ~UBGraphicsLineItem();
+
+        void initialize();
+
+        void setUuid(const QUuid &pUuid);
+
+        void setColor(const QColor& color);
+        void setStyle(const Qt::PenStyle& style);
+
+        QColor color() const;
+        Qt::PenStyle style() const;
+
+        virtual UBGraphicsScene* scene();
+
+        enum { Type = UBGraphicsItemType::LineItemType };
+
+        virtual int type() const
+        {
+            return Type;
+        }
+
+        void setLine(const QLineF pLine)
+        {
+            mIsNominalLine = false;
+            QGraphicsLineItem::setLine(pLine);
+        }
+
+        virtual UBItem* deepCopy() const;
+
+        virtual void copyItemParameters(UBItem *copy) const;
+
+        QLineF originalLine() { return mOriginalLine;}
+        qreal originalWidth() { return mOriginalWidth;}
+        bool isNominalLine() {return mIsNominalLine;}
+
+        void setNominalLine(bool isNominalLine) { mIsNominalLine = isNominalLine; }
+
+        QList<QPointF> linePoints();
+
+        QColor colorOnDarkBackground() const
+        {
+            return mColorOnDarkBackground;
+        }
+
+        void setColorOnDarkBackground(QColor pColorOnDarkBackground)
+        {
+            mColorOnDarkBackground = pColorOnDarkBackground;
+        }
+
+        QColor colorOnLightBackground() const
+        {
+            return mColorOnLightBackground;
+        }
+
+        void setColorOnLightBackground(QColor pColorOnLightBackground)
+        {
+            mColorOnLightBackground = pColorOnLightBackground;
+        }
+
+        void SetDelegate();
+
+    protected:
+        void paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget);
+        virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+
+    private:
+
+        bool mHasAlpha;
+
+        QLineF mOriginalLine;
+        qreal mOriginalWidth;
+        bool mIsNominalLine;
+
+        QColor mColorOnDarkBackground;
+        QColor mColorOnLightBackground;
+
+};
+
+#endif // UBGRAPHICSLINEITEM_H
+

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -41,6 +41,7 @@ class UBGraphicsPixmapItem;
 class UBGraphicsProxyWidget;
 class UBGraphicsSvgItem;
 class UBGraphicsPolygonItem;
+class UBGraphicsLineItem;
 class UBGraphicsMediaItem;
 class UBGraphicsWidgetItem;
 class UBGraphicsW3CWidgetItem;
@@ -400,8 +401,11 @@ public slots:
         UBGraphicsPolygonItem* curveToPolygonItem(const QList<QPair<QPointF, qreal> > &points);
         UBGraphicsPolygonItem* curveToPolygonItem(const QList<QPointF> &points, qreal startWidth, qreal endWidth);
         void addPolygonItemToCurrentStroke(UBGraphicsPolygonItem* polygonItem);
+        void addLineItemToCurrentStroke(UBGraphicsLineItem* lineItem);
 
         void initPolygonItem(UBGraphicsPolygonItem*);
+        void initLineItem(UBGraphicsLineItem*);
+
 
         void drawEraser(const QPointF& pEndPoint, bool pressed = true);
         void redrawEraser(bool pressed);
@@ -493,6 +497,7 @@ public slots:
         UBZLayerController *mZLayerController;
         UBGraphicsPolygonItem* mpLastPolygon;
         UBGraphicsPolygonItem* mTempPolygon;
+        UBGraphicsLineItem* mpLastLine;
 
         bool mDrawWithCompass;
         UBGraphicsPolygonItem *mCurrentPolygon;

--- a/src/domain/UBItem.cpp
+++ b/src/domain/UBItem.cpp
@@ -41,6 +41,7 @@
 #include "domain/UBGraphicsScene.h"
 #include "tools/UBGraphicsCurtainItem.h"
 #include "domain/UBGraphicsItemDelegate.h"
+#include "domain/UBGraphicsLineItem.h"
 
 UBItem::UBItem()
     : mUuid(QUuid())
@@ -135,6 +136,8 @@ UBGraphicsItemDelegate *UBGraphicsItem::Delegate(QGraphicsItem *pItem)
     case UBGraphicsCurtainItem::Type :
         result = (static_cast<UBGraphicsCurtainItem*>(pItem))->Delegate();
         break;
+    case UBGraphicsLineItem::Type :
+        result = (static_cast<UBGraphicsLineItem*>(pItem))->Delegate();
     }
 
     return result;

--- a/src/domain/domain.pri
+++ b/src/domain/domain.pri
@@ -6,6 +6,7 @@ HEADERS += src/domain/UBGraphicsScene.h \
     src/domain/UBPageSizeUndoCommand.h \
     src/domain/UBGraphicsProxyWidget.h \
     src/domain/UBGraphicsSvgItem.h \
+    src/domain/UBGraphicsLineItem.h \
     src/domain/UBGraphicsPolygonItem.h \
     src/domain/UBItem.h \
     src/domain/UBGraphicsWidgetItem.h \
@@ -35,6 +36,7 @@ SOURCES += src/domain/UBGraphicsScene.cpp \
     src/domain/UBPageSizeUndoCommand.cpp \
     src/domain/UBGraphicsProxyWidget.cpp \
     src/domain/UBGraphicsSvgItem.cpp \
+    src/domain/UBGraphicsLineItem.cpp \
     src/domain/UBGraphicsPolygonItem.cpp \
     src/domain/UBItem.cpp \
     src/domain/UBGraphicsWidgetItem.cpp \


### PR DESCRIPTION
At first I made showing the characteristics that apply only to the selected tool (otherwise there would be too many).
After that I create a new graphics item based on QGraphicsLineItem, because polygons do not support lines styles, and add a new characteristic for line tool for it style (it can be solid, dashed and dotted).

![изображение](https://user-images.githubusercontent.com/75923933/185358246-da270479-d31f-485f-8cd1-c873debb990f.png)

![изображение](https://user-images.githubusercontent.com/75923933/185358590-60c2f1f4-b5d7-4558-a6aa-8e72158ce56d.png)
