### PR TITLE
workaround: avoid QTBUG-108284 with CSS styled cursors

### DIFF
--- a/src/domain/UBGraphicsWidgetItem.h
+++ b/src/domain/UBGraphicsWidgetItem.h
@@ -67,13 +67,13 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
 
         enum { Type = UBGraphicsItemType::GraphicsWidgetItemType };
 
-        virtual int type() const { return Type; }
+        virtual int type() const override { return Type; }
 
         virtual void initialize();
 
-        virtual void resize(qreal w, qreal h);
-        virtual void resize(const QSizeF & size);
-        virtual QSizeF size() const;
+        virtual void resize(qreal w, qreal h) override;
+        virtual void resize(const QSizeF & size) override;
+        virtual QSizeF size() const override;
 
         QUrl mainHtml() const;
         void loadMainHtml();
@@ -109,9 +109,9 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
         virtual void setSnapshotPath(const QUrl &newFilePath);
         virtual QUrl getSnapshotPath() const;
 
-        virtual void clearSource();
+        virtual void clearSource() override;
 
-        virtual void setUuid(const QUuid &pUuid);
+        virtual void setUuid(const QUuid &pUuid) override;
 
         QSize nominalSize() const;
 
@@ -128,8 +128,8 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
         const QPixmap& takeSnapshot();
         void saveSnapshot() const;
 
-        virtual UBItem* deepCopy() const = 0;
-        virtual UBGraphicsScene* scene();
+        virtual UBItem* deepCopy() const override = 0;
+        virtual UBGraphicsScene* scene() override;
 
         static int widgetType(const QUrl& pUrl);
         static QString widgetName(const QUrl& pUrl);
@@ -170,18 +170,19 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
         QMap<QString, QString> mPreferences;
 
 
-        virtual bool event(QEvent *event);
-        virtual void dropEvent(QGraphicsSceneDragDropEvent *event);
-        virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
-        virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
-        virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
-        virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event);
+        virtual bool event(QEvent *event) override;
+        virtual void dropEvent(QGraphicsSceneDragDropEvent *event) override;
+        virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+        virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+        virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+        virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
         virtual void sendJSEnterEvent();
         virtual void sendJSLeaveEvent();
         virtual void injectInlineJavaScript();
-        virtual void wheelEvent(QGraphicsSceneWheelEvent *event);
-        virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
-        virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+        virtual void wheelEvent(QGraphicsSceneWheelEvent *event) override;
+        virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+        virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+        virtual bool eventFilter(QObject *obj, QEvent *ev) override;
 
     protected slots:
         void geometryChangeRequested(const QRect& geom);


### PR DESCRIPTION
See [QTBUG-108284](https://bugreports.qt.io/browse/QTBUG-108284)

- CSS styled cursors don't work with Qt 5.15 - 6.4 (at least)
- intercept CursorChange event on QWebEngineView's window
- forward to QGraphicsProxyWidget
- additionally mark other overriding functions as `override`
- commit may be reverted when bug is fixed in Qt

Fix was verified with Qt 5.15 and Qt 6.2 on Linux.