### PR TITLE
fix: correct calculation of graphics item margins

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -2392,7 +2392,16 @@ void UBSvgSubsetAdaptor::UBSvgSubsetWriter::graphicsItemToSvg(QGraphicsItem* ite
     mXmlWriter.writeAttribute("x", "0");
     mXmlWriter.writeAttribute("y", "0");
 
-    QRectF rect = item->boundingRect() - QMarginsF(0.5, 0.5, 0.5, 0.5);
+    QRectF rect = item->boundingRect();
+
+    QAbstractGraphicsShapeItem* shapeItem = dynamic_cast<QAbstractGraphicsShapeItem*>(item);
+
+    if (shapeItem && shapeItem->pen().style() != Qt::NoPen)
+    {
+        qreal margin = shapeItem->pen().widthF() / 2.f;
+        rect -= QMarginsF(margin, margin, margin, margin);
+    }
+
     mXmlWriter.writeAttribute("width", QString("%1").arg(rect.width()));
     mXmlWriter.writeAttribute("height", QString("%1").arg(rect.height()));
 


### PR DESCRIPTION
- boundingRect only adds a margin if
  - it is a QAbstractGraphicsShapeItem, and
  - it has a pen (style != Qt::NoPen)
- the margin is then half the pen width at each side