### PR TITLE
fix: assure transparent background for widgets

### DIFF
--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -94,13 +94,8 @@ UBGraphicsWidgetItem::UBGraphicsWidgetItem(const QUrl &pWidgetUrl, QGraphicsItem
     setAcceptDrops(true);
     setAutoFillBackground(false);
 
-    mWebEngineView->setBackgroundRole(QPalette::Window);
+    mWebEngineView->setAttribute(Qt::WA_TranslucentBackground);
     mWebEngineView->page()->setBackgroundColor(QColor(Qt::transparent));
-
-    QPalette viewPalette = palette();
-    viewPalette.setBrush(QPalette::Base, QBrush(Qt::transparent));
-    viewPalette.setBrush(QPalette::Window, QBrush(Qt::transparent));
-    setPalette(viewPalette);
 
     setDelegate(new UBGraphicsWidgetItemDelegate(this));
 

--- a/src/gui/UBToolWidget.cpp
+++ b/src/gui/UBToolWidget.cpp
@@ -114,7 +114,7 @@ void UBToolWidget::initialize()
     QWebEngineProfile* profile = UBApplication::webController->webProfile();
     mWebView->setPage(new WebPage(profile, mWebView));
 
-    mWebView->setBackgroundRole(QPalette::Window);
+    mWebView->setAttribute(Qt::WA_TranslucentBackground);
     mWebView->page()->setBackgroundColor(QColor(Qt::transparent));
 
     mWebView->installEventFilter(this);


### PR DESCRIPTION
This PR assures a transparent background for widgets.

I had situations, when the background e.g. of Horologe was light gray instead of transparent. This was not always the case and it seemed that it depends on some environmental settings. It never happened when a widget was converted to a tool.

This PR harmonizes the transparency settings for widget and tool and uses additional flags to assure transparency. See also https://github.com/letsfindaway/OpenBoard/issues/107.

- fix setting flags for transparent background
- harmonize between UBGraphicsWidgetItem and UBToolWidget

Signed-off-by: letsfindaway <me@letsfindaway.de>