### PR TITLE
feat: open target=_blank links in widgets in same view

### DIFF
--- a/src/domain/UBWebEngineView.cpp
+++ b/src/domain/UBWebEngineView.cpp
@@ -121,3 +121,31 @@ void UBWebEngineView::contextMenuEvent(QContextMenuEvent *event)
 
     menu->popup(event->globalPos());
 }
+
+QWebEngineView *UBWebEngineView::createWindow(QWebEnginePage::WebWindowType type)
+{
+    switch (type)
+    {
+    case QWebEnginePage::WebBrowserWindow:
+        break;
+
+    case QWebEnginePage::WebBrowserTab: {
+        // create a throwaway view to get the URL
+        QWebEngineView* view = new QWebEngineView();
+
+        connect(view, &QWebEngineView::urlChanged, this, [this,view](const QUrl& url){
+            // load URL in current view and delete temporary view
+            load(url);
+            view->deleteLater();
+        });
+
+        return view;
+    }
+
+    case QWebEnginePage::WebDialog:
+    case QWebEnginePage::WebBrowserBackgroundTab:
+        break;
+    }
+
+    return nullptr;
+}

--- a/src/domain/UBWebEngineView.h
+++ b/src/domain/UBWebEngineView.h
@@ -46,6 +46,7 @@ public slots:
 
 protected:
     void contextMenuEvent(QContextMenuEvent *event) override;
+    QWebEngineView *createWindow(QWebEnginePage::WebWindowType type) override;
 
 private:
     QMainWindow* mInspectorWindow;


### PR DESCRIPTION
- links with target=_blank cannot open a new tab from a widget
- intercept such requests and open link in same view

See also https://github.com/letsfindaway/OpenBoard/issues/115

Verified with Qt 5.15 and Qt 6.2