### PR TITLE
refactor: remove obsolete edumedia handling

### DIFF
--- a/resources/forms/mainWindow.ui
+++ b/resources/forms/mainWindow.ui
@@ -1598,18 +1598,6 @@
     <string>Erase all Annotations</string>
    </property>
   </action>
-  <action name="actionEduMedia">
-   <property name="icon">
-    <iconset resource="../OpenBoard.qrc">
-     <normaloff>:/images/toolbar/addToolToLibrary.png</normaloff>:/images/toolbar/addToolToLibrary.png</iconset>
-   </property>
-   <property name="text">
-    <string>eduMedia</string>
-   </property>
-   <property name="toolTip">
-    <string>Import eduMedia simulation</string>
-   </property>
-  </action>
   <action name="actionCheckUpdate">
    <property name="icon">
     <iconset resource="../OpenBoard.qrc">


### PR DESCRIPTION
The code currently contains some special handling for data coming from `edumedia-sciences.com` and containing Flash animations. Edumedia completely switched to HTML5, so the import feature for Flash based animations from Edumedia is obsolete. This PR removes the related code from `UBBoardController` and an already unused and unreferenced action from `mainWindow.ui`. 

Note that documents containing Flash animations imported earlier are not affected.

Note also that Edumedia content can now easily be imported to OpenBoard by using the Web content embedding feature of OpenBoard.

Third note: The translation files stillcontain text strings referring to Edumedia, but I think those should be cleaned up at some later time using 

```sh
lupdate -no-obsolete
```