### PR TITLE
Text item is created with a larger width. If a selected area is used,…

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1414,7 +1414,17 @@ void UBBoardView::mouseReleaseEvent (QMouseEvent *event)
 
                 textItem->setTextInteractionFlags(Qt::TextEditorInteraction);
                 textItem->setSelected (true);
-                textItem->setTextWidth(0);
+                if (rubberRect.width() > 100)
+                    textItem->setTextWidth(mapToScene(rubberRect).boundingRect().width());
+                else
+                {
+                    int adaptedWidth = scene()->nominalSize().width() / mController->currentZoom() * 0.95
+                            - (mapToScene(event->localPos().toPoint()).x() - mapToScene(0,0).x());
+                    if(adaptedWidth > 100)
+                        textItem->setTextWidth(adaptedWidth);
+                    else
+                        textItem->setTextWidth(0);
+                }
                 textItem->setFocus();
             }
         }


### PR DESCRIPTION
… the Text item has the width of this selected area. If there is no selected area, the width is set to fill the screen from the mouse point to the right border minus 5%. It works even if the zoom factor != 1. Link to this [issue](https://github.com/OpenBoard-org/OpenBoard/issues/682).