### PR TITLE
Changed the behaviour of the masking mechanism: When the selector is …

### DIFF
--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -673,7 +673,11 @@ void UBDesktopAnnotationController::selectorActionPressed()
 
 void UBDesktopAnnotationController::selectorActionReleased()
 {
+#ifdef UB_REQUIRES_MASK_UPDATE
+    mDesktopPalette->minimizeMe(eMinimizedLocation_None);
+#else
     UBApplication::mainWindow->actionSelector->setChecked(true);
+#endif
     switchCursor(UBStylusTool::Selector);
 }
 
@@ -719,6 +723,9 @@ void UBDesktopAnnotationController::switchCursor(const int tool)
 {
     mTransparentDrawingScene->setToolCursor(tool);
     mTransparentDrawingView->setToolCursor(tool);
+#ifdef UB_REQUIRES_MASK_UPDATE
+    UBApplication::mainWindow->actionSelector->setChecked(false);
+#endif
 }
 
 /**
@@ -765,6 +772,11 @@ void UBDesktopAnnotationController::onDesktopPaletteMaximized()
         connect(pPointerButton, SIGNAL(pressed()), this, SLOT(pointerActionPressed()));
         connect(pPointerButton, SIGNAL(released()), this, SLOT(pointerActionReleased()));
     }
+#ifdef UB_REQUIRES_MASK_UPDATE
+    UBApplication::mainWindow->actionSelector->setChecked(false);
+    updateMask(false);
+#endif
+
 }
 
 /**
@@ -883,36 +895,6 @@ void UBDesktopAnnotationController::updateMask(bool bTransparent)
 
         p.end();
 
-        // Then we add the annotations. We create another painter because we need to
-        // apply transformations on it for coordinates matching
-        QPainter annotationPainter;
-
-        QTransform trans;
-        trans.translate(mTransparentDrawingView->width()/2, mTransparentDrawingView->height()/2);
-
-        annotationPainter.begin(&mMask);
-        annotationPainter.setPen(Qt::red);
-        annotationPainter.setBrush(Qt::red);
-
-        annotationPainter.setTransform(trans);
-
-        QList<QGraphicsItem*> allItems = mTransparentDrawingScene->items();
-
-        for(int i = 0; i < allItems.size(); i++)
-        {
-            QGraphicsItem* pCrntItem = allItems.at(i);
-
-            if(pCrntItem->isVisible() && pCrntItem->type() == UBGraphicsPolygonItem::Type)
-            {
-                QPainterPath crntPath = pCrntItem->shape();
-                QRectF rect = crntPath.boundingRect();
-
-                annotationPainter.drawRect(rect);
-            }
-        }
-
-        annotationPainter.end();
-
         mTransparentDrawingView->setMask(mMask.mask());
     }
     else
@@ -945,7 +927,7 @@ void UBDesktopAnnotationController::refreshMask()
                 || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Pen
                 || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Marker)
         {
-            updateMask(true);
+            updateMask(UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Selector);
         }
     }
 }

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -202,10 +202,10 @@ void UBDesktopPalette::maximizeMe()
     adjustSizeAndPosition();
 
     // Notify that the maximization has been done
-    emit maximized();
 #ifdef UB_REQUIRES_MASK_UPDATE
         emit refreshMask();
 #endif
+    emit maximized();
 }
 
 void UBDesktopPalette::showEvent(QShowEvent *event)


### PR DESCRIPTION
I changed the behaviour of the masking mechanism. In the current version it does not work. If the user has added annotations over the desktop, he has no chance to work with the desktop any more. The masking mechanism prevents him from interacting with the desktop.

So I improved this behaviour. As the selector button has no use in that case (because you cannot click through annotations anyway), I changed the behaviour of the selector. It hides all annotations and minimizes the desktop palette. Then the user can operate with the desktop. When he wants the annotations back, he just maximizes the desktop palette again.

Hiding the desktop palette may be a bit surprising in this situation. But as the user cannot draw annotations, there is actually no real need of having the desktop palette maximized.