### PR TITLE
Check widget compatibility

### DIFF
--- a/resources/etc/widgets.md5sum
+++ b/resources/etc/widgets.md5sum
@@ -1,3 +1,5 @@
+2538bef70e75fcc6c3ebe2ec35e0a904,http://www.openboard.org/widget/application/geoinfo,GeoInfo.wgt
+7ade330c8afe00e543169486f65b7ccf,http://www.openboard.org/widget/application/icell,iCell.wgt
 0e417c056f2725a7147c12a74cc17bfd,http://www.openboard.org/widget/interactivity/assaudio,Ass audio.wgt
 183b3cee755f695eef5fa7293d0acd32,http://www.openboard.org/widget/interactivity/assimages,Ass images.wgt
 dadbfcf9fe185fcb3aa15cacec3d1aa1,http://www.openboard.org/widget/interactivity/calculation,Calculation.wgt

--- a/resources/library/applications/GeoInfo.wgt/config.xml
+++ b/resources/library/applications/GeoInfo.wgt/config.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <widget xmlns="http://www.w3.org/ns/widgets" 
+        xmlns:ub="http://uniboard.mnemis.com/widgets"
+        id="http://www.openboard.org/widget/application/geoinfo"
         version="2.0"
         width="680"
         height="400" 
-		ub:resizable="false">
-  <name>GeoInfo</name>
-  <content src="GeoInfo.html"/>
+        ub:resizable="false">
+    <name>GeoInfo</name>
+    <content src="GeoInfo.html"/>
 </widget>

--- a/resources/library/applications/iCell.wgt/config.xml
+++ b/resources/library/applications/iCell.wgt/config.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <widget xmlns="http://www.w3.org/ns/widgets" 
-        identifier="http://uniboard.mnemis.com/widgets/Clock" 
-        version="1.1"
+        xmlns:ub="http://uniboard.mnemis.com/widgets"
+        id="http://www.openboard.org/widget/application/icell"
+        version="2.0"
         width="500"
         height="500" >        
-  <name>iCell</name>
-  <content src="widget.html"/> 
+    <name>iCell</name>
+    <content src="widget.html"/>
 </widget>
 
 <!-- This XML is probably more complete, but it isn't working very well (the widget is resized, but its content doesn't move)

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -892,8 +892,30 @@ UBGraphicsScene* UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(UBDocumentProx
                 else if (src.contains(".wgt"))
                 {
                     UBGraphicsW3CWidgetItem* w3cWidgetItem = graphicsW3CWidgetFromSvg();
+
                     if (w3cWidgetItem)
                     {
+                        // check compatibility
+                        QUuid uuid(mXmlReader.attributes().value(mNamespaceUri, "uuid").toString());
+
+                        if (!proxy->isWidgetCompatible(uuid))
+                        {
+                            // show a substitute image and freeze the widget
+                            QPixmap pixmap(w3cWidgetItem->size().toSize());
+                            pixmap.fill(Qt::lightGray);
+                            QPainter painter(&pixmap);
+                            QFont font = painter.font();
+                            font.setPixelSize(16);
+                            painter.setFont(font);
+                            const QRectF rectangle(QPointF(0, 0), w3cWidgetItem->size());
+                            painter.drawText(rectangle, Qt::AlignCenter, QObject::tr("Incompatible widget"));
+                            w3cWidgetItem->setSnapshot(pixmap, true);
+
+                            // disable user interactions
+                            w3cWidgetItem->setFreezable(false);
+                            w3cWidgetItem->setCanBeTool(false);
+                        }
+
                         w3cWidgetItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 
                         w3cWidgetItem->resize(foreignObjectWidth, foreignObjectHeight);

--- a/src/adaptors/UBWidgetUpgradeAdaptor.h
+++ b/src/adaptors/UBWidgetUpgradeAdaptor.h
@@ -44,22 +44,35 @@ private:
     {
     public:
         Widget() = default;
-        Widget(const QString& dir);
+        explicit Widget(const QString& dir);
         bool operator==(const Widget& other) const;
-        bool valid();
+        bool valid() const;
         QString path() const;
         QString id() const;
         QString version() const;
+        bool hasUniqueId() const;
 
     private:
         QString m_path;
         QString m_id;
         QString m_version;
+        bool m_hasUniqueId;
+    };
+
+    enum class ApiUsage
+    {
+        NO,
+        COMPATIBLE,
+        INCOMPATIBLE
     };
 
 public:
     UBWidgetUpgradeAdaptor();
     void upgradeWidgets(UBDocumentProxy *proxy);
+
+private:
+    ApiUsage scanDir(const QDir &widget) const;
+    ApiUsage scanFile(const QFileInfo& info) const;
     void copyDir(QDir target, QDir source);
     void fillLibraryWidgets();
 

--- a/src/document/UBDocumentProxy.cpp
+++ b/src/document/UBDocumentProxy.cpp
@@ -124,6 +124,16 @@ void UBDocumentProxy::setPageDpi(int dpi)
     mPageDpi = dpi;
 }
 
+bool UBDocumentProxy::isWidgetCompatible(const QUuid &uuid) const
+{
+    return mWidgetCompatibility.value(uuid, true);
+}
+
+void UBDocumentProxy::setWidgetCompatible(const QUuid &uuid, bool compatible)
+{
+    mWidgetCompatibility[uuid] = compatible;
+}
+
 int UBDocumentProxy::incPageCount()
 {
     if (mPageCount <= 0)

--- a/src/document/UBDocumentProxy.h
+++ b/src/document/UBDocumentProxy.h
@@ -84,6 +84,9 @@ class UBDocumentProxy : public QObject
         int pageDpi();
         void setPageDpi(int dpi);
 
+        bool isWidgetCompatible(const QUuid& uuid) const;
+        void setWidgetCompatible(const QUuid& uuid, bool compatible);
+
     protected:
         void setPageCount(int pPageCount);
         int incPageCount();
@@ -103,6 +106,7 @@ class UBDocumentProxy : public QObject
 
         int mPageDpi;
 
+        QMap<QUuid, bool> mWidgetCompatibility;
 };
 
 inline bool operator==(const UBDocumentProxy &proxy1, const UBDocumentProxy &proxy2)

--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -196,6 +196,11 @@ bool UBGraphicsWidgetItem::canBeTool() const
     #endif
 }
 
+void UBGraphicsWidgetItem::setCanBeTool(bool tool)
+{
+    mCanBeTool = tool;
+}
+
 QString UBGraphicsWidgetItem::preference(const QString& key) const
 {
     return mPreferences.value(key);
@@ -338,6 +343,11 @@ bool UBGraphicsWidgetItem::resizable() const
 bool UBGraphicsWidgetItem::isFrozen() const
 {
     return mIsFrozen;
+}
+
+void UBGraphicsWidgetItem::setFreezable(bool freezable)
+{
+    mIsFreezable = freezable;
 }
 
 bool UBGraphicsWidgetItem::isWebActive() const

--- a/src/domain/UBGraphicsWidgetItem.h
+++ b/src/domain/UBGraphicsWidgetItem.h
@@ -84,6 +84,7 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
 
         bool canBeContent() const;
         bool canBeTool() const;
+        void setCanBeTool(bool tool);
 
         QString preference(const QString& key) const;
         void setPreference(const QString& key, QString value);
@@ -119,6 +120,7 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
         bool freezable() const;
         bool resizable() const;
         bool isFrozen() const;
+        void setFreezable(bool freezable);
         bool isWebActive() const;
 
         const QPixmap& snapshot() const;

--- a/src/domain/UBGraphicsWidgetItemDelegate.cpp
+++ b/src/domain/UBGraphicsWidgetItemDelegate.cpp
@@ -94,6 +94,7 @@ void UBGraphicsWidgetItemDelegate::decorateMenu(QMenu* menu)
     freezeAction->setIcon(freezeIcon);
 
     freezeAction->setCheckable(true);
+    freezeAction->setEnabled(delegated()->freezable());
 
     if (delegated()->canBeTool())
     {


### PR DESCRIPTION
This PR improves the handling of widget compatibility when upgrading from OpenBoard 1.6.x to 1.7.x.

- It adds an explicit API version marker to the `config.xml` file, which identifies widgets compatible with the asynchronous API.
- It shows a note on the screen for incompatible widgets.
- It includes the location of user installed widgets (`~/.local/share/OpenBoard/interactive content/` on Linux, similar locations on other platforms) when searching for upgraded widgets.

The version marker is already documented [in my Wiki page](https://github.com/letsfindaway/OpenBoard/wiki/Widget-API#widget-upgrade).