### PR TITLE
Duplicate files

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -1088,35 +1088,11 @@ void UBBoardController::downloadURL(const QUrl& url, QString contentSourceUrl, c
         QString fileName = formedUrl.toLocalFile();
         QString contentType = UBFileSystemUtils::mimeTypeFromFileName(fileName);
 
-        bool shouldLoadFileData =
-                contentType.startsWith("image")
-                || contentType.startsWith("application/widget")
-                || contentType.startsWith("application/vnd.apple-widget");
-
-       if (shouldLoadFileData)
-       {
-            QFile file(fileName);
-            file.open(QIODevice::ReadOnly);
-            downloadFinished(true, formedUrl, QUrl(), contentType, file.readAll(), pPos, pSize, isBackground, internalData);
-            file.close();
-       }
-       else
-       {
-           // media items should be copyed in separate thread
-
-           sDownloadFileDesc desc;
-           desc.modal = false;
-           desc.srcUrl = sUrl;
-           desc.originalSrcUrl = contentSourceUrl;
-           desc.currentSize = 0;
-           desc.name = QFileInfo(url.toString()).fileName();
-           desc.totalSize = 0; // The total size will be retrieved during the download
-           desc.pos = pPos;
-           desc.size = pSize;
-           desc.isBackground = isBackground;
-
-           UBDownloadManager::downloadManager()->addFileToDownload(desc);
-       }
+        // directly add local file to document without copying
+        QFile file(fileName);
+        file.open(QIODevice::ReadOnly);
+        downloadFinished(true, formedUrl, QUrl(), contentType, file.readAll(), pPos, pSize, isBackground, internalData);
+        file.close();
     }
     else
     {

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -1434,7 +1434,7 @@ void UBPersistenceManager::cleanupDocument(UBDocumentProxy *pDocumentProxy) cons
 {
     static QRegularExpression uuidPattern("{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}");
 
-    if (!pDocumentProxy->needsCleanup())
+    if (!pDocumentProxy->testAndResetCleanupNeeded())
     {
         return;
     }

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -1101,6 +1101,8 @@ void UBPersistenceManager::persistDocumentScene(UBDocumentProxy* pDocumentProxy,
 
 UBDocumentProxy* UBPersistenceManager::persistDocumentMetadata(UBDocumentProxy* pDocumentProxy, bool forceImmediateSaving)
 {
+    cleanupDocument(pDocumentProxy);
+
     if (forceImmediateSaving)
     {
         UBMetadataDcSubsetAdaptor::persist(pDocumentProxy);
@@ -1425,6 +1427,69 @@ void UBPersistenceManager::loadFolderTreeFromXml(const QString &path, const QDom
             }
         }
         iterElement = iterElement.nextSiblingElement();
+    }
+}
+
+void UBPersistenceManager::cleanupDocument(UBDocumentProxy *pDocumentProxy) const
+{
+    static QRegularExpression uuidPattern("{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}");
+
+    if (!pDocumentProxy->needsCleanup())
+    {
+        return;
+    }
+
+    // scan pages and collect possible UUID references
+    const QString path = pDocumentProxy->persistencePath() + "/";
+    const QStringList pages = getSceneFileNames(path);
+    QSet<QString> references;
+
+    for (const QString& page : pages)
+    {
+        QFile svgFile(path + page);
+
+        if (svgFile.open(QFile::ReadOnly))
+        {
+            const QString content = svgFile.readAll();
+            auto matches = uuidPattern.globalMatch(content);
+
+            while (matches.hasNext())
+            {
+                QRegularExpressionMatch match = matches.next();
+                references << match.captured();
+            }
+        }
+    }
+
+    // scan folders and remove unreferenced files and directories
+    static const QStringList folders = { ".", "audios", "videos", "objects" };
+
+    for (const QString& folder : folders)
+    {
+        QFileInfoList entries = QDir(path + folder).entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+
+        for (const QFileInfo& entry : entries)
+        {
+            QRegularExpressionMatch match = uuidPattern.match(entry.fileName());
+
+            if (match.hasMatch() && !references.contains(match.captured()))
+            {
+                const QString filename = folder + "/" + entry.fileName();
+                const QString absoluteFilePath = entry.absoluteFilePath();
+
+                // unreferenced file or directory
+                if (entry.isDir())
+                {
+                    qDebug() << "Deleting unreferenced directory" << filename;
+                    UBFileSystemUtils::deleteDir(absoluteFilePath);
+                }
+                else
+                {
+                    qDebug() << "Deleting unreferenced file" << filename;
+                    UBFileSystemUtils::deleteFile(absoluteFilePath);
+                }
+            }
+        }
     }
 }
 

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -181,6 +181,8 @@ private:
         void saveFoldersTreeToXml(QXmlStreamWriter &writer, const QModelIndex &parentIndex);
         void loadFolderTreeFromXml(const QString &path, const QDomElement &element);
 
+        void cleanupDocument(UBDocumentProxy *pDocumentProxy) const;
+
         QString xmlFolderStructureFilename;
 
         UBSceneCache mSceneCache;

--- a/src/document/UBDocumentProxy.cpp
+++ b/src/document/UBDocumentProxy.cpp
@@ -43,6 +43,7 @@ UBDocumentProxy::UBDocumentProxy()
     : mPageCount(0)
     , mPageDpi(0)
     , mPersistencePath("")
+    , mNeedsCleanup(true)
 {
     init();
 }
@@ -54,12 +55,14 @@ UBDocumentProxy::UBDocumentProxy(const UBDocumentProxy &rValue) :
     mMetaDatas = rValue.mMetaDatas;
     mIsModified = rValue.mIsModified;
     mPageCount = rValue.mPageCount;
+    mNeedsCleanup = rValue.mNeedsCleanup;
 }
 
 
 UBDocumentProxy::UBDocumentProxy(const QString& pPersistancePath)
     : mPageCount(0)
     , mPageDpi(0)
+    , mNeedsCleanup(true)
 {
     init();
     setPersistencePath(pPersistancePath);
@@ -134,6 +137,13 @@ void UBDocumentProxy::setWidgetCompatible(const QUuid &uuid, bool compatible)
     mWidgetCompatibility[uuid] = compatible;
 }
 
+bool UBDocumentProxy::needsCleanup()
+{
+    bool tmp = mNeedsCleanup;
+    mNeedsCleanup = false;
+    return tmp;
+}
+
 int UBDocumentProxy::incPageCount()
 {
     if (mPageCount <= 0)
@@ -158,6 +168,8 @@ int UBDocumentProxy::decPageCount()
     {
         mPageCount = 0;
     }
+
+    mNeedsCleanup = true;
 
     return mPageCount;
 }

--- a/src/document/UBDocumentProxy.cpp
+++ b/src/document/UBDocumentProxy.cpp
@@ -137,7 +137,7 @@ void UBDocumentProxy::setWidgetCompatible(const QUuid &uuid, bool compatible)
     mWidgetCompatibility[uuid] = compatible;
 }
 
-bool UBDocumentProxy::needsCleanup()
+bool UBDocumentProxy::testAndResetCleanupNeeded()
 {
     bool tmp = mNeedsCleanup;
     mNeedsCleanup = false;

--- a/src/document/UBDocumentProxy.h
+++ b/src/document/UBDocumentProxy.h
@@ -86,6 +86,8 @@ class UBDocumentProxy : public QObject
 
         bool isWidgetCompatible(const QUuid& uuid) const;
         void setWidgetCompatible(const QUuid& uuid, bool compatible);
+        
+        bool needsCleanup();
 
     protected:
         void setPageCount(int pPageCount);
@@ -107,6 +109,8 @@ class UBDocumentProxy : public QObject
         int mPageDpi;
 
         QMap<QUuid, bool> mWidgetCompatibility;
+        
+        bool mNeedsCleanup;
 };
 
 inline bool operator==(const UBDocumentProxy &proxy1, const UBDocumentProxy &proxy2)

--- a/src/document/UBDocumentProxy.h
+++ b/src/document/UBDocumentProxy.h
@@ -87,7 +87,7 @@ class UBDocumentProxy : public QObject
         bool isWidgetCompatible(const QUuid& uuid) const;
         void setWidgetCompatible(const QUuid& uuid, bool compatible);
         
-        bool needsCleanup();
+        bool testAndResetCleanupNeeded();
 
     protected:
         void setPageCount(int pPageCount);


### PR DESCRIPTION
This PR addresses #671 with the following changes:

- It removes the `shouldLoadFileData` check in `UBBoardController` and never copies dropped files here, because in all cases (audio, video, images, widget, pdf) the files are copied anyway later.
- It adds a `UBPersistenceManager::cleanupDocument` function which removes unreferenced files from the document. 