### PR TITLE
Fix crash after PDF import using DnD

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -1459,6 +1459,7 @@ UBItem *UBBoardController::downloadFinished(bool pSuccess, QUrl sourceUrl, QUrl 
 
             selectedDocument()->setMetaData(UBSettings::documentUpdatedAt, UBStringUtils::toUtcIsoDateTime(QDateTime::currentDateTime()));
             updateActionStates();
+            emit initThumbnailsRequired(this);
         }
     }
     else if (UBMimeType::OpenboardTool == itemMimeType)


### PR DESCRIPTION
This PR fixes #670 by re-initializing thumbnails in the `UBBoardThumbnailsView` after PDF import using DnD.

The reason for this crash was that the thumbnails in the page navigator on the left side of the board have not been updated when adding a PDF document using DnD. Later on however the code assumes that it can access these thumbnails by index. The missing index cause an out-of-range assertion.

The fix simply emits the `initThumbnailsRequired()` signal after import.