### PR TITLE
Avoid deprecations for Qt 5.15 and Qt 6.2

### DIFF
--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -655,7 +655,11 @@ void UBCFFSubsetAdaptor::UBCFFSubsetReader::readTextCharAttr(const QDomElement &
     }
     QString fontFamilyText = element.attribute(aFontfamily);
     if (!fontFamilyText.isNull()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        format.setFontFamilies(QStringList(fontFamilyText));
+#else
         format.setFontFamily(fontFamilyText);
+#endif
     }
     if (!element.attribute(aFontstyle).isNull()) {
         bool italic = (element.attribute(aFontstyle) == "italic");
@@ -817,7 +821,11 @@ bool UBCFFSubsetAdaptor::UBCFFSubsetReader::parseSvgTextarea(const QDomElement &
      // default values
     textFormat.setFontPointSize(12);
     textFormat.setForeground(qApp->palette().windowText().color());
-    textFormat.setFontFamily("Arial");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        textFormat.setFontFamilies(QStringList("Arial"));
+#else
+        textFormat.setFontFamily("Arial");
+#endif
     textFormat.setFontItalic(false);
     textFormat.setFontWeight(QFont::Normal);
 

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -235,8 +235,9 @@ void UBApplication::setupTranslators(QStringList args)
     else{
         mApplicationTranslator = new QTranslator(this);
         mQtGuiTranslator = new QTranslator(this);
-        mApplicationTranslator->load(UBPlatformUtils::translationPath(QString("OpenBoard_"),language));
-        installTranslator(mApplicationTranslator);
+
+        if (mApplicationTranslator->load(UBPlatformUtils::translationPath(QString("OpenBoard_"),language)))
+            installTranslator(mApplicationTranslator);
 
         QString qtGuiTranslationPath = UBPlatformUtils::translationPath("qt_", language);
 
@@ -248,7 +249,11 @@ void UBApplication::setupTranslators(QStringList args)
         }
 
         QLocale locale(language);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QString qtTranslationPath = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+#else
         QString qtTranslationPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#endif
         bool loaded = false;
 
         if (qtGuiTranslationPath.isEmpty())

--- a/src/core/UBOpenSankoreImporter.cpp
+++ b/src/core/UBOpenSankoreImporter.cpp
@@ -51,14 +51,13 @@ UBOpenSankoreImporter::UBOpenSankoreImporter(QWidget* mainWidget, QObject *paren
 
 void UBOpenSankoreImporter::onProceedClicked()
 {
-    QProcess newProcess;
 #ifdef Q_OS_LINUX
-    newProcess.startDetached(qApp->applicationDirPath()+"/importer/OpenBoardImporter");
+    QProcess::startDetached(qApp->applicationDirPath()+"/importer/OpenBoardImporter", QStringList());
 #elif defined Q_OS_OSX
-    newProcess.startDetached(qApp->applicationDirPath()+"/../Resources/OpenBoardImporter.app/Contents/MacOS/OpenBoardImporter");
+    QProcess::startDetached(qApp->applicationDirPath()+"/../Resources/OpenBoardImporter.app/Contents/MacOS/OpenBoardImporter", QStringList());
 #elif defined Q_OS_WIN
     QString importerPath = QDir::toNativeSeparators(qApp->applicationDirPath())+"\\OpenBoardImporter.exe";
-    newProcess.startDetached("explorer.exe", QStringList() << importerPath);
+    QProcess::startDetached("explorer.exe", QStringList() << importerPath);
 #endif
     qApp->exit(0);
 

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -1483,7 +1483,12 @@ void UBDocumentTreeView::dragMoveEvent(QDragMoveEvent *event)
         index = selectedIndexes().first();
     }
 
-    bool acceptIt = isAcceptable(index, indexAt(event->pos()));
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint eventPos = event->position().toPoint();
+#else
+    QPoint eventPos = event->pos();
+#endif
+    bool acceptIt = isAcceptable(index, indexAt(eventPos));
 
     if (event->mimeData()->hasFormat(UBApplication::mimeTypeUniboardPage)) {
         UBSortFilterProxyModel *proxy = dynamic_cast<UBSortFilterProxyModel*>(model());
@@ -1496,7 +1501,7 @@ void UBDocumentTreeView::dragMoveEvent(QDragMoveEvent *event)
             docModel =  dynamic_cast<UBDocumentTreeModel*>(model());
         }
 
-        QModelIndex targetIndex = mapIndexToSource(indexAt(event->pos()));
+        QModelIndex targetIndex = mapIndexToSource(indexAt(eventPos));
 
         if (!docModel || !docModel->isDocument(targetIndex) || docModel->inTrash(targetIndex)) {
             event->ignore();
@@ -1507,7 +1512,7 @@ void UBDocumentTreeView::dragMoveEvent(QDragMoveEvent *event)
             docModel->setHighLighted(targetIndex);
             acceptIt = true;
         }
-        updateIndexEnvirons(indexAt(event->pos()));
+        updateIndexEnvirons(indexAt(eventPos));
     }
     QTreeView::dragMoveEvent(event);
 
@@ -1526,7 +1531,12 @@ void UBDocumentTreeView::dropEvent(QDropEvent *event)
         docModel = dynamic_cast<UBDocumentTreeModel*>(proxy->sourceModel());
     }
 
-    QModelIndex targetIndex = mapIndexToSource(indexAt(event->pos()));
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint eventPos = event->position().toPoint();
+#else
+    QPoint eventPos = event->pos();
+#endif
+    QModelIndex targetIndex = mapIndexToSource(indexAt(eventPos));
     QModelIndexList dropIndex = mapIndexesToSource(selectionModel()->selectedRows(0));
 
     bool isUBPage = event->mimeData()->hasFormat(UBApplication::mimeTypeUniboardPage);

--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -315,16 +315,20 @@ void UBBoardThumbnailsView::dragEnterEvent(QDragEnterEvent *event)
 
 void UBBoardThumbnailsView::dragMoveEvent(QDragMoveEvent *event)
 {        
-    QPointF position = event->pos();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint eventPos = event->position().toPoint();
+#else
+    QPoint eventPos = event->pos();
+#endif
 
     //autoscroll during drag'n'drop
-    QPointF scenePos = mapToScene(position.toPoint());
+    QPointF scenePos = mapToScene(eventPos);
     int thumbnailHeight = mThumbnailWidth / UBSettings::minScreenRatio;
     QRectF thumbnailArea(0, scenePos.y() - thumbnailHeight/2, mThumbnailWidth, thumbnailHeight);
 
     ensureVisible(thumbnailArea);
 
-    UBDraggableLivePixmapItem* item = dynamic_cast<UBDraggableLivePixmapItem*>(itemAt(position.toPoint()));
+    UBDraggableLivePixmapItem* item = dynamic_cast<UBDraggableLivePixmapItem*>(itemAt(eventPos));
     if (item)
     {
         if (item != mDropTarget)
@@ -337,7 +341,7 @@ void UBBoardThumbnailsView::dragMoveEvent(QDragMoveEvent *event)
         QPointF itemCenter(item->pos().x() + (item->boundingRect().width()-verticalScrollBarWidth) * scale,
                            item->pos().y() + item->boundingRect().height() * scale / 2);
 
-        bool dropAbove = mapToScene(position.toPoint()).y() < itemCenter.y();
+        bool dropAbove = mapToScene(eventPos).y() < itemCenter.y();
         bool movingUp = mDropSource->sceneIndex() > item->sceneIndex();
         qreal y = 0;
 

--- a/src/gui/UBDocumentThumbnailWidget.cpp
+++ b/src/gui/UBDocumentThumbnailWidget.cpp
@@ -132,7 +132,12 @@ void UBDocumentThumbnailWidget::dragMoveEvent(QDragMoveEvent *event)
     QRect boundingFrame = frameRect();
     //setting up automatic scrolling
     const int SCROLL_DISTANCE = 16;
-    int bottomDist = boundingFrame.bottom() - event->pos().y(), topDist = boundingFrame.top() - event->pos().y();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint eventPos = event->position().toPoint();
+#else
+    QPoint eventPos = event->pos();
+#endif
+    int bottomDist = boundingFrame.bottom() - eventPos.y(), topDist = boundingFrame.top() - eventPos.y();
     if(qAbs(bottomDist) <= SCROLL_DISTANCE)
     {
         mScrollMagnitude = (SCROLL_DISTANCE - bottomDist)*4;
@@ -158,7 +163,7 @@ void UBDocumentThumbnailWidget::dragMoveEvent(QDragMoveEvent *event)
     }
 
     int minDistance = 0;
-    QGraphicsItem *underlyingItem = itemAt(event->pos());
+    QGraphicsItem *underlyingItem = itemAt(eventPos);
     mClosestDropItem = dynamic_cast<UBThumbnailPixmap*>(underlyingItem);
 
     if (!mClosestDropItem)
@@ -170,7 +175,7 @@ void UBDocumentThumbnailWidget::dragMoveEvent(QDragMoveEvent *event)
                         item->pos().x() + item->boundingRect().width() * scale / 2,
                         item->pos().y() + item->boundingRect().height() * scale / 2);
 
-            int distance = (itemCenter.toPoint() - mapToScene(event->pos()).toPoint()).manhattanLength();
+            int distance = (itemCenter.toPoint() - mapToScene(eventPos).toPoint()).manhattanLength();
             if (!mClosestDropItem || distance < minDistance)
             {
                 mClosestDropItem = item;
@@ -187,7 +192,7 @@ void UBDocumentThumbnailWidget::dragMoveEvent(QDragMoveEvent *event)
                     mClosestDropItem->pos().x() + mClosestDropItem->boundingRect().width() * scale / 2,
                     mClosestDropItem->pos().y() + mClosestDropItem->boundingRect().height() * scale / 2);
 
-        mDropIsRight = mapToScene(event->pos()).x() > itemCenter.x();
+        mDropIsRight = mapToScene(eventPos).x() > itemCenter.x();
 
         if (!mDropCaretRectItem && selectedItems().count() < mGraphicItems.count())
         {

--- a/src/gui/UBFeaturesActionBar.cpp
+++ b/src/gui/UBFeaturesActionBar.cpp
@@ -269,7 +269,12 @@ void UBFeaturesActionBar::dropEvent(QDropEvent *event)
         return;
     }
 
-    QWidget *dest = childAt(event->pos());
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint eventPos = event->position().toPoint();
+#else
+    QPoint eventPos = event->pos();
+#endif
+    QWidget *dest = childAt(eventPos);
     if (dest == mpDeleteBtn) {
         QList<UBFeature> featuresList = fMimeData->features();
         foreach (UBFeature curFeature, featuresList) {

--- a/src/gui/UBFeaturesWidget.cpp
+++ b/src/gui/UBFeaturesWidget.cpp
@@ -421,7 +421,12 @@ void UBFeaturesListView::dragEnterEvent( QDragEnterEvent *event )
 void UBFeaturesListView::dragMoveEvent( QDragMoveEvent *event )
 {
     const UBFeaturesMimeData *fMimeData = qobject_cast<const UBFeaturesMimeData*>(event->mimeData());
-    QModelIndex index = indexAt(event->pos());
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint eventPos = event->position().toPoint();
+#else
+    QPoint eventPos = event->pos();
+#endif
+    QModelIndex index = indexAt(eventPos);
     UBFeature onFeature = model()->data(index, Qt::UserRole + 1).value<UBFeature>();
     if (fMimeData) {
         if (!index.isValid() || !onFeature.isFolder()) {

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -122,7 +122,11 @@ void UBFloatingPalette::mousePressEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton)
     {
         mIsMoving = true;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        mDragPosition = event->globalPosition().toPoint() - frameGeometry().topLeft();
+#else
         mDragPosition = event->globalPos() - frameGeometry().topLeft();
+#endif
         event->accept();
     }
     else
@@ -135,7 +139,11 @@ void UBFloatingPalette::mouseMoveEvent(QMouseEvent *event)
 {
     if (mIsMoving)
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        moveInsideParent(event->globalPosition().toPoint() - mDragPosition);
+#else
         moveInsideParent(event->globalPos() - mDragPosition);
+#endif
         event->accept();
         emit moving();
     }

--- a/src/gui/UBMagnifer.cpp
+++ b/src/gui/UBMagnifer.cpp
@@ -262,7 +262,12 @@ void UBMagnifier::mousePressEvent ( QMouseEvent * event )
         }
 
         mMousePressPos = event->pos();
-        mMousePressDelta = (qreal)updPointGrab.x() + (qreal)size().width() / 2 - (qreal)event->globalPos().x();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPointF globalPosition = event->globalPosition();
+#else
+    QPointF globalPosition = event->globalPos();
+#endif
+        mMousePressDelta = (qreal)updPointGrab.x() + (qreal)size().width() / 2 - globalPosition.x();
 
         event->accept();
 
@@ -289,7 +294,11 @@ void UBMagnifier::mouseMoveEvent ( QMouseEvent * event )
         if(mShouldResizeWidget && (event->buttons() & Qt::LeftButton))
         {
 
-            QPoint currGlobalPos = event->globalPos();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            QPointF currGlobalPos = event->globalPosition();
+#else
+            QPointF currGlobalPos = event->globalPos();
+#endif
             qreal cvW = mView->width();
 
             qreal newXSize = ( currGlobalPos.x() + mMousePressDelta - updPointGrab.x() ) * 2;

--- a/src/gui/UBMousePressFilter.cpp
+++ b/src/gui/UBMousePressFilter.cpp
@@ -62,8 +62,13 @@ bool UBMousePressFilter::eventFilter(QObject *obj, QEvent *event)
                 delete mPendingEvent;
             }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            QPointF globalPosition = mouseEvent->globalPosition();
+#else
+            QPointF globalPosition = mouseEvent->globalPos();
+#endif
             mPendingEvent = new QMouseEvent(QEvent::MouseButtonDblClick,
-                mouseEvent->pos(), mouseEvent->globalPos(),
+                mouseEvent->pos(), globalPosition,
                 mouseEvent->button(), mouseEvent->buttons(),
                 mouseEvent->modifiers());
 
@@ -76,8 +81,12 @@ bool UBMousePressFilter::eventFilter(QObject *obj, QEvent *event)
     {
         if (mPendingEvent)
         {
-            QTabletEvent * tabletEvent = static_cast<QTabletEvent *>(event);
-            QPoint point = tabletEvent->globalPos() - mPendingEvent->globalPos();
+            QMouseEvent * mouseEvent = static_cast<QMouseEvent *>(event);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            QPointF point = mouseEvent->globalPosition() - mPendingEvent->globalPosition();
+#else
+            QPointF point = mouseEvent->globalPos() - mPendingEvent->globalPos();
+#endif
             if (isMouseRelease || point.manhattanLength() > QApplication::startDragDistance())
             {
                 delete mPendingEvent;

--- a/src/web/simplebrowser/tabwidget.cpp
+++ b/src/web/simplebrowser/tabwidget.cpp
@@ -86,7 +86,7 @@ TabWidget::TabWidget(QWebEngineProfile *profile, QWidget *parent)
                       arg(icon->pixmap().width()));
 #else
         setStyleSheet(QStringLiteral("QTabWidget::tab-bar { left: %1px; }").
-                      arg(icon->pixmap()->width()));
+                      arg(icon->pixmap(Qt::ReturnByValue).width()));
 #endif
     }
 }


### PR DESCRIPTION
This PR fixes the deprecation warnings when compiling with Qt 5.15 or Qt 6.2.

Additionally it fixes a warning about an unused result in `UBApplication`, which should actually be used and is also easy to use.

Also a bug was fixed in the `UBMousePressFilter`, where a `QEvent` was casted to a `QTabletEvent`, even if it was in fact a `QMouseEvent`.