### PR TITLE
Live thumbnails using QGraphicsPixmapItem

### DIFF
--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -48,6 +48,7 @@
 #include "gui/UBBackgroundPalette.h"
 #include "gui/UBFavoriteToolPalette.h"
 #include "gui/UBStartupHintsPalette.h"
+#include "gui/UBPageNavigationWidget.h"
 
 #include "web/UBWebController.h"
 

--- a/src/board/UBBoardPaletteManager.h
+++ b/src/board/UBBoardPaletteManager.h
@@ -34,7 +34,6 @@
 
 #include "gui/UBLeftPalette.h"
 #include "gui/UBRightPalette.h"
-#include "gui/UBPageNavigationWidget.h"
 #include "gui/UBCachePropertiesWidget.h"
 #include "gui/UBDockDownloadWidget.h"
 #include "core/UBApplicationController.h"
@@ -54,6 +53,7 @@ class UBKeyboardPalette;
 class UBMainWindow;
 class UBApplicationController;
 class UBStartupHintsPalette;
+class UBPageNavigationWidget;
 
 class UBBoardPaletteManager : public QObject
 {

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1699,6 +1699,19 @@ void UBBoardView::resizeEvent (QResizeEvent * event)
     emit resized (event);
 }
 
+void UBBoardView::paintEvent(QPaintEvent *event)
+{
+    QGraphicsView::paintEvent(event);
+
+    // ignore paint events under the left palette
+    int paletteWidth = UBApplication::boardController->paletteManager()->leftPalette()->width();
+
+    if (event->rect().right() >= paletteWidth)
+    {
+        emit painted(mapToScene(event->rect()).boundingRect());
+    }
+}
+
 void UBBoardView::drawBackground (QPainter *painter, const QRectF &rect)
 {
     if (testAttribute (Qt::WA_TranslucentBackground))

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -73,6 +73,7 @@ signals:
     void resized(QResizeEvent* event);
     void shown();
     void mouseReleased();
+    void painted(const QRectF region);
 
 protected:
 
@@ -111,6 +112,8 @@ protected:
     virtual void dragMoveEvent(QDragMoveEvent *event);
 
     virtual void resizeEvent(QResizeEvent * event);
+
+    virtual void paintEvent(QPaintEvent *event);
 
     virtual void drawBackground(QPainter *painter, const QRectF &rect);
 

--- a/src/gui/UBBoardThumbnailsView.h
+++ b/src/gui/UBBoardThumbnailsView.h
@@ -36,7 +36,8 @@
 #include <QMouseEvent>
 
 #include "document/UBDocumentProxy.h"
-#include "UBThumbnailWidget.h"
+
+class UBDraggableLivePixmapItem;
 
 class UBBoardThumbnailsView : public QGraphicsView
 {
@@ -57,6 +58,7 @@ public slots:
 
     void longPressTimeout();
     void mousePressAndHoldEvent(QPoint pos);
+    void updateThumbnailPixmap(const QRectF region);
 
 protected:
     virtual void resizeEvent(QResizeEvent *event);
@@ -69,22 +71,25 @@ protected:
     virtual void mouseMoveEvent(QMouseEvent *event);
     virtual void mouseReleaseEvent(QMouseEvent *event);
 
+    virtual void scrollContentsBy(int dx, int dy);
+
 signals:
     void mousePressAndHoldEventRequired(QPoint pos);
     void moveThumbnailRequired(int from, int to);
 
 private:
-    UBDraggableThumbnailView* createThumbnail(UBDocumentProxy* document, int i);
+    UBDraggableLivePixmapItem* createThumbnail(UBDocumentProxy* document, int i);
     void updateThumbnailsPos();
+    void updateExposure();
 
-    QList<UBDraggableThumbnailView*> mThumbnails;
+    QList<UBDraggableLivePixmapItem*> mThumbnails;
 
     int mThumbnailWidth;
     const int mThumbnailMinWidth;
     const int mMargin;
 
-    UBDraggableThumbnailView* mDropSource;
-    UBDraggableThumbnailView* mDropTarget;
+    UBDraggableLivePixmapItem* mDropSource;
+    UBDraggableLivePixmapItem* mDropTarget;
     QGraphicsRectItem *mDropBar;
 
     int mLongPressInterval;

--- a/src/gui/UBFeaturesWidget.cpp
+++ b/src/gui/UBFeaturesWidget.cpp
@@ -32,7 +32,6 @@
 #include <QWidget>
 
 #include "UBFeaturesWidget.h"
-#include "gui/UBThumbnailWidget.h"
 #include "frameworks/UBFileSystemUtils.h"
 #include "core/UBApplication.h"
 #include "core/UBDownloadManager.h"

--- a/src/gui/UBThumbnailWidget.cpp
+++ b/src/gui/UBThumbnailWidget.cpp
@@ -120,7 +120,6 @@ void UBThumbnailWidget::setGraphicsItems(const QList<QGraphicsItem*>& pGraphicsI
 
     foreach (const QString label, pLabels)
     {
-        QFontMetrics fm(font());
         UBThumbnailTextItem *labelItem =
             new UBThumbnailTextItem(label); // deleted while replace or by the scene destruction
 

--- a/src/gui/UBThumbnailWidget.cpp
+++ b/src/gui/UBThumbnailWidget.cpp
@@ -952,9 +952,9 @@ void UBWidgetTextThumbnailElement::Place(int row, int col, qreal width, qreal he
     }
 }
 
-void UBDraggableThumbnail::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+void UBDraggableThumbnailItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-    QGraphicsProxyWidget::paint(painter, option, widget);
+    UBThumbnailPixmapItem::paint(painter, option, widget);
     using namespace UBThumbnailUI;
 
     if (editable())
@@ -981,21 +981,21 @@ void UBDraggableThumbnail::paint(QPainter *painter, const QStyleOptionGraphicsIt
     }
 }
 
-void UBDraggableThumbnail::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+void UBDraggableThumbnailItem::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     event->accept();
     showUI();
     update();
 }
 
-void UBDraggableThumbnail::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
+void UBDraggableThumbnailItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
     event->accept();
     hideUI();
     update();
 }
 
-void UBDraggableThumbnail::deletePage()
+void UBDraggableThumbnailItem::deletePage()
 {
     if(UBApplication::mainWindow->yesNoQuestion(QObject::tr("Remove Page"),
                                                 QObject::tr("Are you sure you want to remove page %1 ?").arg(sceneIndex()+1),
@@ -1005,24 +1005,24 @@ void UBDraggableThumbnail::deletePage()
     }
 }
 
-void UBDraggableThumbnail::duplicatePage()
+void UBDraggableThumbnailItem::duplicatePage()
 {
     UBApplication::boardController->duplicateScene(sceneIndex());
 }
 
-void UBDraggableThumbnail::moveUpPage()
+void UBDraggableThumbnailItem::moveUpPage()
 {
     if (sceneIndex()!=0)
         UBApplication::boardController->moveSceneToIndex(sceneIndex(), sceneIndex() - 1);
 }
 
-void UBDraggableThumbnail::moveDownPage()
+void UBDraggableThumbnailItem::moveDownPage()
 {
     if (sceneIndex() < UBApplication::boardController->selectedDocument()->pageCount()-1)
         UBApplication::boardController->moveSceneToIndex(sceneIndex(), sceneIndex() + 1);
 }
 
-void UBDraggableThumbnail::mousePressEvent(QGraphicsSceneMouseEvent *event)
+void UBDraggableThumbnailItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
     QPointF p = event->pos();
 
@@ -1056,14 +1056,61 @@ void UBDraggableThumbnail::mousePressEvent(QGraphicsSceneMouseEvent *event)
     }
 }
 
-void UBDraggableThumbnail::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
+void UBDraggableThumbnailItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     event->accept();
 }
 
 
-void UBDraggableThumbnailView::updatePos(qreal width, qreal height)
+UBDraggableLivePixmapItem::UBDraggableLivePixmapItem(UBGraphicsScene *pageScene, UBDocumentProxy *documentProxy, int index)
+    : UBDraggableThumbnailItem(documentProxy, index)
+    , mScene(pageScene)
+    , mPageNumber(new UBThumbnailTextItem(index))
+    , mExposed(false)
 {
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setAcceptDrops(true);
+
+    mSelectionItem = new QGraphicsRectItem(sceneBoundingRect().x() - sSelectionItemMargin,
+                                           sceneBoundingRect().y() - sSelectionItemMargin,
+                                           sceneBoundingRect().width() + 2*sSelectionItemMargin,
+                                           sceneBoundingRect().height() + 2*sSelectionItemMargin);
+    mSelectionItem->setPen(QPen(UBSettings::treeViewBackgroundColor, 8));
+    mSelectionItem->setZValue(-1);
+
+    connect(&updateTimer, &QTimer::timeout, this, [this](){
+        updatePixmap();
+
+        if (--updateCount <= 0)
+        {
+            updateTimer.stop();
+        }
+    });
+}
+
+void UBDraggableLivePixmapItem::updatePos(qreal width, qreal height)
+{
+    QSizeF newSize(width, height);
+
+    if (newSize != mSize)
+    {
+        mSize = newSize;
+        QPixmap pixmap = QPixmap(mSize.toSize());
+        pixmap.fill(Qt::white);
+        setPixmap(pixmap);
+        updatePixmap();
+
+        QRectF sceneRect(QPointF(0, 0), mScene->sceneSize());
+        sceneRect.translate(-sceneRect.center());
+        QSizeF sceneSize = mSize.scaled(sceneRect.size(), Qt::KeepAspectRatioByExpanding);
+        QSizeF expand = (sceneSize - sceneRect.size()) / 2;
+        QMarginsF margins(expand.width(), expand.height(), expand.width(), expand.height());
+
+        mTransform = QTransform();
+        mTransform.scale(mSize.width() / sceneSize.width(), mSize.height() / sceneSize.height());
+        mTransform.translate(sceneSize.width() / 2, sceneSize.height() / 2);
+    }
+
     QFontMetrics fm(mPageNumber->font());
     int labelSpacing = UBSettings::thumbnailSpacing + fm.height();
 
@@ -1081,20 +1128,99 @@ void UBDraggableThumbnailView::updatePos(qreal width, qreal height)
     setTransform(transform);
     setFlag(QGraphicsItem::ItemIsSelectable, true);
 
+    // even spacing, all thumbnails have the same size
     QPointF position(2*sSelectionItemMargin, 2*sSelectionItemMargin + sceneIndex() * (height + labelSpacing) + (height - h * scaledFactor) / 2);
 
     setPos(position);
 
     mSelectionItem->setRect(sceneBoundingRect().x() - sSelectionItemMargin,
-                           sceneBoundingRect().y() - sSelectionItemMargin,
-                           sceneBoundingRect().width() + 2*sSelectionItemMargin,
-                           sceneBoundingRect().height() + 2*sSelectionItemMargin);
+                            sceneBoundingRect().y() - sSelectionItemMargin,
+                            sceneBoundingRect().width() + 2*sSelectionItemMargin,
+                            sceneBoundingRect().height() + 2*sSelectionItemMargin);
 
     position.setY(sSelectionItemMargin + position.y() + (height + h * scaledFactor) / 2);
     position.setX(position.x() + (w * scaledFactor - fm.horizontalAdvance(mPageNumber->toPlainText())) / 2);
 
     mPageNumber->setPos(position);
 }
+
+void UBDraggableLivePixmapItem::setHighlighted(bool highlighted)
+{
+    if (highlighted)
+    {
+        mSelectionItem->show();
+    }
+    else
+    {
+        mSelectionItem->hide();
+    }
+}
+
+void UBDraggableLivePixmapItem::setExposed(bool exposed)
+{
+    if (exposed != mExposed)
+    {
+        mExposed = exposed;
+
+        if (exposed)
+        {
+            updatePixmap();
+
+            // start a burst of updates to follow PDF loading or similar
+            updateCount = 10;
+            updateTimer.start(300);
+        }
+        else
+        {
+            updateTimer.stop();
+        }
+    }
+}
+
+bool UBDraggableLivePixmapItem::isExposed()
+{
+    return mExposed;
+}
+
+void UBDraggableLivePixmapItem::updatePixmap(const QRectF &region)
+{
+    if (mSize.isValid() && mExposed)
+    {
+        QPixmap pixmap = this->pixmap();
+        QRectF pixmapRect;
+
+        if (region.isNull())
+        {
+            // full update
+            pixmapRect = QRectF(QPoint(0, 0), mSize);
+        }
+        else
+        {
+            // only render affected region
+
+            /*
+             * To avoid problems with antialiaing we have to make sure that the
+             * pixmapRect has an integer size and position and covers at least
+             * the affected region. The following steps assure this.
+             */
+            pixmapRect = mTransform.mapRect(region);        // translate to pixmap coordinates
+            pixmapRect += QMarginsF(1, 1, 1, 1);            // add a margin
+            pixmapRect = pixmapRect.toRect();               // cut to integer
+            pixmapRect &= QRectF(QPointF(0, 0), mSize);     // limit to pixmap area
+        }
+
+        if (pixmapRect.isValid())
+        {
+            QPainter painter(&pixmap);
+            QRectF sceneRect = mTransform.inverted().mapRect(pixmapRect);
+            mScene->render(&painter, pixmapRect, sceneRect);
+            setPixmap(pixmap);
+        }
+    }
+}
+
+
+
 
 UBThumbnailUI::UBThumbnailUIIcon* UBThumbnailUI::addIcon(const QString& thumbnailIcon, int pos)
 {


### PR DESCRIPTION
This PR provides an alternative implementation of live thumbnails for board navigation avoiding an issue with drop-down menus on web widgets. See https://github.com/letsfindaway/OpenBoard/issues/118 for a detailed discussion of this topic.

Please check this PR on a HiDPI display before merging. I assume it is ok, but this should be verified.