### PR TITLE
Can the masking mechanism be removed?

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -487,21 +487,10 @@ QString UBBoardController::truncate(QString text, int maxWidth)
     return fontMetrics.elidedText(text, Qt::ElideRight, maxWidth);
 }
 
-
-void UBBoardController::stylusToolDoubleClicked(int tool)
-{
-    if (tool == UBStylusTool::ZoomIn || tool == UBStylusTool::ZoomOut)
-    {
-        zoomRestore();
-    }
-    else if (tool == UBStylusTool::Hand)
-    {
-        centerRestore();
-        mActiveScene->setLastCenter(QPointF(0,0));
-    }
+void UBBoardController::restoreScroll(){
+    centerRestore();
+    mActiveScene->setLastCenter(QPointF(0,0));
 }
-
-
 
 void UBBoardController::addScene()
 {

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -207,6 +207,7 @@ class UBBoardController : public UBDocumentContainer
         void clearSceneBackground();
         void zoomIn(QPointF scenePoint = QPointF(0,0));
         void zoomOut(QPointF scenePoint = QPointF(0,0));
+        void restoreScroll();
         void zoomRestore();
         void centerRestore();
         void centerOn(QPointF scenePoint = QPointF(0,0));
@@ -321,7 +322,6 @@ class UBBoardController : public UBDocumentContainer
         QTimer *mAutosaveTimer;
 
     private slots:
-        void stylusToolDoubleClicked(int tool);
         void boardViewResized(QResizeEvent* event);
         void documentWillBeDeleted(UBDocumentProxy* pProxy);
         void updateBackgroundActionsState(bool isDark, UBPageBackground pageBackground);

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -234,7 +234,8 @@ void UBBoardPaletteManager::setupPalettes()
 
     // Add the other palettes
     mStylusPalette = new UBStylusPalette(mContainer, UBSettings::settings()->appToolBarOrientationVertical->get().toBool() ? Qt::Vertical : Qt::Horizontal);
-    connect(mStylusPalette, SIGNAL(stylusToolDoubleClicked(int)), UBApplication::boardController, SLOT(stylusToolDoubleClicked(int)));
+    connect(mStylusPalette, &UBStylusPalette::restoreZoom, UBApplication::boardController, &UBBoardController::zoomRestore);
+    connect(mStylusPalette, &UBStylusPalette::restoreScroll, UBApplication::boardController, &UBBoardController::restoreScroll);
     mStylusPalette->show(); // always show stylus palette at startup
 
     mZoomPalette = new UBZoomPalette(mContainer);
@@ -982,7 +983,8 @@ void UBBoardPaletteManager::changeStylusPaletteOrientation(QVariant var)
         mStylusPalette = new UBStylusPalette(mContainer, Qt::Horizontal);
     }
 
-    connect(mStylusPalette, SIGNAL(stylusToolDoubleClicked(int)), UBApplication::boardController, SLOT(stylusToolDoubleClicked(int)));
+    connect(mStylusPalette, &UBStylusPalette::restoreZoom, UBApplication::boardController, &UBBoardController::zoomRestore);
+    connect(mStylusPalette, &UBStylusPalette::restoreScroll, UBApplication::boardController, &UBBoardController::restoreScroll);
     mStylusPalette->setVisible(bVisible); // always show stylus palette at startup
 }
 

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -252,9 +252,8 @@ void UBBoardPaletteManager::setupPalettes()
         mBackgroundsPalette->addAction(UBApplication::mainWindow->actionPlainDarkBackground);
         mBackgroundsPalette->addAction(UBApplication::mainWindow->actionCrossedDarkBackground);
         mBackgroundsPalette->addAction(UBApplication::mainWindow->actionRuledDarkBackground);
-    });
+    }, true);
     mBackgroundsPalette->setButtonIconSize(QSize(128, 128));
-    mBackgroundsPalette->groupActions();
     mBackgroundsPalette->setClosable(true);
     mBackgroundsPalette->setAutoClose(false);
     mBackgroundsPalette->adjustSizeAndPosition();
@@ -266,11 +265,10 @@ void UBBoardPaletteManager::setupPalettes()
         mAddItemPalette->addAction(UBApplication::mainWindow->actionAddItemToCurrentPage);
         mAddItemPalette->addAction(UBApplication::mainWindow->actionAddItemToNewPage);
         mAddItemPalette->addAction(UBApplication::mainWindow->actionAddItemToLibrary);
-    });
+    }, true);
 
     mAddItemPalette->setButtonIconSize(QSize(128, 128));
     mAddItemPalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    mAddItemPalette->groupActions();
     mAddItemPalette->setClosable(true);
     mAddItemPalette->adjustSizeAndPosition();
     mAddItemPalette->hide();
@@ -281,10 +279,9 @@ void UBBoardPaletteManager::setupPalettes()
         mErasePalette->addAction(UBApplication::mainWindow->actionEraseItems);
         mErasePalette->addAction(UBApplication::mainWindow->actionClearPage);
         mErasePalette->addAction(UBApplication::mainWindow->actionEraseBackground);
-    });
+    }, true);
     mErasePalette->setButtonIconSize(QSize(128, 128));
     mErasePalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    mErasePalette->groupActions();
     mErasePalette->setClosable(true);
     mErasePalette->adjustSizeAndPosition();
     mErasePalette->hide();
@@ -296,11 +293,10 @@ void UBBoardPaletteManager::setupPalettes()
         mPagePalette->addAction(UBApplication::mainWindow->actionNewPage);
         mPagePalette->addAction(UBApplication::mainWindow->actionDuplicatePage);
         mPagePalette->addAction(UBApplication::mainWindow->actionImportPage);
-    });
+    }, true);
 
     mPagePalette->setButtonIconSize(QSize(128, 128));
     mPagePalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    mPagePalette->groupActions();
     mPagePalette->setClosable(true);
     mPagePalette->adjustSizeAndPosition();
     mPagePalette->hide();
@@ -332,11 +328,10 @@ void UBBoardPaletteManager::pagePaletteButtonReleased()
                 mPagePalette->addAction(UBApplication::mainWindow->actionNewPage);
                 mPagePalette->addAction(UBApplication::mainWindow->actionDuplicatePage);
                 mPagePalette->addAction(UBApplication::mainWindow->actionImportPage);
-            });
+            }, true);
 
             mPagePalette->setButtonIconSize(QSize(128, 128));
             mPagePalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-            mPagePalette->groupActions();
             mPagePalette->setClosable(true);
 
             // As we recreate the pagePalette every time, we must reconnect the slots

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -242,16 +242,16 @@ void UBBoardPaletteManager::setupPalettes()
     mStylusPalette->stackUnder(mZoomPalette);
 
     mTipPalette = new UBStartupHintsPalette(mContainer);
-    QList<QAction*> backgroundsActions;
 
-    backgroundsActions << UBApplication::mainWindow->actionPlainLightBackground;
-    backgroundsActions << UBApplication::mainWindow->actionCrossedLightBackground;
-    backgroundsActions << UBApplication::mainWindow->actionRuledLightBackground;
-    backgroundsActions << UBApplication::mainWindow->actionPlainDarkBackground;
-    backgroundsActions << UBApplication::mainWindow->actionCrossedDarkBackground;
-    backgroundsActions << UBApplication::mainWindow->actionRuledDarkBackground;
-
-    mBackgroundsPalette = new UBBackgroundPalette(backgroundsActions, mContainer);
+    mBackgroundsPalette = new UBBackgroundPalette(mContainer);
+    mBackgroundsPalette->changeActions([&]{
+        mBackgroundsPalette->addAction(UBApplication::mainWindow->actionPlainLightBackground);
+        mBackgroundsPalette->addAction(UBApplication::mainWindow->actionCrossedLightBackground);
+        mBackgroundsPalette->addAction(UBApplication::mainWindow->actionRuledLightBackground);
+        mBackgroundsPalette->addAction(UBApplication::mainWindow->actionPlainDarkBackground);
+        mBackgroundsPalette->addAction(UBApplication::mainWindow->actionCrossedDarkBackground);
+        mBackgroundsPalette->addAction(UBApplication::mainWindow->actionRuledDarkBackground);
+    });
     mBackgroundsPalette->setButtonIconSize(QSize(128, 128));
     mBackgroundsPalette->groupActions();
     mBackgroundsPalette->setClosable(true);
@@ -259,13 +259,14 @@ void UBBoardPaletteManager::setupPalettes()
     mBackgroundsPalette->adjustSizeAndPosition();
     mBackgroundsPalette->hide();
 
-    QList<QAction*> addItemActions;
 
-    addItemActions << UBApplication::mainWindow->actionAddItemToCurrentPage;
-    addItemActions << UBApplication::mainWindow->actionAddItemToNewPage;
-    addItemActions << UBApplication::mainWindow->actionAddItemToLibrary;
+    mAddItemPalette = new UBActionPalette(Qt::Horizontal, mContainer);
+    mAddItemPalette->changeActions([&]{
+        mAddItemPalette->addAction(UBApplication::mainWindow->actionAddItemToCurrentPage);
+        mAddItemPalette->addAction(UBApplication::mainWindow->actionAddItemToNewPage);
+        mAddItemPalette->addAction(UBApplication::mainWindow->actionAddItemToLibrary);
+    });
 
-    mAddItemPalette = new UBActionPalette(addItemActions, Qt::Horizontal, mContainer);
     mAddItemPalette->setButtonIconSize(QSize(128, 128));
     mAddItemPalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     mAddItemPalette->groupActions();
@@ -273,14 +274,13 @@ void UBBoardPaletteManager::setupPalettes()
     mAddItemPalette->adjustSizeAndPosition();
     mAddItemPalette->hide();
 
-    QList<QAction*> eraseActions;
-
-    eraseActions << UBApplication::mainWindow->actionEraseAnnotations;
-    eraseActions << UBApplication::mainWindow->actionEraseItems;
-    eraseActions << UBApplication::mainWindow->actionClearPage;
-    eraseActions << UBApplication::mainWindow->actionEraseBackground;
-
-    mErasePalette = new UBActionPalette(eraseActions, Qt::Horizontal , mContainer);
+    mErasePalette = new UBActionPalette(Qt::Horizontal , mContainer);
+    mErasePalette->changeActions([&]{
+        mErasePalette->addAction(UBApplication::mainWindow->actionEraseAnnotations);
+        mErasePalette->addAction(UBApplication::mainWindow->actionEraseItems);
+        mErasePalette->addAction(UBApplication::mainWindow->actionClearPage);
+        mErasePalette->addAction(UBApplication::mainWindow->actionEraseBackground);
+    });
     mErasePalette->setButtonIconSize(QSize(128, 128));
     mErasePalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     mErasePalette->groupActions();
@@ -290,11 +290,13 @@ void UBBoardPaletteManager::setupPalettes()
 
     QList<QAction*> pageActions;
 
-    pageActions << UBApplication::mainWindow->actionNewPage;
-    pageActions << UBApplication::mainWindow->actionDuplicatePage;
-    pageActions << UBApplication::mainWindow->actionImportPage;
+    mPagePalette = new UBActionPalette(Qt::Horizontal , mContainer);
+    mPagePalette->changeActions([&]{
+        mPagePalette->addAction(UBApplication::mainWindow->actionNewPage);
+        mPagePalette->addAction(UBApplication::mainWindow->actionDuplicatePage);
+        mPagePalette->addAction(UBApplication::mainWindow->actionImportPage);
+    });
 
-    mPagePalette = new UBActionPalette(pageActions, Qt::Horizontal , mContainer);
     mPagePalette->setButtonIconSize(QSize(128, 128));
     mPagePalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     mPagePalette->groupActions();
@@ -323,12 +325,14 @@ void UBBoardPaletteManager::pagePaletteButtonReleased()
             // The palette is reinstanciated because the duplication depends on the current scene
             delete(mPagePalette);
             mPagePalette = 0;
-            QList<QAction*>pageActions;
-            pageActions << UBApplication::mainWindow->actionNewPage;
-            pageActions << UBApplication::mainWindow->actionDuplicatePage;
-            pageActions << UBApplication::mainWindow->actionImportPage;
 
-            mPagePalette = new UBActionPalette(pageActions, Qt::Horizontal , mContainer);
+            mPagePalette = new UBActionPalette(Qt::Horizontal , mContainer);
+            mPagePalette->changeActions([&]{
+                mPagePalette->addAction(UBApplication::mainWindow->actionNewPage);
+                mPagePalette->addAction(UBApplication::mainWindow->actionDuplicatePage);
+                mPagePalette->addAction(UBApplication::mainWindow->actionImportPage);
+            });
+
             mPagePalette->setButtonIconSize(QSize(128, 128));
             mPagePalette->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
             mPagePalette->groupActions();

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -655,19 +655,6 @@ void UBApplicationController::closing()
     if (mMirror)
         mMirror->stop();
 
-    if (mUninoteController)
-    {
-        mUninoteController->hideWindow();
-        mUninoteController->close();
-    }
-
-    /*
-
-    if (UBApplication::documentController)
-        UBApplication::documentController->closing();
-
-    */
-
     UBPersistenceManager::persistenceManager()->closing(); // ALTI/AOU - 20140616 : to update the file "documents/folders.xml"
 }
 

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -341,16 +341,6 @@ void UBDesktopAnnotationController::showWindow()
 #endif // UB_REQUIRES_MASK_UPDATE
 }
 
-
-void UBDesktopAnnotationController::close()
-{
-    if (mTransparentDrawingView)
-        mTransparentDrawingView->hide();
-
-    mDesktopPalette->hide();
-}
-
-
 void UBDesktopAnnotationController::stylusToolChanged(int tool)
 {
     Q_UNUSED(tool);

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -75,6 +75,7 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
         , mbArrowClicked(false)
         , mBoardStylusTool(UBDrawingController::drawingController()->stylusTool())
         , mDesktopStylusTool(UBDrawingController::drawingController()->stylusTool())
+        , buttonsConnected(false)
 {
 
     mTransparentDrawingView = new UBBoardView(UBApplication::boardController, static_cast<QWidget*>(0), false, true); // deleted in UBDesktopAnnotationController::destructor
@@ -721,50 +722,56 @@ void UBDesktopAnnotationController::switchCursor(const int tool)
     mTransparentDrawingView->setToolCursor(tool);
 }
 
-/**
- * \brief Reconnect the pressed & released signals of the property palettes
- */
-void UBDesktopAnnotationController::onDesktopPaletteMaximized()
-{
+void UBDesktopAnnotationController::connectButtons(){
+    if(buttonsConnected) return;
+    buttonsConnected = true;
     // Pen
     UBActionPaletteButton* pPenButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionPen);
     if(NULL != pPenButton)
     {
-        connect(pPenButton, SIGNAL(pressed()), this, SLOT(penActionPressed()));
-        connect(pPenButton, SIGNAL(released()), this, SLOT(penActionReleased()));
+        connect(pPenButton, &UBActionPaletteButton::pressed, this, &UBDesktopAnnotationController::penActionPressed);
+        connect(pPenButton, &UBActionPaletteButton::released, this, &UBDesktopAnnotationController::penActionReleased);
     }
-
     // Eraser
     UBActionPaletteButton* pEraserButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionEraser);
     if(NULL != pEraserButton)
     {
-        connect(pEraserButton, SIGNAL(pressed()), this, SLOT(eraserActionPressed()));
-        connect(pEraserButton, SIGNAL(released()), this, SLOT(eraserActionReleased()));
+        connect(pEraserButton, &UBActionPaletteButton::pressed, this, &UBDesktopAnnotationController::eraserActionPressed);
+        connect(pEraserButton, &UBActionPaletteButton::released, this, &UBDesktopAnnotationController::eraserActionReleased);
     }
 
     // Marker
     UBActionPaletteButton* pMarkerButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionMarker);
     if(NULL != pMarkerButton)
     {
-        connect(pMarkerButton, SIGNAL(pressed()), this, SLOT(markerActionPressed()));
-        connect(pMarkerButton, SIGNAL(released()), this, SLOT(markerActionReleased()));
+        connect(pMarkerButton, &UBActionPaletteButton::pressed, this, &UBDesktopAnnotationController::markerActionPressed);
+        connect(pMarkerButton, &UBActionPaletteButton::released, this, &UBDesktopAnnotationController::markerActionReleased);
     }
 
     // Pointer
     UBActionPaletteButton* pSelectorButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionSelector);
     if(NULL != pSelectorButton)
     {
-        connect(pSelectorButton, SIGNAL(pressed()), this, SLOT(selectorActionPressed()));
-        connect(pSelectorButton, SIGNAL(released()), this, SLOT(selectorActionReleased()));
+        connect(pSelectorButton, &UBActionPaletteButton::pressed, this, &UBDesktopAnnotationController::selectorActionPressed);
+        connect(pSelectorButton, &UBActionPaletteButton::released, this, &UBDesktopAnnotationController::selectorActionReleased);
     }
 
     // Pointer
     UBActionPaletteButton* pPointerButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionPointer);
     if(NULL != pPointerButton)
     {
-        connect(pPointerButton, SIGNAL(pressed()), this, SLOT(pointerActionPressed()));
-        connect(pPointerButton, SIGNAL(released()), this, SLOT(pointerActionReleased()));
+        connect(pPointerButton, &UBActionPaletteButton::pressed, this, &UBDesktopAnnotationController::pointerActionPressed);
+        connect(pPointerButton, &UBActionPaletteButton::released, this, &UBDesktopAnnotationController::pointerActionReleased);
     }
+}
+
+
+/**
+ * \brief Reconnect the pressed & released signals of the property palettes
+ */
+void UBDesktopAnnotationController::onDesktopPaletteMaximized()
+{
+    connectButtons();
 }
 
 /**
@@ -773,29 +780,6 @@ void UBDesktopAnnotationController::onDesktopPaletteMaximized()
  */
 void UBDesktopAnnotationController::onDesktopPaletteMinimize()
 {
-    // Pen
-    UBActionPaletteButton* pPenButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionPen);
-    if(NULL != pPenButton)
-    {
-        disconnect(pPenButton, SIGNAL(pressed()), this, SLOT(penActionPressed()));
-        disconnect(pPenButton, SIGNAL(released()), this, SLOT(penActionReleased()));
-    }
-
-    // Marker
-    UBActionPaletteButton* pMarkerButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionMarker);
-    if(NULL != pMarkerButton)
-    {
-        disconnect(pMarkerButton, SIGNAL(pressed()), this, SLOT(markerActionPressed()));
-        disconnect(pMarkerButton, SIGNAL(released()), this, SLOT(markerActionReleased()));
-    }
-
-    // Eraser
-    UBActionPaletteButton* pEraserButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionEraser);
-    if(NULL != pEraserButton)
-    {
-        disconnect(pEraserButton, SIGNAL(pressed()), this, SLOT(eraserActionPressed()));
-        disconnect(pEraserButton, SIGNAL(released()), this, SLOT(eraserActionReleased()));
-    }
 }
 
 void UBDesktopAnnotationController::TransparentWidgetResized()

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -122,7 +122,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     connect(UBApplication::mainWindow->actionPointer, SIGNAL(triggered()), this, SLOT(onToolClicked()));
     connect(UBApplication::mainWindow->actionSelector, SIGNAL(triggered()), this, SLOT(onToolClicked()));
     connect(mDesktopPalette, SIGNAL(maximized()), this, SLOT(onDesktopPaletteMaximized()));
-    connect(mDesktopPalette, SIGNAL(minimizeStart(eMinimizedLocation)), this, SLOT(onDesktopPaletteMinimize()));
     connect(mDesktopPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
     connect(mRightPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
     connect(mRightPalette, SIGNAL(pageSelectionChangedRequired()), this, SLOT(updateBackground()));
@@ -136,7 +135,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     mDesktopPenPalette = new UBDesktopPenPalette(mTransparentDrawingView, rightPalette); 
 
     connect(mDesktopPalette, SIGNAL(maximized()), mDesktopPenPalette, SLOT(onParentMaximized()));
-    connect(mDesktopPalette, SIGNAL(minimizeStart(eMinimizedLocation)), mDesktopPenPalette, SLOT(onParentMinimized()));
 
     mDesktopMarkerPalette = new UBDesktopMarkerPalette(mTransparentDrawingView, rightPalette);
     mDesktopEraserPalette = new UBDesktopEraserPalette(mTransparentDrawingView, rightPalette);
@@ -769,14 +767,6 @@ void UBDesktopAnnotationController::connectButtons(){
 void UBDesktopAnnotationController::onDesktopPaletteMaximized()
 {
     connectButtons();
-}
-
-/**
- * \brief Disconnect the pressed & release signals of the property palettes
- * This is done to prevent memory leaks
- */
-void UBDesktopAnnotationController::onDesktopPaletteMinimize()
-{
 }
 
 void UBDesktopAnnotationController::TransparentWidgetResized()

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -121,7 +121,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     connect(mDesktopPalette, SIGNAL(screenClick()), this, SLOT(screenCapture()));
     connect(UBApplication::mainWindow->actionPointer, SIGNAL(triggered()), this, SLOT(onToolClicked()));
     connect(UBApplication::mainWindow->actionSelector, SIGNAL(triggered()), this, SLOT(onToolClicked()));
-    connect(mDesktopPalette, SIGNAL(maximized()), this, SLOT(onDesktopPaletteMaximized()));
     connect(mDesktopPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
     connect(mRightPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
     connect(mRightPalette, SIGNAL(pageSelectionChangedRequired()), this, SLOT(updateBackground()));
@@ -167,7 +166,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     connect(UBApplication::boardController->paletteManager()->rightPalette(), SIGNAL(resized()), this, SLOT(refreshMask()));
     connect(UBApplication::boardController->paletteManager()->addItemPalette(), SIGNAL(closed()), this, SLOT(refreshMask()));
 #endif
-    onDesktopPaletteMaximized();
 
     // FIX #633: Ensure that these palettes stay on top of the other elements
     //mDesktopEraserPalette->raise();
@@ -341,6 +339,8 @@ void UBDesktopAnnotationController::showWindow()
     UBPlatformUtils::setDesktopMode(true);
 
     mDesktopPalette->appear();
+
+    connectButtons();
 
 #ifdef UB_REQUIRES_MASK_UPDATE
     updateMask(true);
@@ -760,14 +760,6 @@ void UBDesktopAnnotationController::connectButtons(){
     }
 }
 
-
-/**
- * \brief Reconnect the pressed & released signals of the property palettes
- */
-void UBDesktopAnnotationController::onDesktopPaletteMaximized()
-{
-    connectButtons();
-}
 
 void UBDesktopAnnotationController::TransparentWidgetResized()
 {

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -213,7 +213,7 @@ QPainterPath UBDesktopAnnotationController::desktopPalettePath() const
  */
 void UBDesktopAnnotationController::desktopPenActionToggled(bool checked)
 {
-    setAssociatedPalettePosition(mDesktopPenPalette, "actionPen");
+    setAssociatedPalettePosition(mDesktopPenPalette, 1);
     mDesktopPenPalette->setVisible(checked);
     mDesktopMarkerPalette->setVisible(false);
     mDesktopEraserPalette->setVisible(false);
@@ -225,7 +225,7 @@ void UBDesktopAnnotationController::desktopPenActionToggled(bool checked)
  */
 void UBDesktopAnnotationController::desktopMarkerActionToggled(bool checked)
 {
-    setAssociatedPalettePosition(mDesktopMarkerPalette, "actionMarker");
+    setAssociatedPalettePosition(mDesktopMarkerPalette, 3);
     mDesktopMarkerPalette->setVisible(checked);
     mDesktopPenPalette->setVisible(false);
     mDesktopEraserPalette->setVisible(false);
@@ -237,7 +237,7 @@ void UBDesktopAnnotationController::desktopMarkerActionToggled(bool checked)
  */
 void UBDesktopAnnotationController::desktopEraserActionToggled(bool checked)
 {
-    setAssociatedPalettePosition(mDesktopEraserPalette, "actionEraser");
+    setAssociatedPalettePosition(mDesktopEraserPalette, 2);
     mDesktopEraserPalette->setVisible(checked);
     mDesktopPenPalette->setVisible(false);
     mDesktopMarkerPalette->setVisible(false);
@@ -248,21 +248,10 @@ void UBDesktopAnnotationController::desktopEraserActionToggled(bool checked)
  * @param palette as the palette
  * @param actionName as the name of the related action
  */
-void UBDesktopAnnotationController::setAssociatedPalettePosition(UBActionPalette *palette, const QString &actionName)
+void UBDesktopAnnotationController::setAssociatedPalettePosition(UBActionPalette *palette, int index)
 {
     QPoint desktopPalettePos = mDesktopPalette->geometry().topLeft();
-    QList<QAction*> actions = mDesktopPalette->actions();
-    int yPen = 0;
-
-    foreach(QAction* act, actions)
-    {
-        if(act->objectName() == actionName)
-        {
-            int iAction = actions.indexOf(act);
-            yPen = iAction * (mDesktopPalette->buttonSize().height() + 2 * mDesktopPalette->border() +6); // This is the mysterious value (6)
-            break;
-        }
-    }
+    int yPen = index * (mDesktopPalette->buttonSize().height() + 2 * mDesktopPalette->border() +6); // This is the mysterious value (6)
 
     // First determine if the palette must be shown on the left or on the right
     if(desktopPalettePos.x() <= (mTransparentDrawingView->width() - (palette->width() + mDesktopPalette->width() + mRightPalette->width() + 20))) // we take a small margin of 20 pixels

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -303,6 +303,7 @@ void UBDesktopAnnotationController::showWindow()
             , mDesktopPalette, SLOT(setDisplaySelectButtonVisible(bool)));
 
     mDesktopPalette->show();
+    mDesktopPalette->setArrowsForPenMarkerErasor(true);
 
     bool showDisplay = UBSettings::settings()->webShowPageImmediatelyOnMirroredScreen->get().toBool();
 
@@ -399,6 +400,8 @@ void UBDesktopAnnotationController::hideWindow()
         mTransparentDrawingView->hide();
 
     mDesktopPalette->hide();
+    mDesktopPalette->setArrowsForPenMarkerErasor(false);
+
 
     mDesktopStylusTool = UBDrawingController::drawingController()->stylusTool();
     UBDrawingController::drawingController()->setStylusTool(mBoardStylusTool);

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -336,8 +336,6 @@ void UBDesktopAnnotationController::showWindow()
 
     mDesktopPalette->appear();
 
-    connectButtons();
-
 #ifdef UB_REQUIRES_MASK_UPDATE
     updateMask(true);
 #endif // UB_REQUIRES_MASK_UPDATE
@@ -526,11 +524,6 @@ void UBDesktopAnnotationController::switchCursor(const int tool)
     mTransparentDrawingScene->setToolCursor(tool);
     mTransparentDrawingView->setToolCursor(tool);
 }
-
-void UBDesktopAnnotationController::connectButtons(){
-    mDesktopPalette->connectButtons();
-}
-
 
 void UBDesktopAnnotationController::TransparentWidgetResized()
 {

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -207,40 +207,11 @@ QPainterPath UBDesktopAnnotationController::desktopPalettePath() const
     return result;
 }
 
-/**
- * \brief Toggle the visibility of the pen associated palette
- * @param checked as the visibility state
- */
-void UBDesktopAnnotationController::desktopPenActionToggled(bool checked)
-{
-    setAssociatedPalettePosition(mDesktopPenPalette, mDesktopPalette->penButtonPos());
-    mDesktopPenPalette->setVisible(checked);
-    mDesktopMarkerPalette->setVisible(false);
-    mDesktopEraserPalette->setVisible(false);
-}
-
-/**
- * \brief Toggle the visibility of the marker associated palette
- * @param checked as the visibility state
- */
-void UBDesktopAnnotationController::desktopMarkerActionToggled(bool checked)
-{
-    setAssociatedPalettePosition(mDesktopMarkerPalette, mDesktopPalette->markerButtonPos());
-    mDesktopMarkerPalette->setVisible(checked);
-    mDesktopPenPalette->setVisible(false);
-    mDesktopEraserPalette->setVisible(false);
-}
-
-/**
- * \brief Toggle the visibility of the eraser associated palette
- * @param checked as the visibility state
- */
-void UBDesktopAnnotationController::desktopEraserActionToggled(bool checked)
-{
-    setAssociatedPalettePosition(mDesktopEraserPalette, mDesktopPalette->eraserButtonPos());
-    mDesktopEraserPalette->setVisible(checked);
-    mDesktopPenPalette->setVisible(false);
-    mDesktopMarkerPalette->setVisible(false);
+void UBDesktopAnnotationController::desktopPropertyActionToggled(UBDesktopPropertyPalette* palette, QPoint pos){
+    setAssociatedPalettePosition(palette, pos);
+    mDesktopEraserPalette->setVisible(palette == mDesktopEraserPalette ? !palette->isVisible() : false);
+    mDesktopPenPalette->setVisible(palette == mDesktopPenPalette ? !palette->isVisible() : false);
+    mDesktopMarkerPalette->setVisible(palette == mDesktopMarkerPalette ? !palette->isVisible() : false);
 }
 
 /**
@@ -462,31 +433,6 @@ void UBDesktopAnnotationController::screenLayoutChanged()
     }
 }
 
-/**
- * \brief Toggle the given palette visibility
- * @param palette as the given palette
- */
-void UBDesktopAnnotationController::togglePropertyPalette(UBActionPalette *palette)
-{
-    if(NULL != palette)
-    {
-        bool bShow = !palette->isVisible();
-        if(mDesktopPenPalette == palette)
-        {
-            desktopPenActionToggled(bShow);
-        }
-        else if(mDesktopMarkerPalette == palette)
-        {
-            desktopMarkerActionToggled(bShow);
-        }
-        else if(mDesktopEraserPalette == palette)
-        {
-            desktopEraserActionToggled(bShow);
-        }
-    }
-}
-
-
 void UBDesktopAnnotationController::switchCursor(const int tool)
 {
     mTransparentDrawingScene->setToolCursor(tool);
@@ -655,11 +601,11 @@ void UBDesktopAnnotationController::hideOtherPalettes(QAction *action){
 }
 void UBDesktopAnnotationController::togglePropertyPalette(QAction * action){
     if(action == UBApplication::mainWindow->actionPen)
-        togglePropertyPalette(mDesktopPenPalette);
+        desktopPropertyActionToggled(mDesktopPenPalette, mDesktopPalette->penButtonPos());
     if(action == UBApplication::mainWindow->actionEraser)
-        togglePropertyPalette(mDesktopEraserPalette);
+        desktopPropertyActionToggled(mDesktopEraserPalette, mDesktopPalette->eraserButtonPos());
     if(action == UBApplication::mainWindow->actionMarker)
-        togglePropertyPalette(mDesktopMarkerPalette);
+        desktopPropertyActionToggled(mDesktopMarkerPalette, mDesktopPalette->markerButtonPos());
 }
 void UBDesktopAnnotationController::switchCursor(QAction * action){
     if(action == UBApplication::mainWindow->actionPen)

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -112,7 +112,7 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
 #endif
     }
 
-    connect(mDesktopPalette, SIGNAL(uniboardClick()), this, SLOT(goToUniboard()));
+    connect(mDesktopPalette, &UBDesktopPalette::uniboardClick, [](){ UBApplication::applicationController->showBoard(); });
     connect(mDesktopPalette, SIGNAL(customClick()), this, SLOT(customCapture()));
     connect(mDesktopPalette, SIGNAL(screenClick()), this, SLOT(screenCapture()));
     connect(mDesktopPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
@@ -413,13 +413,6 @@ void UBDesktopAnnotationController::hideWindow()
     mDesktopStylusTool = UBDrawingController::drawingController()->stylusTool();
     UBDrawingController::drawingController()->setStylusTool(mBoardStylusTool);
 }
-
-
-void UBDesktopAnnotationController::goToUniboard()
-{
-    UBApplication::applicationController->showBoard();
-}
-
 
 void UBDesktopAnnotationController::customCapture()
 {

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -213,7 +213,7 @@ QPainterPath UBDesktopAnnotationController::desktopPalettePath() const
  */
 void UBDesktopAnnotationController::desktopPenActionToggled(bool checked)
 {
-    setAssociatedPalettePosition(mDesktopPenPalette, 1);
+    setAssociatedPalettePosition(mDesktopPenPalette, mDesktopPalette->penButtonPos());
     mDesktopPenPalette->setVisible(checked);
     mDesktopMarkerPalette->setVisible(false);
     mDesktopEraserPalette->setVisible(false);
@@ -225,7 +225,7 @@ void UBDesktopAnnotationController::desktopPenActionToggled(bool checked)
  */
 void UBDesktopAnnotationController::desktopMarkerActionToggled(bool checked)
 {
-    setAssociatedPalettePosition(mDesktopMarkerPalette, 3);
+    setAssociatedPalettePosition(mDesktopMarkerPalette, mDesktopPalette->markerButtonPos());
     mDesktopMarkerPalette->setVisible(checked);
     mDesktopPenPalette->setVisible(false);
     mDesktopEraserPalette->setVisible(false);
@@ -237,7 +237,7 @@ void UBDesktopAnnotationController::desktopMarkerActionToggled(bool checked)
  */
 void UBDesktopAnnotationController::desktopEraserActionToggled(bool checked)
 {
-    setAssociatedPalettePosition(mDesktopEraserPalette, 2);
+    setAssociatedPalettePosition(mDesktopEraserPalette, mDesktopPalette->eraserButtonPos());
     mDesktopEraserPalette->setVisible(checked);
     mDesktopPenPalette->setVisible(false);
     mDesktopMarkerPalette->setVisible(false);
@@ -248,23 +248,16 @@ void UBDesktopAnnotationController::desktopEraserActionToggled(bool checked)
  * @param palette as the palette
  * @param actionName as the name of the related action
  */
-void UBDesktopAnnotationController::setAssociatedPalettePosition(UBActionPalette *palette, int index)
+void UBDesktopAnnotationController::setAssociatedPalettePosition(UBActionPalette *palette, QPoint pos)
 {
     QPoint desktopPalettePos = mDesktopPalette->geometry().topLeft();
-    int yPen = index * (mDesktopPalette->buttonSize().height() + 2 * mDesktopPalette->border() +6); // This is the mysterious value (6)
-
-    // First determine if the palette must be shown on the left or on the right
-    if(desktopPalettePos.x() <= (mTransparentDrawingView->width() - (palette->width() + mDesktopPalette->width() + mRightPalette->width() + 20))) // we take a small margin of 20 pixels
-    {
-        // Display it on the right
-        desktopPalettePos += QPoint(mDesktopPalette->width(), yPen);
+    desktopPalettePos += pos;
+    if(desktopPalettePos.x() <= (mTransparentDrawingView->width() - (palette->width() + mDesktopPalette->width() + mRightPalette->width() + 20))){ // we take a small margin of 20 pixels
+       desktopPalettePos += QPoint(mDesktopPalette->width() - 18, 0);
     }
-    else
-    {
-        // Display it on the left
-        desktopPalettePos += QPoint(0 - palette->width(), yPen);
+    else{
+       desktopPalettePos += QPoint(0 - palette->width() - 4, 0);
     }
-
     palette->setCustomPosition(true);
     palette->move(desktopPalettePos);
 }

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -115,8 +115,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     connect(mDesktopPalette, SIGNAL(uniboardClick()), this, SLOT(goToUniboard()));
     connect(mDesktopPalette, SIGNAL(customClick()), this, SLOT(customCapture()));
     connect(mDesktopPalette, SIGNAL(screenClick()), this, SLOT(screenCapture()));
-    connect(UBApplication::mainWindow->actionPointer, SIGNAL(triggered()), this, SLOT(onToolClicked()));
-    connect(UBApplication::mainWindow->actionSelector, SIGNAL(triggered()), this, SLOT(onToolClicked()));
     connect(mDesktopPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
     connect(mRightPalette, SIGNAL(mouseEntered()), mTransparentDrawingScene, SLOT(hideTool()));
     connect(mRightPalette, SIGNAL(pageSelectionChangedRequired()), this, SLOT(updateBackground()));
@@ -427,7 +425,7 @@ void UBDesktopAnnotationController::goToUniboard()
 
 void UBDesktopAnnotationController::customCapture()
 {
-    onToolClicked();
+    hideOtherPalettes(nullptr);
     mIsFullyTransparent = true;
     updateBackground();
 
@@ -454,7 +452,7 @@ void UBDesktopAnnotationController::customCapture()
 
 void UBDesktopAnnotationController::screenCapture()
 {
-    onToolClicked();
+    hideOtherPalettes(nullptr);
     mIsFullyTransparent = true;
     updateBackground();
 
@@ -684,13 +682,6 @@ void UBDesktopAnnotationController::refreshMask()
             updateMask(true);
         }
     }
-}
-
-void UBDesktopAnnotationController::onToolClicked()
-{
-    mDesktopEraserPalette->hide();
-    mDesktopMarkerPalette->hide();
-    mDesktopPenPalette->hide();
 }
 
 void UBDesktopAnnotationController::hideOtherPalettes(QAction *action){

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -75,7 +75,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
         , mbArrowClicked(false)
         , mBoardStylusTool(UBDrawingController::drawingController()->stylusTool())
         , mDesktopStylusTool(UBDrawingController::drawingController()->stylusTool())
-        , buttonsConnected(false)
 {
 
     mTransparentDrawingView = new UBBoardView(UBApplication::boardController, static_cast<QWidget*>(0), false, true); // deleted in UBDesktopAnnotationController::destructor
@@ -723,8 +722,6 @@ void UBDesktopAnnotationController::switchCursor(const int tool)
 }
 
 void UBDesktopAnnotationController::connectButtons(){
-    if(buttonsConnected) return;
-    buttonsConnected = true;
     // Pen
     UBActionPaletteButton* pPenButton = mDesktopPalette->getButtonFromAction(UBApplication::mainWindow->actionPen);
     if(NULL != pPenButton)

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -119,7 +119,7 @@ class UBDesktopAnnotationController : public QObject
 
     private:
 
-        void setAssociatedPalettePosition(UBActionPalette* palette, int index);
+        void setAssociatedPalettePosition(UBActionPalette* palette, QPoint pos);
         void togglePropertyPalette(UBActionPalette* palette);
         void updateMask(bool bTransparent);
 

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -129,6 +129,10 @@ class UBDesktopAnnotationController : public QObject
         void onToolClicked();
 
     private:
+
+        void connectButtons();
+        bool buttonsConnected;
+
         void setAssociatedPalettePosition(UBActionPalette* palette, const QString& actionName);
         void togglePropertyPalette(UBActionPalette* palette);
         void updateMask(bool bTransparent);

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -119,7 +119,7 @@ class UBDesktopAnnotationController : public QObject
 
     private:
 
-        void setAssociatedPalettePosition(UBActionPalette* palette, const QString& actionName);
+        void setAssociatedPalettePosition(UBActionPalette* palette, int index);
         void togglePropertyPalette(UBActionPalette* palette);
         void updateMask(bool bTransparent);
 

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -80,8 +80,6 @@ class UBDesktopAnnotationController : public QObject
         void screenCapture();
         void updateShowHideState(bool pEnabled);
 
-        void close();
-
         void stylusToolChanged(int tool);
         void updateBackground();
 

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -123,7 +123,6 @@ class UBDesktopAnnotationController : public QObject
 
         void switchCursor(int tool);
         void onDesktopPaletteMaximized();
-        void onDesktopPaletteMinimize();
         void onTransparentWidgetResized();
         void refreshMask();
         void onToolClicked();

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -39,6 +39,7 @@
 class UBDesktopPalette;
 class UBBoardView;
 class UBGraphicsScene;
+class UBDesktopPropertyPalette;
 class UBDesktopPenPalette;
 class UBDesktopMarkerPalette;
 class UBDesktopEraserPalette;
@@ -103,9 +104,8 @@ class UBDesktopAnnotationController : public QObject
 
     private slots:
         void updateColors();
-        void desktopPenActionToggled(bool checked);
-        void desktopMarkerActionToggled(bool checked);
-        void desktopEraserActionToggled(bool checked);
+        void desktopPropertyActionToggled(UBDesktopPropertyPalette* palette, QPoint pos);
+
         void eraseDesktopAnnotations();
 
         void switchCursor(int tool);
@@ -120,7 +120,6 @@ class UBDesktopAnnotationController : public QObject
     private:
 
         void setAssociatedPalettePosition(UBActionPalette* palette, QPoint pos);
-        void togglePropertyPalette(UBActionPalette* palette);
         void updateMask(bool bTransparent);
 
         UBDesktopPalette *mDesktopPalette;

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -76,7 +76,6 @@ class UBDesktopAnnotationController : public QObject
     public slots:
 
         void screenLayoutChanged();
-        void goToUniboard();
         void customCapture();
         void screenCapture();
         void updateShowHideState(bool pEnabled);

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -110,22 +110,13 @@ class UBDesktopAnnotationController : public QObject
         void desktopMarkerActionToggled(bool checked);
         void desktopEraserActionToggled(bool checked);
         void eraseDesktopAnnotations();
-        void markerActionPressed();
-        void eraserActionPressed();
-        void markerActionReleased();
-        void eraserActionReleased();
-        void selectorActionPressed();
-        void selectorActionReleased();
-        void pointerActionPressed();
-        void pointerActionReleased();
 
         void switchCursor(int tool);
         void onTransparentWidgetResized();
         void refreshMask();
         void onToolClicked();
 
-        void mDesktopMarkerPalette_hide();
-        void mDesktopEraserPalette_hide();
+        void hideOtherPalettes(QAction *);
         void togglePropertyPalette(QAction * action);
         void switchCursor(QAction * action);
 
@@ -146,20 +137,9 @@ class UBDesktopAnnotationController : public QObject
 
         UBRightPalette* mRightPalette;
 
-        QTime mPenHoldTimer;
-        QTime mMarkerHoldTimer;
-        QTime mEraserHoldTimer;
-        QTimer mHoldTimerPen;
-        QTimer mHoldTimerMarker;
-        QTimer mHoldTimerEraser;
-
         bool mWindowPositionInitialized;
         bool mIsFullyTransparent;
         bool mDesktopToolsPalettePositioned;
-        bool mPendingPenButtonPressed;
-        bool mPendingMarkerButtonPressed;
-        bool mPendingEraserButtonPressed;
-        bool mbArrowClicked;
 
         int mBoardStylusTool;
         int mDesktopStylusTool;

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -114,7 +114,6 @@ class UBDesktopAnnotationController : public QObject
         void switchCursor(int tool);
         void onTransparentWidgetResized();
         void refreshMask();
-        void onToolClicked();
 
         void hideOtherPalettes(QAction *);
         void togglePropertyPalette(QAction * action);

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -122,8 +122,6 @@ class UBDesktopAnnotationController : public QObject
 
     private:
 
-        void connectButtons();
-
         void setAssociatedPalettePosition(UBActionPalette* palette, const QString& actionName);
         void togglePropertyPalette(UBActionPalette* palette);
         void updateMask(bool bTransparent);

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -122,7 +122,6 @@ class UBDesktopAnnotationController : public QObject
         void pointerActionReleased();
 
         void switchCursor(int tool);
-        void onDesktopPaletteMaximized();
         void onTransparentWidgetResized();
         void refreshMask();
         void onToolClicked();

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -131,7 +131,6 @@ class UBDesktopAnnotationController : public QObject
     private:
 
         void connectButtons();
-        bool buttonsConnected;
 
         void setAssociatedPalettePosition(UBActionPalette* palette, const QString& actionName);
         void togglePropertyPalette(UBActionPalette* palette);

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -110,10 +110,8 @@ class UBDesktopAnnotationController : public QObject
         void desktopMarkerActionToggled(bool checked);
         void desktopEraserActionToggled(bool checked);
         void eraseDesktopAnnotations();
-        void penActionPressed();
         void markerActionPressed();
         void eraserActionPressed();
-        void penActionReleased();
         void markerActionReleased();
         void eraserActionReleased();
         void selectorActionPressed();
@@ -125,6 +123,12 @@ class UBDesktopAnnotationController : public QObject
         void onTransparentWidgetResized();
         void refreshMask();
         void onToolClicked();
+
+        void mDesktopMarkerPalette_hide();
+        void mDesktopEraserPalette_hide();
+        void togglePropertyPalette(QAction * action);
+        void switchCursor(QAction * action);
+
 
     private:
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -270,19 +270,6 @@ void UBDesktopPalette::setArrowsForPenMarkerErasor(bool arrows){
     UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
 }
 
-
-void UBDesktopPalette::showEvent(QShowEvent *event)
-{
-    Q_UNUSED(event);
-    setArrowsForPenMarkerErasor(true);
-}
-
-void UBDesktopPalette::hideEvent(QHideEvent *event)
-{
-    Q_UNUSED(event);
-    setArrowsForPenMarkerErasor(false);
-}
-
 void UBDesktopPalette::actionPressed(QToolButton* button, QAction* action, int stylusTool)
 {
     emit hideOtherPalettes(action);

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -372,6 +372,6 @@ void UBDesktopPalette::penActionReleased(QAction* action)
         pendingButton = nullptr;
     }
     action->setChecked(true);
-    emit switchCursor(UBApplication::mainWindow->actionPen);
+    emit switchCursor(action);
 }
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -87,38 +87,38 @@ void UBDesktopPalette::createAndConnectButtons(){
     addAction(mActionUniboard);
     UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
     connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(button, UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
+        actionPressed(button, UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionPen);
+        actionReleased(UBApplication::mainWindow->actionPen);
     });
     button = addAction(UBApplication::mainWindow->actionEraser);
     connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(button, UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
+        actionPressed(button, UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionEraser);
+        actionReleased(UBApplication::mainWindow->actionEraser);
     });
     button = addAction(UBApplication::mainWindow->actionMarker);
     connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(button, UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
+        actionPressed(button, UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionMarker);
+        actionReleased(UBApplication::mainWindow->actionMarker);
     });
     button = addAction(UBApplication::mainWindow->actionSelector);
     connect(button, &UBActionPaletteButton::pressed, this, [=](){
         emit hideOtherPalettes(nullptr);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionSelector);
+        actionReleased(UBApplication::mainWindow->actionSelector);
     });
     button = addAction(UBApplication::mainWindow->actionPointer);
     connect(button, &UBActionPaletteButton::pressed, this, [=](){
         emit hideOtherPalettes(nullptr);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionPointer);
+        actionReleased(UBApplication::mainWindow->actionPointer);
     });
     if (UBPlatformUtils::hasVirtualKeyboard())
         addAction(UBApplication::mainWindow->actionVirtualKeyboard);
@@ -296,7 +296,7 @@ int UBDesktopPalette::getParentRightOffset()
 void UBDesktopPalette::parentResized()
 {
     QPoint p = pos();
-    if (minimizedLocation() == eMinimizedLocation_Right)
+    if (mMinimizedLocation == eMinimizedLocation_Right)
     {
         p.setX(parentWidget()->width() - getParentRightOffset() -width());
     }
@@ -304,7 +304,7 @@ void UBDesktopPalette::parentResized()
     moveInsideParent(p);
 }
 
-void UBDesktopPalette::penActionPressed(QToolButton* button, QAction* action, int stylusTool)
+void UBDesktopPalette::actionPressed(QToolButton* button, QAction* action, int stylusTool)
 {
     emit hideOtherPalettes(action);
     UBDrawingController::drawingController()->setStylusTool(stylusTool);
@@ -331,7 +331,7 @@ void UBDesktopPalette::penActionPressed(QToolButton* button, QAction* action, in
 /**
  * \brief Handles the pen action released event
  */
-void UBDesktopPalette::penActionReleased(QAction* action)
+void UBDesktopPalette::actionReleased(QAction* action)
 {
     if(pendingButton == action)
     {

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -83,7 +83,7 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
 }
 
-void UBDesktopPalette::addActionAndConnectWithPressedReleasedEvent(QAction* action, int stylusTool, bool connectPressedEvent){
+std::function<QPoint()> UBDesktopPalette::addActionAndConnectWithPressedReleasedEvent(QAction* action, int stylusTool, bool connectPressedEvent){
     UBActionPaletteButton* button = addAction(action);
     connect(button, &UBActionPaletteButton::pressed, [=](){
         emit hideOtherPalettes(action);
@@ -93,16 +93,17 @@ void UBDesktopPalette::addActionAndConnectWithPressedReleasedEvent(QAction* acti
     connect(button, &UBActionPaletteButton::released, [=](){
         actionReleased(action);
     });
+    return [=]{return button->pos();};
 }
 
 
 
 void UBDesktopPalette::createAndConnectButtons(){  
     changeActions([&]{
-        addAction(mActionUniboard);
-        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPen, UBStylusTool::Pen, true);
-        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser, true);
-        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker, true);
+        addAction(mActionUniboard);       
+        penButtonPos = addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPen, UBStylusTool::Pen, true);
+        eraserButtonPos = addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser, true);
+        markerButtonPos = addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker, true);
         addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionSelector);
         addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPointer);
         if (UBPlatformUtils::hasVirtualKeyboard())

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -174,6 +174,54 @@ void UBDesktopPalette::minimizeMe()
 #endif
 }
 
+void UBDesktopPalette::minimizePalette(const QPoint& pos)
+{
+    if(!mCanBeMinimized)
+    {
+        //  If this floating palette cannot be minimized, we exit this method.
+    return;
+    }
+
+    if(mMinimizedLocation == eMinimizedLocation_None)
+    {
+    //  Verify if we have to minimize this palette
+    if(pos.x() == 5)
+    {
+        mMinimizedLocation = eMinimizedLocation_Left;
+    }
+//    else if(pos.y() == 5)
+//    {
+//        mMinimizedLocation = eMinimizedLocation_Top;
+//    }
+    else if(pos.x() == parentWidget()->width() - getParentRightOffset() - width() - 5)
+    {
+        mMinimizedLocation = eMinimizedLocation_Right;
+    }
+//    else if(pos.y() == parentSize.height() - height() - 5)
+//    {
+//        mMinimizedLocation = eMinimizedLocation_Bottom;
+//    }
+
+    //  Minimize the Palette
+    if(mMinimizedLocation != eMinimizedLocation_None)
+    {
+        minimizeMe();
+    }
+    }
+    else
+    {
+    //  Restore the palette
+    if(pos.x() > 5 &&
+       pos.y() > 5 &&
+       pos.x() < parentWidget()->width() - getParentRightOffset()  - width() - 5 &&
+       pos.y() < parentWidget()->size().height() - height() - 5)
+    {
+        mMinimizedLocation = eMinimizedLocation_None;
+        emit maximizeStart();
+    }
+    }
+}
+
 //  Called when the user wants to maximize the palette
 void UBDesktopPalette::maximizeMe()
 {

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -52,7 +52,6 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     , mMinimizedLocation(eMinimizedLocation_None)
     , pendingButton(nullptr)
 {
-    QList<QAction*> actions;
 
     mActionUniboard = new QAction(QIcon(":/images/toolbar/board.png"), tr("Show OpenBoard"), this);
     connect(mActionUniboard, SIGNAL(triggered()), this, SIGNAL(uniboardClick()));
@@ -72,7 +71,6 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     connect(mShowHideAction, SIGNAL(triggered(bool)), this, SLOT(showHideClick(bool)));
 
     createAndConnectButtons();
-    setActions(actions);
     setButtonIconSize(QSize(42, 42));
 
     adjustSizeAndPosition();
@@ -128,6 +126,8 @@ void UBDesktopPalette::createAndConnectButtons(){
     addAction(mActionCustomSelect);
     addAction(mDisplaySelectAction);
     addAction(mShowHideAction);
+
+    actionChanged();
 }
 
 UBDesktopPalette::~UBDesktopPalette()
@@ -183,10 +183,8 @@ void UBDesktopPalette::setDisplaySelectButtonVisible(bool visible)
 //  Called when the palette is near the border and must be minimized
 void UBDesktopPalette::minimizeMe()
 {
-    QList<QAction*> actions;
     clearLayout();
 
-    actions << mMaximizeAction;
     mMapActionToButton.clear();
     addAction(mMaximizeAction);
     actionChanged();
@@ -244,12 +242,10 @@ void UBDesktopPalette::minimizePalette(const QPoint& pos)
 //  Called when the user wants to maximize the palette
 void UBDesktopPalette::maximizeMe()
 {
-    QList<QAction*> actions;
     clearLayout();
 
     createAndConnectButtons();
 
-    setActions(actions);
 
     adjustSizeAndPosition();
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -102,16 +102,6 @@ UBDesktopPalette::~UBDesktopPalette()
 
 }
 
-
-void UBDesktopPalette::adjustPosition()
-{
-    QPoint pos = this->pos();
-    if(this->pos().y() < 30){
-        pos.setY(30);
-        moveInsideParent(pos);
-    }
-}
-
 void UBDesktopPalette::disappearForCapture()
 {
     setWindowOpacity(0.0);
@@ -261,8 +251,6 @@ void UBDesktopPalette::showEvent(QShowEvent *event)
     eraserIcon.addFile(":images/stylusPalette/eraserArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
     eraserIcon.addFile(":images/stylusPalette/eraserOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
     UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
-
-    adjustPosition();
 }
 
 void UBDesktopPalette::hideEvent(QHideEvent *event)

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -56,15 +56,12 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
 
     mActionUniboard = new QAction(QIcon(":/images/toolbar/board.png"), tr("Show OpenBoard"), this);
     connect(mActionUniboard, SIGNAL(triggered()), this, SIGNAL(uniboardClick()));
-    createAndConnectButtons();
 
     mActionCustomSelect = new QAction(QIcon(":/images/toolbar/captureArea.png"), tr("Capture Part of the Screen"), this);
     connect(mActionCustomSelect, SIGNAL(triggered()), this, SIGNAL(customClick()));
-    actions << mActionCustomSelect;
 
     mDisplaySelectAction = new QAction(QIcon(":/images/toolbar/captureScreen.png"), tr("Capture the Screen"), this);
     connect(mDisplaySelectAction, SIGNAL(triggered()), this, SIGNAL(screenClick()));
-    actions << mDisplaySelectAction;
 
     QIcon showHideIcon;
     showHideIcon.addPixmap(QPixmap(":/images/toolbar/eyeOpened.png"), QIcon::Normal , QIcon::On);
@@ -73,8 +70,8 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     mShowHideAction->setCheckable(true);
 
     connect(mShowHideAction, SIGNAL(triggered(bool)), this, SLOT(showHideClick(bool)));
-    actions << mShowHideAction;
 
+    createAndConnectButtons();
     setActions(actions);
     setButtonIconSize(QSize(42, 42));
 
@@ -128,7 +125,9 @@ void UBDesktopPalette::createAndConnectButtons(){
     });
     if (UBPlatformUtils::hasVirtualKeyboard())
         addAction(UBApplication::mainWindow->actionVirtualKeyboard);
-
+    addAction(mActionCustomSelect);
+    addAction(mDisplaySelectAction);
+    addAction(mShowHideAction);
 }
 
 UBDesktopPalette::~UBDesktopPalette()
@@ -249,11 +248,6 @@ void UBDesktopPalette::maximizeMe()
     clearLayout();
 
     createAndConnectButtons();
-
-    actions << mActionCustomSelect;
-    actions << mDisplaySelectAction;
-    actions << mShowHideAction;
-
 
     setActions(actions);
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -94,7 +94,6 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     maximizeIcon.addPixmap(QPixmap(":/images/toolbar/stylusTab.png"), QIcon::Normal, QIcon::On);
     mMaximizeAction = new QAction(maximizeIcon, tr("Show the stylus palette"), this);
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
-    mCanBeMinimized = true;
 }
 
 
@@ -176,11 +175,6 @@ void UBDesktopPalette::minimizeMe()
 
 void UBDesktopPalette::minimizePalette(const QPoint& pos)
 {
-    if(!mCanBeMinimized)
-    {
-        //  If this floating palette cannot be minimized, we exit this method.
-    return;
-    }
 
     if(mMinimizedLocation == eMinimizedLocation_None)
     {

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -49,6 +49,7 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     , mShowHideAction(NULL)
     , mDisplaySelectAction(NULL)
     , rightPalette(_rightPalette)
+    , mMinimizedLocation(eMinimizedLocation_None)
 {
     QList<QAction*> actions;
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -95,7 +95,7 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     mMaximizeAction = new QAction(maximizeIcon, tr("Show the stylus palette"), this);
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
     connect(this, SIGNAL(maximizeStart()), this, SLOT(maximizeMe()));
-    setMinimizePermission(true);
+    mCanBeMinimized = true;
 }
 
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -56,10 +56,15 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
 
     mActionUniboard = new QAction(QIcon(":/images/toolbar/board.png"), tr("Show OpenBoard"), this);
     connect(mActionUniboard, SIGNAL(triggered()), this, SIGNAL(uniboardClick()));
-    actions << mActionUniboard;
-
-
-    actions << UBApplication::mainWindow->actionPen;
+    mMapActionToButton.clear();
+    addAction(mActionUniboard);
+    UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
+    connect(button, &UBActionPaletteButton::pressed, [=](){
+        penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionPen);
+    });
     actions << UBApplication::mainWindow->actionEraser;
     actions << UBApplication::mainWindow->actionMarker;
     actions << UBApplication::mainWindow->actionSelector;
@@ -155,7 +160,9 @@ void UBDesktopPalette::minimizeMe()
     clearLayout();
 
     actions << mMaximizeAction;
-    setActions(actions);
+    mMapActionToButton.clear();
+    addAction(mMaximizeAction);
+    actionChanged();
 
     adjustSizeAndPosition();
 
@@ -213,8 +220,15 @@ void UBDesktopPalette::maximizeMe()
     QList<QAction*> actions;
     clearLayout();
 
-    actions << mActionUniboard;
-    actions << UBApplication::mainWindow->actionPen;
+    mMapActionToButton.clear();
+    addAction(mActionUniboard);
+    UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
+    connect(button, &UBActionPaletteButton::pressed, [=](){
+        penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionPen);
+    });
     actions << UBApplication::mainWindow->actionEraser;
     actions << UBApplication::mainWindow->actionMarker;
     actions << UBApplication::mainWindow->actionSelector;
@@ -225,6 +239,7 @@ void UBDesktopPalette::maximizeMe()
     actions << mActionCustomSelect;
     actions << mDisplaySelectAction;
     actions << mShowHideAction;
+
 
     setActions(actions);
 
@@ -347,17 +362,6 @@ void UBDesktopPalette::penActionReleased(QAction* action)
 }
 
 void UBDesktopPalette::connectButtons(){
-    // Pen
-    UBActionPaletteButton* pPenButton = getButtonFromAction(UBApplication::mainWindow->actionPen);
-    if(NULL != pPenButton)
-    {
-        connect(pPenButton, &UBActionPaletteButton::pressed, [=](){
-            penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
-        });
-        connect(pPenButton, &UBActionPaletteButton::released, [=](){
-            penActionReleased(UBApplication::mainWindow->actionPen);
-        });
-    }
     // Eraser
     UBActionPaletteButton* pEraserButton = getButtonFromAction(UBApplication::mainWindow->actionEraser);
     if(NULL != pEraserButton)

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -293,17 +293,6 @@ int UBDesktopPalette::getParentRightOffset()
     return rightPalette->width();
 }
 
-void UBDesktopPalette::parentResized()
-{
-    QPoint p = pos();
-    if (mMinimizedLocation == eMinimizedLocation_Right)
-    {
-        p.setX(parentWidget()->width() - getParentRightOffset() -width());
-    }
-
-    moveInsideParent(p);
-}
-
 void UBDesktopPalette::actionPressed(QToolButton* button, QAction* action, int stylusTool)
 {
     emit hideOtherPalettes(action);

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -255,38 +255,32 @@ void UBDesktopPalette::maximizeMe()
 #endif
 }
 
-void UBDesktopPalette::showEvent(QShowEvent *event)
-{
-    Q_UNUSED(event);
+void UBDesktopPalette::setArrowsForPenMarkerErasor(bool arrows){
     QIcon penIcon;
     QIcon markerIcon;
     QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/penArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
+    penIcon.addFile(arrows ? ":images/stylusPalette/penArrow.svg" : ":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
+    penIcon.addFile(arrows ? ":images/stylusPalette/penOnArrow.svg" : ":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
     UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/markerArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
+    markerIcon.addFile(arrows ? ":images/stylusPalette/markerArrow.svg" : ":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
+    markerIcon.addFile(arrows ? ":images/stylusPalette/markerOnArrow.svg" : ":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
     UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraserArrow.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOnArrow.svg", QSize(), QIcon::Normal, QIcon::On);
+    eraserIcon.addFile(arrows ? ":images/stylusPalette/eraserArrow.svg" : ":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
+    eraserIcon.addFile(arrows ? ":images/stylusPalette/eraserOnArrow.svg" : ":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
     UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
+}
+
+
+void UBDesktopPalette::showEvent(QShowEvent *event)
+{
+    Q_UNUSED(event);
+    setArrowsForPenMarkerErasor(true);
 }
 
 void UBDesktopPalette::hideEvent(QHideEvent *event)
 {
     Q_UNUSED(event);
-    QIcon penIcon;
-    QIcon markerIcon;
-    QIcon eraserIcon;
-    penIcon.addFile(":images/stylusPalette/pen.svg", QSize(), QIcon::Normal, QIcon::Off);
-    penIcon.addFile(":images/stylusPalette/penOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionPen->setIcon(penIcon);
-    markerIcon.addFile(":images/stylusPalette/marker.svg", QSize(), QIcon::Normal, QIcon::Off);
-    markerIcon.addFile(":images/stylusPalette/markerOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionMarker->setIcon(markerIcon);
-    eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
-    eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
-    UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
+    setArrowsForPenMarkerErasor(false);
 }
 
 void UBDesktopPalette::actionPressed(QToolButton* button, QAction* action, int stylusTool)

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -48,10 +48,11 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     : UBActionPalette(Qt::TopLeftCorner, parent)
     , mShowHideAction(NULL)
     , mDisplaySelectAction(NULL)
-    , rightPalette(_rightPalette)
     , mMinimizedLocation(eMinimizedLocation_None)
     , pendingButton(nullptr)
 {
+
+    getParentRightOffset = [_rightPalette]{return _rightPalette->width();};
 
     mActionUniboard = new QAction(QIcon(":/images/toolbar/board.png"), tr("Show OpenBoard"), this);
     connect(mActionUniboard, SIGNAL(triggered()), this, SIGNAL(uniboardClick()));
@@ -286,11 +287,6 @@ void UBDesktopPalette::hideEvent(QHideEvent *event)
     eraserIcon.addFile(":images/stylusPalette/eraser.svg", QSize(), QIcon::Normal, QIcon::Off);
     eraserIcon.addFile(":images/stylusPalette/eraserOn.svg", QSize(), QIcon::Normal, QIcon::On);
     UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
-}
-
-int UBDesktopPalette::getParentRightOffset()
-{
-    return rightPalette->width();
 }
 
 void UBDesktopPalette::actionPressed(QToolButton* button, QAction* action, int stylusTool)

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -83,50 +83,32 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
 }
 
+void UBDesktopPalette::addActionAndConnectWithPressedReleasedEvent(QAction* action, int stylusTool, bool connectPressedEvent){
+    UBActionPaletteButton* button = addAction(action);
+    connect(button, &UBActionPaletteButton::pressed, [=](){
+        emit hideOtherPalettes(action);
+        if (connectPressedEvent)
+            actionPressed(button, action, stylusTool);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        actionReleased(action);
+    });
+}
 
-void UBDesktopPalette::createAndConnectButtons(){
+
+
+void UBDesktopPalette::createAndConnectButtons(){  
     addAction(mActionUniboard);
-    UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
-    connect(button, &UBActionPaletteButton::pressed, [=](){
-        actionPressed(button, UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        actionReleased(UBApplication::mainWindow->actionPen);
-    });
-    button = addAction(UBApplication::mainWindow->actionEraser);
-    connect(button, &UBActionPaletteButton::pressed, [=](){
-        actionPressed(button, UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        actionReleased(UBApplication::mainWindow->actionEraser);
-    });
-    button = addAction(UBApplication::mainWindow->actionMarker);
-    connect(button, &UBActionPaletteButton::pressed, [=](){
-        actionPressed(button, UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        actionReleased(UBApplication::mainWindow->actionMarker);
-    });
-    button = addAction(UBApplication::mainWindow->actionSelector);
-    connect(button, &UBActionPaletteButton::pressed, this, [=](){
-        emit hideOtherPalettes(nullptr);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        actionReleased(UBApplication::mainWindow->actionSelector);
-    });
-    button = addAction(UBApplication::mainWindow->actionPointer);
-    connect(button, &UBActionPaletteButton::pressed, this, [=](){
-        emit hideOtherPalettes(nullptr);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        actionReleased(UBApplication::mainWindow->actionPointer);
-    });
+    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPen, UBStylusTool::Pen, true);
+    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser, true);
+    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker, true);
+    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionSelector);
+    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPointer);
     if (UBPlatformUtils::hasVirtualKeyboard())
         addAction(UBApplication::mainWindow->actionVirtualKeyboard);
     addAction(mActionCustomSelect);
     addAction(mDisplaySelectAction);
     addAction(mShowHideAction);
-
     actionChanged();
 }
 
@@ -272,7 +254,6 @@ void UBDesktopPalette::setArrowsForPenMarkerErasor(bool arrows){
 
 void UBDesktopPalette::actionPressed(QToolButton* button, QAction* action, int stylusTool)
 {
-    emit hideOtherPalettes(action);
     UBDrawingController::drawingController()->setStylusTool(stylusTool);
     mButtonHoldTimer = QTime::currentTime();
     pendingButton = action;

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -84,25 +84,24 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
 
 
 void UBDesktopPalette::createAndConnectButtons(){
-    mMapActionToButton.clear();
     addAction(mActionUniboard);
     UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
     connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
+        penActionPressed(button, UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
         penActionReleased(UBApplication::mainWindow->actionPen);
     });
     button = addAction(UBApplication::mainWindow->actionEraser);
     connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
+        penActionPressed(button, UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
         penActionReleased(UBApplication::mainWindow->actionEraser);
     });
     button = addAction(UBApplication::mainWindow->actionMarker);
     connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
+        penActionPressed(button, UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
     });
     connect(button, &UBActionPaletteButton::released, [=](){
         penActionReleased(UBApplication::mainWindow->actionMarker);
@@ -185,7 +184,6 @@ void UBDesktopPalette::minimizeMe()
 {
     clearLayout();
 
-    mMapActionToButton.clear();
     addAction(mMaximizeAction);
     actionChanged();
 
@@ -290,20 +288,6 @@ void UBDesktopPalette::hideEvent(QHideEvent *event)
     UBApplication::mainWindow->actionEraser->setIcon(eraserIcon);
 }
 
-QPoint UBDesktopPalette::buttonPos(QAction *action)
-{
-    QPoint p;
-
-    UBActionPaletteButton* pB = mMapActionToButton[action];
-    if(NULL != pB)
-    {
-        p = pB->pos();
-    }
-
-    return p;
-}
-
-
 int UBDesktopPalette::getParentRightOffset()
 {
     return rightPalette->width();
@@ -320,7 +304,7 @@ void UBDesktopPalette::parentResized()
     moveInsideParent(p);
 }
 
-void UBDesktopPalette::penActionPressed(QAction* action, int stylusTool)
+void UBDesktopPalette::penActionPressed(QToolButton* button, QAction* action, int stylusTool)
 {
     emit hideOtherPalettes(action);
     UBDrawingController::drawingController()->setStylusTool(stylusTool);
@@ -330,7 +314,7 @@ void UBDesktopPalette::penActionPressed(QAction* action, int stylusTool)
     // Check if the mouse cursor is on the little arrow
     QPoint cursorPos = QCursor::pos();
     QPoint palettePos = mapToGlobal(QPoint(0, 0));  // global coordinates of palette
-    QPoint clickedButtonPos = buttonPos(action);
+    QPoint clickedButtonPos = button->pos();
 
     int iX = cursorPos.x() - (palettePos.x() + clickedButtonPos.x());    // x position of the cursor in the palette
     int iY = cursorPos.y() - (palettePos.y() + clickedButtonPos.y());    // y position of the cursor in the palette

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -385,6 +385,9 @@ void UBDesktopPalette::connectButtons(){
     UBActionPaletteButton* pSelectorButton = getButtonFromAction(UBApplication::mainWindow->actionSelector);
     if(NULL != pSelectorButton)
     {
+        connect(pSelectorButton, &UBActionPaletteButton::pressed, this, [=](){
+            emit hideOtherPalettes(nullptr);
+        });
         connect(pSelectorButton, &UBActionPaletteButton::released, [=](){
             penActionReleased(UBApplication::mainWindow->actionSelector);
         });
@@ -394,6 +397,9 @@ void UBDesktopPalette::connectButtons(){
     UBActionPaletteButton* pPointerButton = getButtonFromAction(UBApplication::mainWindow->actionPointer);
     if(NULL != pPointerButton)
     {
+        connect(pPointerButton, &UBActionPaletteButton::pressed, this, [=](){
+            emit hideOtherPalettes(nullptr);
+        });
         connect(pPointerButton, &UBActionPaletteButton::released, [=](){
             penActionReleased(UBApplication::mainWindow->actionPointer);
         });

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -94,7 +94,6 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     maximizeIcon.addPixmap(QPixmap(":/images/toolbar/stylusTab.png"), QIcon::Normal, QIcon::On);
     mMaximizeAction = new QAction(maximizeIcon, tr("Show the stylus palette"), this);
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
-    connect(this, SIGNAL(maximizeStart()), this, SLOT(maximizeMe()));
     mCanBeMinimized = true;
 }
 
@@ -218,7 +217,7 @@ void UBDesktopPalette::minimizePalette(const QPoint& pos)
        pos.y() < parentWidget()->size().height() - height() - 5)
     {
         mMinimizedLocation = eMinimizedLocation_None;
-        emit maximizeStart();
+        maximizeMe();
     }
     }
 }

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -46,8 +46,8 @@
 
 UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalette)
     : UBActionPalette(Qt::TopLeftCorner, parent)
-    , mShowHideAction(NULL)
     , mDisplaySelectAction(NULL)
+    , mShowHideAction(NULL)
     , mMinimizedLocation(eMinimizedLocation_None)
     , pendingButton(nullptr)
 {

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -56,22 +56,7 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
 
     mActionUniboard = new QAction(QIcon(":/images/toolbar/board.png"), tr("Show OpenBoard"), this);
     connect(mActionUniboard, SIGNAL(triggered()), this, SIGNAL(uniboardClick()));
-    mMapActionToButton.clear();
-    addAction(mActionUniboard);
-    UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
-    connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionPen);
-    });
-    actions << UBApplication::mainWindow->actionEraser;
-    actions << UBApplication::mainWindow->actionMarker;
-    actions << UBApplication::mainWindow->actionSelector;
-    actions << UBApplication::mainWindow->actionPointer;
-
-    if (UBPlatformUtils::hasVirtualKeyboard())
-        actions << UBApplication::mainWindow->actionVirtualKeyboard;
+    createAndConnectButtons();
 
     mActionCustomSelect = new QAction(QIcon(":/images/toolbar/captureArea.png"), tr("Capture Part of the Screen"), this);
     connect(mActionCustomSelect, SIGNAL(triggered()), this, SIGNAL(customClick()));
@@ -102,6 +87,49 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
 }
 
+
+void UBDesktopPalette::createAndConnectButtons(){
+    mMapActionToButton.clear();
+    addAction(mActionUniboard);
+    UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
+    connect(button, &UBActionPaletteButton::pressed, [=](){
+        penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionPen);
+    });
+    button = addAction(UBApplication::mainWindow->actionEraser);
+    connect(button, &UBActionPaletteButton::pressed, [=](){
+        penActionPressed(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionEraser);
+    });
+    button = addAction(UBApplication::mainWindow->actionMarker);
+    connect(button, &UBActionPaletteButton::pressed, [=](){
+        penActionPressed(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionMarker);
+    });
+    button = addAction(UBApplication::mainWindow->actionSelector);
+    connect(button, &UBActionPaletteButton::pressed, this, [=](){
+        emit hideOtherPalettes(nullptr);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionSelector);
+    });
+    button = addAction(UBApplication::mainWindow->actionPointer);
+    connect(button, &UBActionPaletteButton::pressed, this, [=](){
+        emit hideOtherPalettes(nullptr);
+    });
+    connect(button, &UBActionPaletteButton::released, [=](){
+        penActionReleased(UBApplication::mainWindow->actionPointer);
+    });
+    if (UBPlatformUtils::hasVirtualKeyboard())
+        addAction(UBApplication::mainWindow->actionVirtualKeyboard);
+
+}
 
 UBDesktopPalette::~UBDesktopPalette()
 {
@@ -220,21 +248,7 @@ void UBDesktopPalette::maximizeMe()
     QList<QAction*> actions;
     clearLayout();
 
-    mMapActionToButton.clear();
-    addAction(mActionUniboard);
-    UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionPen);
-    connect(button, &UBActionPaletteButton::pressed, [=](){
-        penActionPressed(UBApplication::mainWindow->actionPen, UBStylusTool::Pen);
-    });
-    connect(button, &UBActionPaletteButton::released, [=](){
-        penActionReleased(UBApplication::mainWindow->actionPen);
-    });
-    actions << UBApplication::mainWindow->actionEraser;
-    actions << UBApplication::mainWindow->actionMarker;
-    actions << UBApplication::mainWindow->actionSelector;
-    actions << UBApplication::mainWindow->actionPointer;
-    if (UBPlatformUtils::hasVirtualKeyboard())
-        actions << UBApplication::mainWindow->actionVirtualKeyboard;
+    createAndConnectButtons();
 
     actions << mActionCustomSelect;
     actions << mDisplaySelectAction;
@@ -359,55 +373,5 @@ void UBDesktopPalette::penActionReleased(QAction* action)
     }
     action->setChecked(true);
     emit switchCursor(UBApplication::mainWindow->actionPen);
-}
-
-void UBDesktopPalette::connectButtons(){
-    // Eraser
-    UBActionPaletteButton* pEraserButton = getButtonFromAction(UBApplication::mainWindow->actionEraser);
-    if(NULL != pEraserButton)
-    {
-        connect(pEraserButton, &UBActionPaletteButton::pressed, [=](){
-            penActionPressed(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
-        });
-        connect(pEraserButton, &UBActionPaletteButton::released, [=](){
-            penActionReleased(UBApplication::mainWindow->actionEraser);
-        });
-    }
-
-    // Marker
-    UBActionPaletteButton* pMarkerButton = getButtonFromAction(UBApplication::mainWindow->actionMarker);
-    if(NULL != pMarkerButton)
-    {
-        connect(pMarkerButton, &UBActionPaletteButton::pressed, [=](){
-            penActionPressed(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
-        });
-        connect(pMarkerButton, &UBActionPaletteButton::released, [=](){
-            penActionReleased(UBApplication::mainWindow->actionMarker);
-        });
-    }
-    // Pointer
-    UBActionPaletteButton* pSelectorButton = getButtonFromAction(UBApplication::mainWindow->actionSelector);
-    if(NULL != pSelectorButton)
-    {
-        connect(pSelectorButton, &UBActionPaletteButton::pressed, this, [=](){
-            emit hideOtherPalettes(nullptr);
-        });
-        connect(pSelectorButton, &UBActionPaletteButton::released, [=](){
-            penActionReleased(UBApplication::mainWindow->actionSelector);
-        });
-    }
-
-    // Pointer
-    UBActionPaletteButton* pPointerButton = getButtonFromAction(UBApplication::mainWindow->actionPointer);
-    if(NULL != pPointerButton)
-    {
-        connect(pPointerButton, &UBActionPaletteButton::pressed, this, [=](){
-            emit hideOtherPalettes(nullptr);
-        });
-        connect(pPointerButton, &UBActionPaletteButton::released, [=](){
-            penActionReleased(UBApplication::mainWindow->actionPointer);
-        });
-    }
-
 }
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -94,10 +94,7 @@ UBDesktopPalette::UBDesktopPalette(QWidget *parent, UBRightPalette* _rightPalett
     mMaximizeAction = new QAction(maximizeIcon, tr("Show the stylus palette"), this);
     connect(mMaximizeAction, SIGNAL(triggered()), this, SLOT(maximizeMe()));
     connect(this, SIGNAL(maximizeStart()), this, SLOT(maximizeMe()));
-    connect(this, SIGNAL(minimizeStart(eMinimizedLocation)), this, SLOT(minimizeMe(eMinimizedLocation)));
     setMinimizePermission(true);
-
-    connect(rightPalette, SIGNAL(resized()), this, SLOT(parentResized()));
 }
 
 
@@ -162,9 +159,8 @@ void UBDesktopPalette::setDisplaySelectButtonVisible(bool visible)
 }
 
 //  Called when the palette is near the border and must be minimized
-void UBDesktopPalette::minimizeMe(eMinimizedLocation location)
+void UBDesktopPalette::minimizeMe()
 {
-    Q_UNUSED(location);
     QList<QAction*> actions;
     clearLayout();
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -98,18 +98,19 @@ void UBDesktopPalette::addActionAndConnectWithPressedReleasedEvent(QAction* acti
 
 
 void UBDesktopPalette::createAndConnectButtons(){  
-    addAction(mActionUniboard);
-    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPen, UBStylusTool::Pen, true);
-    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser, true);
-    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker, true);
-    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionSelector);
-    addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPointer);
-    if (UBPlatformUtils::hasVirtualKeyboard())
-        addAction(UBApplication::mainWindow->actionVirtualKeyboard);
-    addAction(mActionCustomSelect);
-    addAction(mDisplaySelectAction);
-    addAction(mShowHideAction);
-    actionChanged();
+    changeActions([&]{
+        addAction(mActionUniboard);
+        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPen, UBStylusTool::Pen, true);
+        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser, true);
+        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker, true);
+        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionSelector);
+        addActionAndConnectWithPressedReleasedEvent(UBApplication::mainWindow->actionPointer);
+        if (UBPlatformUtils::hasVirtualKeyboard())
+            addAction(UBApplication::mainWindow->actionVirtualKeyboard);
+        addAction(mActionCustomSelect);
+        addAction(mDisplaySelectAction);
+        addAction(mShowHideAction);
+    });
 }
 
 UBDesktopPalette::~UBDesktopPalette()
@@ -167,8 +168,9 @@ void UBDesktopPalette::minimizeMe()
 {
     clearLayout();
 
-    addAction(mMaximizeAction);
-    actionChanged();
+    changeActions([&]{
+        addAction(mMaximizeAction);
+    });
 
     adjustSizeAndPosition();
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -303,8 +303,7 @@ void UBDesktopPalette::parentResized()
 
 void UBDesktopPalette::penActionPressed(QAction* action, int stylusTool)
 {
-    emit mDesktopMarkerPalette_hide();
-    emit mDesktopEraserPalette_hide();
+    emit hideOtherPalettes(action);
     UBDrawingController::drawingController()->setStylusTool(stylusTool);
     mButtonHoldTimer = QTime::currentTime();
     pendingButton = action;
@@ -324,10 +323,6 @@ void UBDesktopPalette::penActionPressed(QAction* action, int stylusTool)
         // We must switch the cursor. For some reason this works correctly even without this:
         // emit switchCursor_Pen();
     }
-    Todo: Funktioniert soweit. Nächste Schritte:
-        1. Andere buttons
-        2. _hide events generisch
-        3. togglePropertyPalette reagiert noch nicht generisch
 }
 
 /**
@@ -351,7 +346,6 @@ void UBDesktopPalette::penActionReleased(QAction* action)
     emit switchCursor(UBApplication::mainWindow->actionPen);
 }
 
-
 void UBDesktopPalette::connectButtons(){
     // Pen
     UBActionPaletteButton* pPenButton = getButtonFromAction(UBApplication::mainWindow->actionPen);
@@ -364,4 +358,46 @@ void UBDesktopPalette::connectButtons(){
             penActionReleased(UBApplication::mainWindow->actionPen);
         });
     }
+    // Eraser
+    UBActionPaletteButton* pEraserButton = getButtonFromAction(UBApplication::mainWindow->actionEraser);
+    if(NULL != pEraserButton)
+    {
+        connect(pEraserButton, &UBActionPaletteButton::pressed, [=](){
+            penActionPressed(UBApplication::mainWindow->actionEraser, UBStylusTool::Eraser);
+        });
+        connect(pEraserButton, &UBActionPaletteButton::released, [=](){
+            penActionReleased(UBApplication::mainWindow->actionEraser);
+        });
+    }
+
+    // Marker
+    UBActionPaletteButton* pMarkerButton = getButtonFromAction(UBApplication::mainWindow->actionMarker);
+    if(NULL != pMarkerButton)
+    {
+        connect(pMarkerButton, &UBActionPaletteButton::pressed, [=](){
+            penActionPressed(UBApplication::mainWindow->actionMarker, UBStylusTool::Marker);
+        });
+        connect(pMarkerButton, &UBActionPaletteButton::released, [=](){
+            penActionReleased(UBApplication::mainWindow->actionMarker);
+        });
+    }
+    // Pointer
+    UBActionPaletteButton* pSelectorButton = getButtonFromAction(UBApplication::mainWindow->actionSelector);
+    if(NULL != pSelectorButton)
+    {
+        connect(pSelectorButton, &UBActionPaletteButton::released, [=](){
+            penActionReleased(UBApplication::mainWindow->actionSelector);
+        });
+    }
+
+    // Pointer
+    UBActionPaletteButton* pPointerButton = getButtonFromAction(UBApplication::mainWindow->actionPointer);
+    if(NULL != pPointerButton)
+    {
+        connect(pPointerButton, &UBActionPaletteButton::released, [=](){
+            penActionReleased(UBApplication::mainWindow->actionPointer);
+        });
+    }
+
 }
+

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -52,6 +52,11 @@ class UBDesktopPalette : public UBActionPalette
         void disappearForCapture();
         void appear();
 
+        std::function<QPoint()> penButtonPos;
+        std::function<QPoint()> eraserButtonPos;
+        std::function<QPoint()> markerButtonPos;
+
+
  // The following actions are owned by UBDesktopPalette and therefore we have to produce signals for them.
         QAction *mActionUniboard;
         QAction *mActionCustomSelect;
@@ -99,7 +104,7 @@ class UBDesktopPalette : public UBActionPalette
         QAction *pendingButton;
         QTime mButtonHoldTimer;
 
-        void addActionAndConnectWithPressedReleasedEvent(QAction* action, int stylusTool = 0, bool connectPressedEvent = false);
+        std::function<QPoint()> addActionAndConnectWithPressedReleasedEvent(QAction* action, int stylusTool = 0, bool connectPressedEvent = false);
         void createAndConnectButtons();
 
         void actionPressed(QToolButton* button, QAction* action, int stylusTool);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -106,6 +106,7 @@ private:
         void actionPressed(QToolButton* button, QAction* action, int stylusTool);
         void actionReleased(QAction* action);
 
+        void setArrowsForPenMarkerErasor(bool arrors);
 signals:
         void hideOtherPalettes(QAction *);
         void togglePropertyPalette(QAction *);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -66,7 +66,6 @@ class UBDesktopPalette : public UBActionPalette
         void updateShowHideState(bool pShowEnabled);
         void setShowHideButtonVisible(bool visible);
         void setDisplaySelectButtonVisible(bool show);
-        void minimizeMe(eMinimizedLocation location);
         void maximizeMe();
         void parentResized();
 
@@ -88,6 +87,7 @@ private:
         UBRightPalette* rightPalette;
         void adjustPosition();
 
+        virtual void minimizeMe();
 
 signals:
         void stylusToolChanged(int tool);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -73,16 +73,12 @@ protected:
         void showEvent(QShowEvent *event);
         void hideEvent(QHideEvent *event);
 
-        virtual int getParentRightOffset();
-
 private:
         QAction *mShowHideAction;
         QAction *mDisplaySelectAction;
         QAction *mMaximizeAction;
         QAction *mActionUniboard;
         QAction *mActionCustomSelect;
-
-        UBRightPalette* rightPalette;
 
         eMinimizedLocation mMinimizedLocation;
 

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -99,6 +99,7 @@ class UBDesktopPalette : public UBActionPalette
         QAction *pendingButton;
         QTime mButtonHoldTimer;
 
+        void addActionAndConnectWithPressedReleasedEvent(QAction* action, int stylusTool = 0, bool connectPressedEvent = false);
         void createAndConnectButtons();
 
         void actionPressed(QToolButton* button, QAction* action, int stylusTool);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -87,6 +87,7 @@ private:
         UBRightPalette* rightPalette;
         void adjustPosition();
 
+        virtual void minimizePalette(const QPoint& pos);
         virtual void minimizeMe();
 
 signals:

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -68,7 +68,6 @@ class UBDesktopPalette : public UBActionPalette
         void setShowHideButtonVisible(bool visible);
         void setDisplaySelectButtonVisible(bool show);
         void maximizeMe();
-        void parentResized();
 
 protected:
         void showEvent(QShowEvent *event);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -86,11 +86,9 @@ class UBDesktopPalette : public UBActionPalette
         void setShowHideButtonVisible(bool visible);
         void setDisplaySelectButtonVisible(bool show);
 
-protected:
-        void showEvent(QShowEvent *event);
-        void hideEvent(QHideEvent *event);
+        void setArrowsForPenMarkerErasor(bool showAarrows);
 
-private:
+    private:
 
         eMinimizedLocation mMinimizedLocation;
 
@@ -106,7 +104,6 @@ private:
         void actionPressed(QToolButton* button, QAction* action, int stylusTool);
         void actionReleased(QAction* action);
 
-        void setArrowsForPenMarkerErasor(bool showAarrows);
 signals:
         void hideOtherPalettes(QAction *);
         void togglePropertyPalette(QAction *);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -53,8 +53,6 @@ class UBDesktopPalette : public UBActionPalette
         void appear();
         QPoint buttonPos(QAction* action);
 
-        void connectButtons();
-
     signals:
         void uniboardClick();
         void customClick();
@@ -99,6 +97,8 @@ private:
 
         QAction *pendingButton;
         QTime mButtonHoldTimer;
+
+        void createAndConnectButtons();
 
 private slots:
         void penActionPressed(QAction* action, int stylusTool);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -85,7 +85,6 @@ private:
 
 
         UBRightPalette* rightPalette;
-        void adjustPosition();
 
         eMinimizedLocation minimizedLocation(){return mMinimizedLocation;}
         eMinimizedLocation mMinimizedLocation;

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -106,7 +106,7 @@ private:
         void actionPressed(QToolButton* button, QAction* action, int stylusTool);
         void actionReleased(QAction* action);
 
-        void setArrowsForPenMarkerErasor(bool arrors);
+        void setArrowsForPenMarkerErasor(bool showAarrows);
 signals:
         void hideOtherPalettes(QAction *);
         void togglePropertyPalette(QAction *);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -52,33 +52,45 @@ class UBDesktopPalette : public UBActionPalette
         void disappearForCapture();
         void appear();
 
+ // The following actions are owned by UBDesktopPalette and therefore we have to produce signals for them.
+        QAction *mActionUniboard;
+        QAction *mActionCustomSelect;
+        QAction *mDisplaySelectAction;
+
     signals:
         void uniboardClick();
         void customClick();
         void screenClick();
 
+// The following actions are owned by UBDesktopPalette. But they are handled internally in UBDesktopPalette.
+// Therefore slots exist. UBDesktopPalette does not emit signals for them.
+
+    private:
+
+        QAction *mMaximizeAction;
+        QAction *mShowHideAction;
+
+    public slots:
+
+        void showHideClick(bool checked);
+        void maximizeMe();
+
+    signals:
 //#ifdef Q_OS_LINUX //TODO: check why this produces an error on linux if uncommented
         void refreshMask();
 //#endif
 
     public slots:
 
-        void showHideClick(bool checked);
         void updateShowHideState(bool pShowEnabled);
         void setShowHideButtonVisible(bool visible);
         void setDisplaySelectButtonVisible(bool show);
-        void maximizeMe();
 
 protected:
         void showEvent(QShowEvent *event);
         void hideEvent(QHideEvent *event);
 
 private:
-        QAction *mShowHideAction;
-        QAction *mDisplaySelectAction;
-        QAction *mMaximizeAction;
-        QAction *mActionUniboard;
-        QAction *mActionCustomSelect;
 
         eMinimizedLocation mMinimizedLocation;
 
@@ -91,7 +103,6 @@ private:
 
         void createAndConnectButtons();
 
-private slots:
         void actionPressed(QToolButton* button, QAction* action, int stylusTool);
         void actionReleased(QAction* action);
 

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -82,12 +82,9 @@ private:
         QAction *mMaximizeAction;
         QAction *mActionUniboard;
         QAction *mActionCustomSelect;
-        QAction* mActionTest;
-
 
         UBRightPalette* rightPalette;
 
-        eMinimizedLocation minimizedLocation(){return mMinimizedLocation;}
         eMinimizedLocation mMinimizedLocation;
 
 
@@ -100,8 +97,8 @@ private:
         void createAndConnectButtons();
 
 private slots:
-        void penActionPressed(QToolButton* button, QAction* action, int stylusTool);
-        void penActionReleased(QAction* action);
+        void actionPressed(QToolButton* button, QAction* action, int stylusTool);
+        void actionReleased(QAction* action);
 
 signals:
         void hideOtherPalettes(QAction *);

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -36,6 +36,8 @@
 #include "gui/UBActionPalette.h"
 #include "gui/UBRightPalette.h"
 
+#define PROPERTY_PALETTE_TIMER      1000
+
 /**
  * The uninotes window. This window is controlled by UBUninotesWindowController.
  */
@@ -50,6 +52,8 @@ class UBDesktopPalette : public UBActionPalette
         void disappearForCapture();
         void appear();
         QPoint buttonPos(QAction* action);
+
+        void connectButtons();
 
     signals:
         void uniboardClick();
@@ -93,7 +97,20 @@ private:
         virtual void minimizePalette(const QPoint& pos);
         virtual void minimizeMe();
 
+        QAction *pendingButton;
+        QTime mButtonHoldTimer;
+
+private slots:
+        void penActionPressed(QAction* action, int stylusTool);
+        void penActionReleased(QAction* action);
+
 signals:
+        void mDesktopMarkerPalette_hide();
+        void mDesktopEraserPalette_hide();
+        void togglePropertyPalette(QAction *);
+        void switchCursor(QAction *);
+
+
         void stylusToolChanged(int tool);
 
 };

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -87,6 +87,10 @@ private:
         UBRightPalette* rightPalette;
         void adjustPosition();
 
+        eMinimizedLocation minimizedLocation(){return mMinimizedLocation;}
+        eMinimizedLocation mMinimizedLocation;
+
+
         virtual void minimizePalette(const QPoint& pos);
         virtual void minimizeMe();
 

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -105,8 +105,7 @@ private slots:
         void penActionReleased(QAction* action);
 
 signals:
-        void mDesktopMarkerPalette_hide();
-        void mDesktopEraserPalette_hide();
+        void hideOtherPalettes(QAction *);
         void togglePropertyPalette(QAction *);
         void switchCursor(QAction *);
 

--- a/src/desktop/UBDesktopPalette.h
+++ b/src/desktop/UBDesktopPalette.h
@@ -51,7 +51,6 @@ class UBDesktopPalette : public UBActionPalette
 
         void disappearForCapture();
         void appear();
-        QPoint buttonPos(QAction* action);
 
     signals:
         void uniboardClick();
@@ -101,7 +100,7 @@ private:
         void createAndConnectButtons();
 
 private slots:
-        void penActionPressed(QAction* action, int stylusTool);
+        void penActionPressed(QToolButton* button, QAction* action, int stylusTool);
         void penActionReleased(QAction* action);
 
 signals:

--- a/src/desktop/UBDesktopPropertyPalette.cpp
+++ b/src/desktop/UBDesktopPropertyPalette.cpp
@@ -39,14 +39,9 @@
 
 UBDesktopPropertyPalette::UBDesktopPropertyPalette(QWidget *parent, UBRightPalette* _rightPalette)
     :UBPropertyPalette(Qt::Horizontal, parent)
-    ,rightPalette(_rightPalette)
-{}
-
-int UBDesktopPropertyPalette::getParentRightOffset()
 {
-    return rightPalette->width();
+    getParentRightOffset = [_rightPalette]{return _rightPalette->width();};
 }
-
 
 UBDesktopPenPalette::UBDesktopPenPalette(QWidget *parent, UBRightPalette* rightPalette)
     : UBDesktopPropertyPalette(parent, rightPalette)

--- a/src/desktop/UBDesktopPropertyPalette.h
+++ b/src/desktop/UBDesktopPropertyPalette.h
@@ -43,10 +43,6 @@ class UBDesktopPropertyPalette : public UBPropertyPalette
 
     public:
         UBDesktopPropertyPalette(QWidget *parent, UBRightPalette* _rightPalette);
-    private:
-        UBRightPalette* rightPalette;
-    protected:
-        virtual int getParentRightOffset();
 };
 
 class UBDesktopPenPalette : public UBDesktopPropertyPalette

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -82,8 +82,6 @@ void UBActionPalette::init(Qt::Orientation orientation)
 
 void UBActionPalette::setActions(QList<QAction*> actions)
 {
-    mMapActionToButton.clear();
-
     foreach(QAction* action, actions)
     {
         addAction(action);
@@ -114,13 +112,15 @@ UBActionPaletteButton* UBActionPalette::createPaletteButton(QAction* action, QWi
     return button;
 }
 
-void UBActionPalette::addAction(QAction* action)
+UBActionPaletteButton* UBActionPalette::addAction(QAction* action)
 {
     UBActionPaletteButton* button = createPaletteButton(action, this);
 
     layout()->addWidget(button);
 
     mActions << action;
+
+    return button;
 }
 
 void UBActionPalette::buttonClicked()

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -32,14 +32,6 @@
 
 #include "core/memcheck.h"
 
-UBActionPalette::UBActionPalette(QList<QAction*> actions, Qt::Orientation orientation, QWidget * parent)
-    : UBFloatingPalette(Qt::TopRightCorner, parent)
-{
-    init(orientation);
-    setActions(actions);
-}
-
-
 UBActionPalette::UBActionPalette(Qt::Orientation orientation, QWidget * parent)
      : UBFloatingPalette(Qt::TopRightCorner, parent)
 {
@@ -79,17 +71,6 @@ void UBActionPalette::init(Qt::Orientation orientation)
 
     updateLayout();
 }
-
-void UBActionPalette::setActions(QList<QAction*> actions)
-{
-    foreach(QAction* action, actions)
-    {
-        addAction(action);
-    }
-
-    actionChanged();
-}
-
 
 UBActionPaletteButton* UBActionPalette::createPaletteButton(QAction* action, QWidget *parent)
 {

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -78,9 +78,6 @@ UBActionPaletteButton* UBActionPalette::createPaletteButton(QAction* action, QWi
     button->setIconSize(mButtonSize);
     button->setToolButtonStyle(mToolButtonStyle);
 
-    if (mButtonGroup)
-        mButtonGroup->addButton(button, mButtons.length());
-
     mButtons << button;
 
     connect(button, &UBActionPaletteButton::clicked,
@@ -91,9 +88,12 @@ UBActionPaletteButton* UBActionPalette::createPaletteButton(QAction* action, QWi
     return button;
 }
 
-UBActionPaletteButton* UBActionPalette::addAction(QAction* action)
+UBActionPaletteButton* UBActionPalette::addAction(QAction* action, bool exclusive)
 {
     UBActionPaletteButton* button = createPaletteButton(action, this);
+
+    if (mButtonGroup && exclusive)
+        mButtonGroup->addButton(button, mButtons.length());
 
     layout()->addWidget(button);
 
@@ -130,19 +130,6 @@ void UBActionPalette::setButtonIconSize(const QSize& size)
 
     mButtonSize = size;
 }
-
-
-void UBActionPalette::groupActions()
-{
-    mButtonGroup = new QButtonGroup(this);
-    int i = 0;
-    foreach(QToolButton* button, mButtons)
-    {
-        mButtonGroup->addButton(button, i);
-        ++i;
-    }
-}
-
 
 void UBActionPalette::setToolButtonStyle(Qt::ToolButtonStyle tbs)
 {

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -102,8 +102,6 @@ UBActionPaletteButton* UBActionPalette::createPaletteButton(QAction* action, QWi
 
     mButtons << button;
 
-    mMapActionToButton[action] = button;
-
     connect(button, &UBActionPaletteButton::clicked,
             this, &UBActionPalette::buttonClicked);
     connect(action, &QAction::changed,

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -110,12 +110,6 @@ void UBActionPalette::buttonClicked()
     }
 }
 
-QList<QAction*> UBActionPalette::actions()
-{
-    return mActions;
-}
-
-
 UBActionPalette::~UBActionPalette()
 {
     qDeleteAll(mButtons.begin(), mButtons.end());

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -160,8 +160,6 @@ void UBActionPalette::groupActions()
         mButtonGroup->addButton(button, i);
         ++i;
     }
-
-    connect(mButtonGroup, SIGNAL(buttonClicked(int)), this, SIGNAL(buttonGroupClicked(int)));
 }
 
 

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -305,19 +305,6 @@ QSize UBActionPalette::buttonSize()
     return mButtonSize;
 }
 
-/**
- * \brief Returns the button related to the given action
- * @param action as the given action
- */
-UBActionPaletteButton* UBActionPalette::getButtonFromAction(QAction *action)
-{
-    UBActionPaletteButton* pButton = NULL;
-
-    pButton = mMapActionToButton.value(action);
-
-    return pButton;
-}
-
 bool UBActionPaletteButton::hitButton(const QPoint &pos) const
 {
     Q_UNUSED(pos);

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -81,7 +81,6 @@ class UBActionPalette : public UBFloatingPalette
 
     signals:
         void closed();
-        void buttonGroupClicked(int id);
         void customMouseReleased();
 
     protected:

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -94,7 +94,6 @@ class UBActionPalette : public UBFloatingPalette
         QList<UBActionPaletteButton*> mButtons;
         QButtonGroup* mButtonGroup;
         QList<QAction*> mActions;
-        QMap<QAction*, UBActionPaletteButton*> mMapActionToButton;
 
         bool mIsClosable;
         Qt::ToolButtonStyle mToolButtonStyle;

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -44,7 +44,6 @@ class UBActionPalette : public UBFloatingPalette
     Q_OBJECT;
 
     public:
-        UBActionPalette(QList<QAction*> actions, Qt::Orientation orientation = Qt::Vertical, QWidget* parent = 0);
         UBActionPalette(Qt::Orientation orientation, QWidget* parent = 0);
         UBActionPalette(Qt::Corner corner, QWidget* parent = 0, Qt::Orientation orient = Qt::Vertical);
         UBActionPalette(QWidget* parent = 0);
@@ -54,8 +53,15 @@ class UBActionPalette : public UBFloatingPalette
         void setButtonIconSize(const QSize& size);
         void setToolButtonStyle(Qt::ToolButtonStyle);
 
+     // todo (C++ 20):
+     // void changeActions(auto& codeBlock);
+        template <typename F>
+        void changeActions(F codeBlock){
+            codeBlock();
+            actionChanged();
+        }
+
         QList<QAction*> actions();
-        virtual void setActions(QList<QAction*> actions);
         void groupActions();
         virtual UBActionPaletteButton* addAction(QAction* action);
 

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -56,14 +56,15 @@ class UBActionPalette : public UBFloatingPalette
      // todo (C++ 20):
      // void changeActions(auto& codeBlock);
         template <typename F>
-        void changeActions(F codeBlock){
+        void changeActions(F codeBlock, bool makeExclusive = false){
+            if (makeExclusive)
+                mButtonGroup = new QButtonGroup();
             codeBlock();
             actionChanged();
         }
 
         QList<QAction*> actions();
-        void groupActions();
-        virtual UBActionPaletteButton* addAction(QAction* action);
+        virtual UBActionPaletteButton* addAction(QAction* action, bool exclusive = true);
 
         void setClosable(bool closable);
         void setAutoClose(bool autoClose)

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -63,7 +63,6 @@ class UBActionPalette : public UBFloatingPalette
             actionChanged();
         }
 
-        QList<QAction*> actions();
         virtual UBActionPaletteButton* addAction(QAction* action, bool exclusive = true);
 
         void setClosable(bool closable);

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -75,8 +75,6 @@ class UBActionPalette : public UBFloatingPalette
         virtual void clearLayout();
         QSize buttonSize();
 
-        virtual UBActionPaletteButton* getButtonFromAction(QAction* action);
-
     public slots:
         void close();
 

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -57,7 +57,7 @@ class UBActionPalette : public UBFloatingPalette
         QList<QAction*> actions();
         virtual void setActions(QList<QAction*> actions);
         void groupActions();
-        virtual void addAction(QAction* action);
+        virtual UBActionPaletteButton* addAction(QAction* action);
 
         void setClosable(bool closable);
         void setAutoClose(bool autoClose)

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -2,14 +2,6 @@
 
 #include "gui/UBMainWindow.h"
 
-UBBackgroundPalette::UBBackgroundPalette(QList<QAction*> actions, QWidget * parent)
-    : UBActionPalette(parent)
-{
-    init();
-    setActions(actions);
-}
-
-
 UBBackgroundPalette::UBBackgroundPalette(QWidget * parent)
      : UBActionPalette(parent)
 {

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -88,8 +88,6 @@ UBActionPaletteButton* UBBackgroundPalette::addAction(QAction* action)
 
 void UBBackgroundPalette::setActions(QList<QAction*> actions)
 {
-    mMapActionToButton.clear();
-
     foreach(QAction* action, actions)
     {
         addAction(action);

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -77,12 +77,13 @@ void UBBackgroundPalette::init()
     updateLayout();
 }
 
-void UBBackgroundPalette::addAction(QAction* action)
+UBActionPaletteButton* UBBackgroundPalette::addAction(QAction* action)
 {
     UBActionPaletteButton* button = createPaletteButton(action, this);
 
     mTopLayout->addWidget(button);
     mActions << action;
+    return button;
 }
 
 void UBBackgroundPalette::setActions(QList<QAction*> actions)

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -86,16 +86,6 @@ UBActionPaletteButton* UBBackgroundPalette::addAction(QAction* action)
     return button;
 }
 
-void UBBackgroundPalette::setActions(QList<QAction*> actions)
-{
-    foreach(QAction* action, actions)
-    {
-        addAction(action);
-    }
-
-    actionChanged();
-}
-
 void UBBackgroundPalette::updateLayout()
 {
     if (mToolButtonStyle == Qt::ToolButtonIconOnly) {

--- a/src/gui/UBBackgroundPalette.h
+++ b/src/gui/UBBackgroundPalette.h
@@ -12,7 +12,6 @@ class UBBackgroundPalette : public UBActionPalette
 
     public:
 
-        UBBackgroundPalette(QList<QAction*> actions, QWidget* parent = 0);
         UBBackgroundPalette(QWidget* parent = 0);
 
         UBActionPaletteButton* addAction(QAction *action);

--- a/src/gui/UBBackgroundPalette.h
+++ b/src/gui/UBBackgroundPalette.h
@@ -15,7 +15,7 @@ class UBBackgroundPalette : public UBActionPalette
         UBBackgroundPalette(QList<QAction*> actions, QWidget* parent = 0);
         UBBackgroundPalette(QWidget* parent = 0);
 
-        void addAction(QAction *action);
+        UBActionPaletteButton* addAction(QAction *action);
         void setActions(QList<QAction *> actions);
         void clearLayout();
 

--- a/src/gui/UBBackgroundPalette.h
+++ b/src/gui/UBBackgroundPalette.h
@@ -16,7 +16,6 @@ class UBBackgroundPalette : public UBActionPalette
         UBBackgroundPalette(QWidget* parent = 0);
 
         UBActionPaletteButton* addAction(QAction *action);
-        void setActions(QList<QAction *> actions);
         void clearLayout();
 
 

--- a/src/gui/UBDocumentToolsPalette.cpp
+++ b/src/gui/UBDocumentToolsPalette.cpp
@@ -42,12 +42,10 @@
 UBDocumentToolsPalette::UBDocumentToolsPalette(QWidget *parent)
     : UBActionPalette(Qt::TopRightCorner, parent)
 {
-    QList<QAction*> actions;
-
-    if (UBPlatformUtils::hasVirtualKeyboard())
-        actions << UBApplication::mainWindow->actionVirtualKeyboard;
-
-    setActions(actions);
+    changeActions([&]{
+       if (UBPlatformUtils::hasVirtualKeyboard())
+            addAction(UBApplication::mainWindow->actionVirtualKeyboard);
+    });
     setButtonIconSize(QSize(42, 42));
 
     adjustSizeAndPosition();

--- a/src/gui/UBFavoriteToolPalette.cpp
+++ b/src/gui/UBFavoriteToolPalette.cpp
@@ -116,7 +116,9 @@ UBFavoriteToolPalette::UBFavoriteToolPalette(QWidget* parent)
 
     foreach(QAction* action, toolsActions)
     {
+        mButtonGroup = new QButtonGroup();
         UBActionPaletteButton* button = createPaletteButton(action, container);
+        mButtonGroup->addButton(button);
         gridLayout->addWidget(button, i / 4, i % 4);
         mActions << action;
         i++;
@@ -125,8 +127,6 @@ UBFavoriteToolPalette::UBFavoriteToolPalette(QWidget* parent)
     setClosable(true);
     setButtonIconSize(QSize(128, 128));
     setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
-    groupActions();
 }
 
 

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -126,7 +126,8 @@ void UBFloatingPalette::mouseMoveEvent(QMouseEvent *event)
 {
     if (mIsMoving)
     {
-        moveInsideParent(event->globalPos() - mDragPosition, true);
+        moveInsideParent(event->globalPos() - mDragPosition);
+        minimizePalette(pos());
         event->accept();
         emit moving();
     }
@@ -155,7 +156,7 @@ int UBFloatingPalette::getParentRightOffset()
     return 0;
 }
 
-void UBFloatingPalette::moveInsideParent(const QPoint &position, bool shrinkIfAtBorder)
+void UBFloatingPalette::moveInsideParent(const QPoint &position)
 {
     QWidget *parent = parentWidget();
 
@@ -177,8 +178,6 @@ void UBFloatingPalette::moveInsideParent(const QPoint &position, bool shrinkIfAt
             }
         }
         move(newX, newY);
-        if(shrinkIfAtBorder)
-            minimizePalette(QPoint(newX, newY));
     }
     else
     {

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -42,7 +42,6 @@ UBFloatingPalette::UBFloatingPalette(Qt::Corner position, QWidget *parent)
     : QWidget(parent, parent ? Qt::Widget : Qt::Tool | (Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint))
     , mCustomPosition(false)
     , mIsMoving(false)
-    , mCanBeMinimized(false)
     , mDefaultPosition(position)
 {
     setCursor(Qt::ArrowCursor);
@@ -127,7 +126,7 @@ void UBFloatingPalette::mouseMoveEvent(QMouseEvent *event)
 {
     if (mIsMoving)
     {
-        moveInsideParent(event->globalPos() - mDragPosition);
+        moveInsideParent(event->globalPos() - mDragPosition, true);
         event->accept();
         emit moving();
     }
@@ -156,7 +155,7 @@ int UBFloatingPalette::getParentRightOffset()
     return 0;
 }
 
-void UBFloatingPalette::moveInsideParent(const QPoint &position)
+void UBFloatingPalette::moveInsideParent(const QPoint &position, bool shrinkIfAtBorder)
 {
     QWidget *parent = parentWidget();
 
@@ -178,7 +177,8 @@ void UBFloatingPalette::moveInsideParent(const QPoint &position)
             }
         }
         move(newX, newY);
-        minimizePalette(QPoint(newX, newY));
+        if(shrinkIfAtBorder)
+            minimizePalette(QPoint(newX, newY));
     }
     else
     {

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -284,54 +284,6 @@ int UBFloatingPalette::gripSize()
     return 5;
 }
 
-void UBFloatingPalette::minimizePalette(const QPoint& pos)
-{
-    if(!mCanBeMinimized)
-    {
-        //  If this floating palette cannot be minimized, we exit this method.
-    return;
-    }
-
-    if(mMinimizedLocation == eMinimizedLocation_None)
-    {
-    //  Verify if we have to minimize this palette
-    if(pos.x() == 5)
-    {
-        mMinimizedLocation = eMinimizedLocation_Left;
-    }
-//    else if(pos.y() == 5)
-//    {
-//        mMinimizedLocation = eMinimizedLocation_Top;
-//    }
-    else if(pos.x() == parentWidget()->width() - getParentRightOffset() - width() - 5)
-    {
-        mMinimizedLocation = eMinimizedLocation_Right;
-    }
-//    else if(pos.y() == parentSize.height() - height() - 5)
-//    {
-//        mMinimizedLocation = eMinimizedLocation_Bottom;
-//    }
-
-    //  Minimize the Palette
-    if(mMinimizedLocation != eMinimizedLocation_None)
-    {
-        minimizeMe();
-    }
-    }
-    else
-    {
-    //  Restore the palette
-    if(pos.x() > 5 &&
-       pos.y() > 5 &&
-       pos.x() < parentWidget()->width() - getParentRightOffset()  - width() - 5 &&
-       pos.y() < parentWidget()->size().height() - height() - 5)
-    {
-        mMinimizedLocation = eMinimizedLocation_None;
-        emit maximizeStart();
-    }
-    }
-}
-
 void UBFloatingPalette::setMinimizePermission(bool permission)
 {
     mCanBeMinimized = permission;

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -89,10 +89,6 @@ void UBFloatingPalette::setBackgroundBrush(const QBrush& brush)
 void UBFloatingPalette::setCustomPosition(bool pFlag)
 {
     mCustomPosition = pFlag;
-
-    if (pFlag)
-        removeAllAssociatedPalette();
-
 }
 
 int UBFloatingPalette::radius()
@@ -190,16 +186,6 @@ void UBFloatingPalette::moveInsideParent(const QPoint &position)
     }
 }
 
-void UBFloatingPalette::addAssociatedPalette(UBFloatingPalette* pOtherPalette)
-{
-    mAssociatedPalette.append(pOtherPalette);
-}
-
-void UBFloatingPalette::removeAssociatedPalette(UBFloatingPalette* pOtherPalette)
-{
-    mAssociatedPalette.removeOne(pOtherPalette);
-}
-
 QSize UBFloatingPalette::preferredSize()
 {
     QSize palettePreferredSize = sizeHint();
@@ -216,11 +202,6 @@ void UBFloatingPalette::adjustSizeAndPosition(bool pUp)
 {
     QSize newPreferredSize = preferredSize();
 
-    foreach (UBFloatingPalette* palette, mAssociatedPalette)
-    {
-        QSize palettePreferredSize = palette->preferredSize();
-        newPreferredSize.setWidth(newPreferredSize.expandedTo(palettePreferredSize).width());
-    }
     QSize previousSize = size();
     int biggerHeight = preferredSize().height() - previousSize.height();
     if ((pUp && (biggerHeight > 0))
@@ -233,20 +214,6 @@ void UBFloatingPalette::adjustSizeAndPosition(bool pUp)
     {
         resize(newPreferredSize);
         moveInsideParent(pos());
-        foreach(UBFloatingPalette* palette, mAssociatedPalette)
-        {
-            palette->move(pos().x(), palette->pos().y());
-            palette->resize(newPreferredSize.width(), palette->size().height());
-        }
-    }
-}
-
-void UBFloatingPalette::removeAllAssociatedPalette()
-{
-    foreach (UBFloatingPalette* palette, mAssociatedPalette)
-    {
-        palette->removeAssociatedPalette(this);
-        removeAssociatedPalette(palette);
     }
 }
 

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -282,8 +282,3 @@ int UBFloatingPalette::gripSize()
 {
     return 5;
 }
-
-void UBFloatingPalette::setMinimizePermission(bool permission)
-{
-    mCanBeMinimized = permission;
-}

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -198,14 +198,14 @@ QSize UBFloatingPalette::preferredSize()
     return palettePreferredSize;
 }
 
-void UBFloatingPalette::adjustSizeAndPosition(bool pUp)
+void UBFloatingPalette::adjustSizeAndPosition(bool alignUp)
 {
     QSize newPreferredSize = preferredSize();
 
     QSize previousSize = size();
     int biggerHeight = preferredSize().height() - previousSize.height();
-    if ((pUp && (biggerHeight > 0))
-        || (!pUp && (biggerHeight < 0)))
+    if ((alignUp && (biggerHeight > 0))
+        || (!alignUp && (biggerHeight < 0)))
     {
         move(pos().x(), pos().y() - biggerHeight);
     }

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -315,7 +315,7 @@ void UBFloatingPalette::minimizePalette(const QPoint& pos)
     //  Minimize the Palette
     if(mMinimizedLocation != eMinimizedLocation_None)
     {
-        emit minimizeStart(mMinimizedLocation);
+        minimizeMe();
     }
     }
     else

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -43,7 +43,6 @@ UBFloatingPalette::UBFloatingPalette(Qt::Corner position, QWidget *parent)
     , mCustomPosition(false)
     , mIsMoving(false)
     , mCanBeMinimized(false)
-    , mMinimizedLocation(eMinimizedLocation_None)
     , mDefaultPosition(position)
 {
     setCursor(Qt::ArrowCursor);

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -42,6 +42,7 @@ UBFloatingPalette::UBFloatingPalette(Qt::Corner position, QWidget *parent)
     : QWidget(parent, parent ? Qt::Widget : Qt::Tool | (Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint))
     , mCustomPosition(false)
     , mIsMoving(false)
+    , getParentRightOffset([]{return 0;})
     , mDefaultPosition(position)
 {
     setCursor(Qt::ArrowCursor);
@@ -149,11 +150,6 @@ void UBFloatingPalette::mouseReleaseEvent(QMouseEvent *event)
     {
         QWidget::mouseReleaseEvent(event);
     }
-}
-
-int UBFloatingPalette::getParentRightOffset()
-{
-    return 0;
 }
 
 void UBFloatingPalette::moveInsideParent(const QPoint &position)

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -70,8 +70,6 @@ class UBFloatingPalette : public QWidget
         void setBackgroundBrush(const QBrush& brush);
         void setGrip(bool newGrip);
 
-        void setMinimizePermission(bool permission);
-
     protected:
 
         virtual void enterEvent(QEvent *event);

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -103,7 +103,6 @@ class UBFloatingPalette : public QWidget
 
     signals:
         void mouseEntered();
-        void maximizeStart();
         void maximized();
         void moving();
 };

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -54,13 +54,6 @@ class UBFloatingPalette : public QWidget
         virtual void mousePressEvent(QMouseEvent *event);
         virtual void mouseReleaseEvent(QMouseEvent *event);
 
-        /**
-         * Add another floating palette to the associated palette. All associated palettes will have the same width
-         * that is calculated as the minimum width of all associated palettes.
-         */
-        void addAssociatedPalette(UBFloatingPalette* pOtherPalette);
-        void removeAssociatedPalette(UBFloatingPalette* pOtherPalette);
-
         virtual void adjustSizeAndPosition(bool pUp = true);
 
         void setCustomPosition(bool pFlag);
@@ -92,12 +85,9 @@ class UBFloatingPalette : public QWidget
         bool mCanBeMinimized;
 
     private:
-        void removeAllAssociatedPalette();
         virtual void minimizePalette(const QPoint& pos){Q_UNUSED(pos)};
         virtual void minimizeMe(){};
 
-
-        QList<UBFloatingPalette*> mAssociatedPalette;
         QPoint mDragPosition;
         Qt::Corner mDefaultPosition;
 

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -54,7 +54,14 @@ class UBFloatingPalette : public QWidget
         virtual void mousePressEvent(QMouseEvent *event);
         virtual void mouseReleaseEvent(QMouseEvent *event);
 
-        virtual void adjustSizeAndPosition(bool pUp = true);
+        /**
+         * @brief adjustSizeAndPosition adjusts the size of the palette. In case it is within a parent
+         * widget, the size must be within the parent widget.
+         * @param alignUp This is a special function that controls what happens if the height changes.
+         * If in this case alignUp is true, the palette is moved up. If alignUp is false, the palette
+         * is moved down.
+         */
+        virtual void adjustSizeAndPosition(bool alignUp = true);
 
         void setCustomPosition(bool pFlag);
 

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -93,17 +93,17 @@ class UBFloatingPalette : public QWidget
         virtual int getParentRightOffset();
 
         eMinimizedLocation minimizedLocation(){return mMinimizedLocation;}
+        bool mCanBeMinimized;
+        eMinimizedLocation mMinimizedLocation;
 
     private:
         void removeAllAssociatedPalette();
-        void minimizePalette(const QPoint& pos);
+        virtual void minimizePalette(const QPoint& pos){Q_UNUSED(pos)};
         virtual void minimizeMe(){};
 
 
         QList<UBFloatingPalette*> mAssociatedPalette;
         QPoint mDragPosition;
-        bool mCanBeMinimized;
-        eMinimizedLocation mMinimizedLocation;
         Qt::Corner mDefaultPosition;
 
     signals:

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -84,12 +84,11 @@ class UBFloatingPalette : public QWidget
         bool mbGrip;
         static const int sLayoutContentMargin = 12;
         static const int sLayoutSpacing = 15;
-        void moveInsideParent(const QPoint &position);
+        void moveInsideParent(const QPoint &position, bool shrinkIfAtBorder = false);
         bool mCustomPosition;
         bool mIsMoving;
 
         virtual int getParentRightOffset();
-        bool mCanBeMinimized;
 
     private:
         virtual void minimizePalette(const QPoint& pos){Q_UNUSED(pos)};

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -97,6 +97,8 @@ class UBFloatingPalette : public QWidget
     private:
         void removeAllAssociatedPalette();
         void minimizePalette(const QPoint& pos);
+        virtual void minimizeMe(){};
+
 
         QList<UBFloatingPalette*> mAssociatedPalette;
         QPoint mDragPosition;
@@ -106,7 +108,6 @@ class UBFloatingPalette : public QWidget
 
     signals:
         void mouseEntered();
-        void minimizeStart(eMinimizedLocation location);
         void maximizeStart();
         void maximized();
         void moving();

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -84,7 +84,7 @@ class UBFloatingPalette : public QWidget
         bool mbGrip;
         static const int sLayoutContentMargin = 12;
         static const int sLayoutSpacing = 15;
-        void moveInsideParent(const QPoint &position, bool shrinkIfAtBorder = false);
+        void moveInsideParent(const QPoint &position);
         bool mCustomPosition;
         bool mIsMoving;
 

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -88,7 +88,7 @@ class UBFloatingPalette : public QWidget
         bool mCustomPosition;
         bool mIsMoving;
 
-        virtual int getParentRightOffset();
+        std::function<int()> getParentRightOffset;
 
     private:
         virtual void minimizePalette(const QPoint& pos){Q_UNUSED(pos)};

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -91,10 +91,7 @@ class UBFloatingPalette : public QWidget
         bool mIsMoving;
 
         virtual int getParentRightOffset();
-
-        eMinimizedLocation minimizedLocation(){return mMinimizedLocation;}
         bool mCanBeMinimized;
-        eMinimizedLocation mMinimizedLocation;
 
     private:
         void removeAllAssociatedPalette();

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -47,27 +47,25 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
     : UBActionPalette(Qt::TopLeftCorner, parent, orient)
     , mLastSelectedId(-1)
 {
-    QList<QAction*> actions;
+    changeActions([&]{
+        addAction(UBApplication::mainWindow->actionPen);
+        addAction(UBApplication::mainWindow->actionEraser);
+        addAction(UBApplication::mainWindow->actionMarker);
+        addAction(UBApplication::mainWindow->actionSelector);
+        addAction(UBApplication::mainWindow->actionPlay);
 
-    actions << UBApplication::mainWindow->actionPen;
-    actions << UBApplication::mainWindow->actionEraser;
-    actions << UBApplication::mainWindow->actionMarker;
-    actions << UBApplication::mainWindow->actionSelector;
-    actions << UBApplication::mainWindow->actionPlay;
+        addAction(UBApplication::mainWindow->actionHand);
+        addAction(UBApplication::mainWindow->actionZoomIn);
+        addAction(UBApplication::mainWindow->actionZoomOut);
 
-    actions << UBApplication::mainWindow->actionHand;
-    actions << UBApplication::mainWindow->actionZoomIn;
-    actions << UBApplication::mainWindow->actionZoomOut;
+        addAction(UBApplication::mainWindow->actionPointer);
+        addAction(UBApplication::mainWindow->actionLine);
+        addAction(UBApplication::mainWindow->actionText);
+        addAction(UBApplication::mainWindow->actionCapture);
 
-    actions << UBApplication::mainWindow->actionPointer;
-    actions << UBApplication::mainWindow->actionLine;
-    actions << UBApplication::mainWindow->actionText;
-    actions << UBApplication::mainWindow->actionCapture;
-
-    if(UBPlatformUtils::hasVirtualKeyboard())
-        actions << UBApplication::mainWindow->actionVirtualKeyboard;
-
-    setActions(actions);
+        if(UBPlatformUtils::hasVirtualKeyboard())
+            addAction(UBApplication::mainWindow->actionVirtualKeyboard);
+    });
     setButtonIconSize(QSize(42, 42));
 
     if(!UBPlatformUtils::hasVirtualKeyboard())

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -54,43 +54,31 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
         addAction(UBApplication::mainWindow->actionSelector);
         addAction(UBApplication::mainWindow->actionPlay);
 
-        addAction(UBApplication::mainWindow->actionHand);
-        addAction(UBApplication::mainWindow->actionZoomIn);
-        addAction(UBApplication::mainWindow->actionZoomOut);
+        UBActionPaletteButton* button = addAction(UBApplication::mainWindow->actionHand);
+        connect(button, &UBActionPaletteButton::doubleClicked, this, &UBStylusPalette::restoreScroll);
+
+        button = addAction(UBApplication::mainWindow->actionZoomIn);
+        connect(button, &UBActionPaletteButton::doubleClicked, this, &UBStylusPalette::restoreZoom);
+
+        button = addAction(UBApplication::mainWindow->actionZoomOut);
+        connect(button, &UBActionPaletteButton::doubleClicked, this, &UBStylusPalette::restoreZoom);
+
 
         addAction(UBApplication::mainWindow->actionPointer);
         addAction(UBApplication::mainWindow->actionLine);
         addAction(UBApplication::mainWindow->actionText);
         addAction(UBApplication::mainWindow->actionCapture);
 
+        groupActions();
+
         if(UBPlatformUtils::hasVirtualKeyboard())
             addAction(UBApplication::mainWindow->actionVirtualKeyboard);
     });
     setButtonIconSize(QSize(42, 42));
 
-    if(!UBPlatformUtils::hasVirtualKeyboard())
-    {
-        groupActions();
-    }
-    else
-    {
-        // VirtualKeyboard action is not in group
-        // So, groupping all buttons, except last
-        mButtonGroup = new QButtonGroup(this);
-        for(int i=0; i < mButtons.size()-1; i++)
-        {
-            mButtonGroup->addButton(mButtons[i], i);
-        }
-    }
-
     adjustSizeAndPosition();
 
     initPosition();
-
-    foreach(const UBActionPaletteButton* button, mButtons)
-    {
-        connect(button, SIGNAL(doubleClicked()), this, SLOT(stylusToolDoubleClicked()));
-    }
 
 }
 
@@ -124,10 +112,3 @@ UBStylusPalette::~UBStylusPalette()
 {
 
 }
-
-void UBStylusPalette::stylusToolDoubleClicked()
-{
-    emit stylusToolDoubleClicked(mButtonGroup->checkedId());
-}
-
-

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -47,7 +47,7 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
     : UBActionPalette(Qt::TopLeftCorner, parent, orient)
     , mLastSelectedId(-1)
 {
-    changeActions([&]{
+    changeActions([&]{        
         addAction(UBApplication::mainWindow->actionPen);
         addAction(UBApplication::mainWindow->actionEraser);
         addAction(UBApplication::mainWindow->actionMarker);
@@ -69,11 +69,9 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
         addAction(UBApplication::mainWindow->actionText);
         addAction(UBApplication::mainWindow->actionCapture);
 
-        groupActions();
-
         if(UBPlatformUtils::hasVirtualKeyboard())
-            addAction(UBApplication::mainWindow->actionVirtualKeyboard);
-    });
+            addAction(UBApplication::mainWindow->actionVirtualKeyboard, false);
+    }, true);
     setButtonIconSize(QSize(42, 42));
 
     adjustSizeAndPosition();

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -83,7 +83,6 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
         {
             mButtonGroup->addButton(mButtons[i], i);
         }
-        connect(mButtonGroup, SIGNAL(buttonClicked(int)), this, SIGNAL(buttonGroupClicked(int)));
     }
 
     adjustSizeAndPosition();

--- a/src/gui/UBStylusPalette.h
+++ b/src/gui/UBStylusPalette.h
@@ -45,15 +45,13 @@ class UBStylusPalette : public UBActionPalette
 
         void initPosition();
 
-    private slots:
-
-        void stylusToolDoubleClicked();
-
     private:
         int mLastSelectedId;
 
     signals:
-        void stylusToolDoubleClicked(int tool);
+
+        void restoreScroll();
+        void restoreZoom();
 };
 
 #endif /* UBSTYLUSPALLETTE_H_ */

--- a/src/gui/UBWebToolsPalette.cpp
+++ b/src/gui/UBWebToolsPalette.cpp
@@ -49,19 +49,20 @@ UBWebToolsPalette::UBWebToolsPalette(QWidget *parent)
 {
     QList<QAction*> actions;
 
-    actions << UBApplication::mainWindow->actionCaptureWebContent;
+    changeActions([&]{
+        addAction(UBApplication::mainWindow->actionCaptureWebContent);
 
-    actions << UBApplication::mainWindow->actionWebCustomCapture;
-    actions << UBApplication::mainWindow->actionWebWindowCapture;
+        addAction(UBApplication::mainWindow->actionWebCustomCapture);
+        addAction(UBApplication::mainWindow->actionWebWindowCapture);
 // NOTE @letsfindaway obsolete, covered by actionWebTrapFlash
-//    actions << UBApplication::mainWindow->actionWebOEmbed;
+//      addAction(UBApplication::mainWindow->actionWebOEmbed);
 
-    actions << UBApplication::mainWindow->actionWebShowHideOnDisplay;
+        addAction(UBApplication::mainWindow->actionWebShowHideOnDisplay);
 
-    if (UBPlatformUtils::hasVirtualKeyboard())
-        actions << UBApplication::mainWindow->actionVirtualKeyboard;
+        if (UBPlatformUtils::hasVirtualKeyboard())
+            addAction(UBApplication::mainWindow->actionVirtualKeyboard);
 
-    setActions(actions);
+    });
     setButtonIconSize(QSize(42, 42));
     adjustSizeAndPosition();
 }


### PR DESCRIPTION
This pull request is only a **draft**. I raised it only because now I have got a question about the next steps.

I made many code refactorings. This reduces the complexity so that we also have 1478 less lines of code. And this without any functional change.

But now I have got a question: Most code of UBDesktopAnnotationController is the masking mechanism. But this masking mechanism does not even work well. For example if you move the desktop palette the mask (especially around the property palettes) is not updated correctly. And the selector does also not work well with the masking as it is not possible to click through drawn things. It is questionable if the masking mechanism is then useful, at all.

What about removing the masking mechanism? I have the impression, that it will never work correctly. The alternative is to have clearly two modes. One with all the drawings where it is not able to interact with the windows behind it. And one without all the drawings. It think, this will be as comfortable as now but would eliminate all these complicated masking algorithms.