### PR TITLE
Improve on-screen keyboard handling

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -44,6 +44,7 @@ QT += webenginewidgets
 QT += printsupport
 QT += core
 QT += concurrent
+linux: QT += dbus
 
 INCLUDEPATH += src
 

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -475,6 +475,11 @@ void UBSettings::init()
 
     useSystemOnScreenKeyboard = new UBSetting(this, "App", "UseSystemOnScreenKeyboard", true);
 
+    if (!UBPlatformUtils::hasSystemOnScreenKeyboard())
+    {
+        useSystemOnScreenKeyboard->set(false);
+    }
+
     showDateColumnOnAlphabeticalSort = new UBSetting(this, "Document", "ShowDateColumnOnAlphabeticalSort", false);
     emptyTrashForOlderDocuments = new UBSetting(this, "Document", "emptyTrashForOlderDocuments", false);
     emptyTrashDaysValue = new UBSetting(this, "Document", "emptyTrashDaysValue", 30);

--- a/src/frameworks/UBPlatformUtils.h
+++ b/src/frameworks/UBPlatformUtils.h
@@ -198,6 +198,7 @@ public:
         static QString translationPath(QString pFilePrefix, QString pLanguage);
         static QString systemLanguage();
         static bool hasVirtualKeyboard();
+        static bool hasSystemOnScreenKeyboard();
         static void bringPreviousProcessToFront();
         static QString osUserLoginName();
         static void setDesktopMode(bool desktop);

--- a/src/frameworks/UBPlatformUtils_mac.mm
+++ b/src/frameworks/UBPlatformUtils_mac.mm
@@ -204,6 +204,11 @@ void UBPlatformUtils::fadeDisplayIn()
     }
 }
 
+bool UBPlatformUtils::hasSystemOnScreenKeyboard()
+{
+    return true;
+}
+
 QStringList UBPlatformUtils::availableTranslations()
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];

--- a/src/frameworks/UBPlatformUtils_win.cpp
+++ b/src/frameworks/UBPlatformUtils_win.cpp
@@ -75,6 +75,11 @@ void UBPlatformUtils::fadeDisplayIn()
     // NOOP
 }
 
+bool UBPlatformUtils::hasSystemOnScreenKeyboard()
+{
+    return true;
+}
+
 QStringList UBPlatformUtils::availableTranslations()
 {
     QString translationsPath = applicationResourcesDirectory() + "/" + "i18n" + "/";


### PR DESCRIPTION
This PR improves the handling of the `onboard` on-screen keyboard on Linux. It improves the detection of the availability of the `onboard` system on-screen keyboard. Additionally it uses now `DBus` to show and hide the keyboard instead of starting and killing the application. 

- add detection function in `UBPlatformUtils`
- on Linux check for `onboard` binary
- disable system OSK if not installed
- use `DBus` to show/hide `onboard`