### PR TITLE
Handle paste or drop of web page URL to board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ plugins/cffadaptor/objects
 ##########
 .directory
 .DS_Store
+Doxyfile

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -47,6 +47,7 @@ class UBDocumentController;
 class UBMessageWindow;
 class UBGraphicsScene;
 class UBDocumentProxy;
+class UBEmbedController;
 class UBBlackoutWidget;
 class UBToolWidget;
 class UBVersion;
@@ -298,6 +299,7 @@ class UBBoardController : public UBDocumentContainer
         UBBoardPaletteManager *mPaletteManager;
         UBSoftwareUpdateDialog *mSoftwareUpdateDialog;
         UBMessageWindow *mMessageWindow;
+        UBEmbedController *mEmbedController;
         UBBoardView *mControlView;
         UBBoardView *mDisplayView;
         QWidget *mControlContainer;

--- a/src/core/UB.h
+++ b/src/core/UB.h
@@ -53,6 +53,7 @@ struct UBMimeType
         PDF,
         OpenboardTool,
         Group,
+        Html,
         UNKNOWN
     };
 };

--- a/src/core/UBDownloadManager.cpp
+++ b/src/core/UBDownloadManager.cpp
@@ -472,25 +472,6 @@ void UBDownloadManager::cancelDownloads()
     finishDownloads(true);
 }
 
-void UBDownloadManager::onDownloadError(int id)
-{
-    QNetworkReply *pReply = dynamic_cast<QNetworkReply *>(mDownloads.value(id));
-    
-    if(NULL != pReply)
-    {
-        // Check which error occured:
-        switch(pReply->error())
-        {
-            case QNetworkReply::OperationCanceledError:
-                // For futur developments: do something in case of download aborting (message? remove the download?)
-            break;
-
-            default:
-                // Check the documentation of QNetworkReply in Qt Assistant for the different error cases
-            break;
-        }
-    }
-}
 
 void UBDownloadManager::finishDownloads(bool cancel)
 {
@@ -610,15 +591,7 @@ void UBDownloadHttpFile::onDownloadProgress(qint64 bytesReceived, qint64 bytesTo
  */
 void UBDownloadHttpFile::onDownloadFinished(bool pSuccess, QUrl sourceUrl, QString pContentTypeHeader, QByteArray pData, QPointF pPos, QSize pSize, bool isBackground)
 {
-    if(pSuccess)
-    {
-        // Notify the end of the download
-        emit downloadFinished(mId, pSuccess, sourceUrl, sourceUrl, pContentTypeHeader, pData, pPos, pSize, isBackground);
-    }
-    else
-    {
-        // Notify the fact that and error occured during the download
-        emit downloadError(mId);
-    }
+    // Notify the end of the download
+    emit downloadFinished(mId, pSuccess, sourceUrl, sourceUrl, pContentTypeHeader, pData, pPos, pSize, isBackground);
 }
 

--- a/src/core/UBDownloadManager.h
+++ b/src/core/UBDownloadManager.h
@@ -92,7 +92,6 @@ public:
 signals:
     void downloadProgress(int id, qint64 current,qint64 total);
     void downloadFinished(int id, bool pSuccess, QUrl sourceUrl, QUrl contentUrl, QString pContentTypeHeader, QByteArray pData, QPointF pPos, QSize pSize, bool isBackground);
-    void downloadError(int id);
 
 private slots:
     void onDownloadFinished(bool pSuccess, QUrl sourceUrl, QString pContentTypeHeader, QByteArray pData, QPointF pPos, QSize pSize, bool isBackground);
@@ -155,7 +154,6 @@ private slots:
     void onUpdateDownloadLists();
     void onDownloadProgress(int id, qint64 received, qint64 total);
     void onDownloadFinished(int id, bool pSuccess, QUrl sourceUrl, QUrl contentUrl, QString pContentTypeHeader, QByteArray pData, QPointF pPos, QSize pSize, bool isBackground);
-    void onDownloadError(int id);
 
 private:
     void init();

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -36,7 +36,6 @@
 
 #include "UBItem.h"
 #include "tools/UBGraphicsCurtainItem.h"
-#include "web/UBEmbedParser.h"
 
 class UBGraphicsPixmapItem;
 class UBGraphicsSvgItem;

--- a/src/frameworks/UBFileSystemUtils.cpp
+++ b/src/frameworks/UBFileSystemUtils.cpp
@@ -578,6 +578,10 @@ UBMimeType::Enum UBFileSystemUtils::mimeTypeFromString(const QString& typeString
     {
         type = UBMimeType::VectorImage;
     }
+    else if (typeString == "text/html")
+    {
+        type = UBMimeType::Html;
+    }
     else if (typeString == "application/vnd.apple-widget")
     {
         type = UBMimeType::AppleWidget;

--- a/src/web/UBEmbedController.h
+++ b/src/web/UBEmbedController.h
@@ -45,21 +45,74 @@ namespace Ui
 }
 
 
+/**
+ * @brief The UBEmbedController class provides means to present embeddable content to the
+ * user and to create web widgets from selected content.
+ *
+ * @sa UBEmbedParser, UBEmbedContent
+ */
 class UBEmbedController : public QObject
 {
     Q_OBJECT
 
 public:
+    /**
+     * @brief Constructs a UBEmbedController object which is a child of the given parent widget.
+     * @param parent Parent widget. Used to position and size the embed dialog so that it
+     * appears on top of that widget.
+     */
     UBEmbedController(QWidget* parent = nullptr);
+
+    /**
+     * @brief Destroys the UBEmbedController object.
+     */
     virtual ~UBEmbedController();
 
+    /**
+     * @brief Update the list of embeddable content shown in the embed dialog.
+     *
+     * In addition to the entries of the list provided by this call, the dialog always
+     * contains a first entry offering to embed the complete web page.
+     *
+     * This function may be called multiple times to update the list.
+     *
+     * @param pAllContent List of embeddable content descriptions.
+     */
     void updateListOfEmbeddableContent(const QList<UBEmbedContent>& pAllContent);
 
 public slots:
+    /**
+     * @brief Show the dialog allowing to select embeddable content.
+     *
+     * Before calling this function, the URL and title of the page should be set by
+     * pageUrlChanged and pageTitleChanged.
+     */
     void showEmbedDialog();
+
+    /**
+     * @brief Hide the dialog allowing to select embeddable content.
+     */
     void hideEmbedDialog() const;
 
+    /**
+     * @brief Update the URL of the web page containing the embeddable content.
+     *
+     * This slot must be called before the UBEmbedController can create a web widget
+     * embedding the complete web page.
+     *
+     * @param url URL of web page.
+     */
     void pageUrlChanged(const QUrl& url);
+
+    /**
+     * @brief Update the title of the web page containing the embeddable content.
+     *
+     * This slot should be called before the UBEmbedController can create a web widget
+     * embedding the complete web page. This information is used to propose a name for
+     * the web widget.
+     *
+     * @param title Title of web page.
+     */
     void pageTitleChanged(const QString& title);
 
 private slots:

--- a/src/web/UBEmbedController.h
+++ b/src/web/UBEmbedController.h
@@ -27,15 +27,17 @@
 
 
 
-#ifndef UBEMBEDCONTROLLER_H_
-#define UBEMBEDCONTROLLER_H_
+#pragma once
 
-#include <QtGui>
+#include <QDialog>
+#include <QDir>
+#include <QList>
+#include <QString>
+#include <QUrl>
+#include <QWidget>
 
 #include <web/UBEmbedContent.h>
 
-// forward
-class QWebEngineView;
 
 namespace Ui
 {
@@ -45,44 +47,41 @@ namespace Ui
 
 class UBEmbedController : public QObject
 {
-    Q_OBJECT;
-    public:
-        UBEmbedController(QWidget* parent = nullptr);
-        virtual ~UBEmbedController();
+    Q_OBJECT
 
-        void showEmbedDialog();
-        void hideEmbedDialog();
+public:
+    UBEmbedController(QWidget* parent = nullptr);
+    virtual ~UBEmbedController();
 
-    public slots:
-        void updateEmbeddableContentFromView(QWebEngineView* pCurrentWebFrame);
-        void textChanged(const QString &);
-        void textEdited(const QString &);
+    void updateListOfEmbeddableContent(const QList<UBEmbedContent>& pAllContent);
 
+public slots:
+    void showEmbedDialog();
+    void hideEmbedDialog() const;
 
-    private slots:
-        void selectFlash(int pFlashIndex);
-        void createWidget();
+    void pageUrlChanged(const QUrl& url);
+    void pageTitleChanged(const QString& title);
 
-    private:
-        void updateListOfEmbeddableContent(const QList<UBEmbedContent>& pAllContent);
+private slots:
+    void textChanged(const QString& text);
+    void selectFlash(int pFlashIndex);
+    void createWidget();
 
-        QString widgetNameForObject(const UBEmbedContent& pObject) const;
+private:
+    void importWidgetInLibrary(const QDir& pSourceDir) const;
 
-        QString generateFullPageHtml(const QUrl& url, const QString& pDirPath, bool pGenerateFile);
-        QString generateHtml(const UBEmbedContent& pObject, const QString& pDirPath, bool pGenerateFile);
+    QString generateFullPageHtml(const QUrl& url, const QString& pDirPath = QString(), bool pGenerateFile = false) const;
+    QString generateHtml(const UBEmbedContent& pObject, const QString& pDirPath = QString(), bool pGenerateFile = false) const;
+    QString generateIcon(const QString& pDirPath) const;
+    void generateConfig(int pWidth, int pHeight, const QString& pDestinationPath) const;
 
-        QString generateIcon(const QString& pDirPath);
+    QString widgetNameForObject(const UBEmbedContent& pObject) const;
 
-        void generateConfig(int pWidth, int pHeight, const QString& pDestinationPath);
-
-        void importWidgetInLibrary(QDir pSourceDir);
-
-        Ui::trapFlashDialog* mTrapFlashUi;
-        QDialog* mTrapDialog;
-        QWidget* mParentWidget;
-        QWebEngineView* mCurrentWebFrame;
-        QList<UBEmbedContent> mAvailableContent;
+private:
+    Ui::trapFlashDialog* mTrapFlashUi;
+    QDialog* mTrapDialog;
+    QWidget* mParentWidget;
+    QList<UBEmbedContent> mAvailableContent;
+    QUrl mUrl;
+    QString mPageTitle;
 };
-
-
-#endif /* UBTRAPFLASHCONTROLLER_H_ */

--- a/src/web/UBEmbedParser.h
+++ b/src/web/UBEmbedParser.h
@@ -40,46 +40,124 @@
 class QNetworkAccessManager;
 class QNetworkReply;
 
-/**********************************************************************************
-  ----------------------------------------------------------------
-  Here is an example of an embed content in an XML representation
-  ----------------------------------------------------------------
-  <oembed>
-    <provider_url>http://www.youtube.com/</provider_url>
-    <title>EPISODE 36 Traditional Mediums</title>
-    <html>
-      <iframe width="480" height="270" src="http://www.youtube.com/embed/C3lApsNmdwM?fs=1&feature=oembed" frameborder="0" allowfullscreen></iframe>
-    </html>
-    <author_name>FZDSCHOOL</author_name>
-    <height>270</height>
-    <thumbnail_width>480</thumbnail_width>
-    <width>480</width>
-    <version>1.0</version>
-    <author_url>http://www.youtube.com/user/FZDSCHOOL</author_url>
-    <provider_name>YouTube</provider_name>
-    <thumbnail_url>http://i4.ytimg.com/vi/C3lApsNmdwM/hqdefault.jpg</thumbnail_url>
-    <type>video</type>
-    <thumbnail_height>360</thumbnail_height>
-  </oembed>
-***********************************************************************************/
 
-
+/**
+ * @brief The UBEmbedParser class provides a means for parsing HTML for embeddable content.
+ *
+ * HTML pages may provide embeddable content via several mechanisms:
+ * - By using `<iframe>` tags.
+ * - By providing information on how to embed content using `<iframe>`.
+ * - By using `<link>` tags with `type="oembed"`.
+ *
+ * The UBEmbedParser scans HTML input for such constructs, retrieves oembed information if
+ * necessary and builds a list of embeddable content. This list can be provided to an
+ * UBEmbedController, which offers the option to create a web widget from a selected
+ * list entry.
+ *
+ * ### Embeddable content from <iframe> tags
+ *
+ * A web page may contain embedded content referenced by an `<iframe>` tag. Such content is
+ * in turn embeddable in other web pages. Such tags and their content are added to the list.
+ *
+ * Sometimes the web page contains instructions on how to embed some content, e.g. in a text
+ * field containing the necessary `<iframe>` tag. In these cases the opening `<` is represented
+ * as entity using `&lt;`. The UBEmbedParser also tries to identify and use such information.
+ *
+ * ### Embeddable content using oEmbed.
+ *
+ * Some web pages provide instructions for embedding using the [oEmbed](https://oembed.com/)
+ * standard. Here special `<link>` tags are used to point to an external resource providing
+ * information about embeddable content. The UBEmbedParser retrieves such information as XML
+ * or JSON documents and includes the result in its list of embeddable content.
+ *
+ * Here is an example of oEmbed information in XML format:
+ * ```xml
+ * <oembed>
+ *   <provider_url>http://www.youtube.com/</provider_url>
+ *   <title>EPISODE 36 Traditional Mediums</title>
+ *   <html>
+ *     <iframe width="480" height="270" src="http://www.youtube.com/embed/C3lApsNmdwM?fs=1&feature=oembed" frameborder="0" allowfullscreen></iframe>
+ *   </html>
+ *   <author_name>FZDSCHOOL</author_name>
+ *   <height>270</height>
+ *   <thumbnail_width>480</thumbnail_width>
+ *   <width>480</width>
+ *   <version>1.0</version>
+ *   <author_url>http://www.youtube.com/user/FZDSCHOOL</author_url>
+ *   <provider_name>YouTube</provider_name>
+ *   <thumbnail_url>http://i4.ytimg.com/vi/C3lApsNmdwM/hqdefault.jpg</thumbnail_url>
+ *   <type>video</type>
+ *   <thumbnail_height>360</thumbnail_height>
+ * </oembed>
+ * ```
+ *
+ * @sa UBEmbedContent, UBEmbedController
+ */
 class UBEmbedParser : public QObject
 {
     Q_OBJECT
 
 public:
+    /**
+     * @brief Constructs a UBEmbedParser object which is a child of parent and the given object name.
+     * @param parent Parent object, default is `nullptr`.
+     * @param name Object name, default is `"UBEmbedParser"`.
+     */
     explicit UBEmbedParser(QObject* parent = nullptr, const char* name="UBEmbedParser");
 
+    /**
+     * @brief Destroys the UBEmbedParser object.
+     */
     virtual ~UBEmbedParser();
+
+    /**
+     * @brief Returns `true` if the parser has found any embeddable content.
+     *
+     * To retrieve the final result, this function should be invoked after parseResult was emitted.
+     *
+     * @return `true` if the parser has found any embeddable content.
+     * @sa parse, parseResult
+     */
     bool hasEmbeddedContent() const;
+
+    /**
+     * @brief Retrieves the list of embeddable content.
+     *
+     * To retrieve the final result, this function should be invoked after parseResult was emitted.
+     * The list remains valid until a new parse process is started.
+     *
+     * @return List of UBEmbedContent found on the HTML page.
+     * @sa parse, parseResult
+     */
     QList<UBEmbedContent> embeddedContent() const;
 
 signals:
+    /**
+     * @brief This signal is emitted when the parsing is complete and the result may be retrieved.
+     *
+     * @param hasEmbeddedContent `true` if any embeddable content was found.
+     */
     void parseResult(bool hasEmbeddedContent);
+
+    /**
+     * @brief This signal is emitted when the parsing was cancelled by invoking parse again while
+     * the previous parse process was not completed.
+     *
+     * This signal is mainly for internal use. It cancels any pending network requests for oembed
+     * information. A parseResult signal is not emitted for the aborted parse operation.
+     */
     void cancelled();
 
 public slots:
+    /**
+     * @brief Start parsing the given HTML input.
+     *
+     * Starts the parsing process for the given HTML input. The parsing is an asynchronous process,
+     * as it may involve retrieving oEmbed information. The end of this proces is signaled by
+     * emitting parseResult.
+     *
+     * @param html HTML document to parse.
+     */
     void parse(const QString& html);
 
 private slots:

--- a/src/web/UBEmbedParser.h
+++ b/src/web/UBEmbedParser.h
@@ -27,8 +27,7 @@
 
 
 
-#ifndef UBOEMBEDPARSER_H
-#define UBOEMBEDPARSER_H
+#pragma once
 
 #include <QList>
 #include <QObject>
@@ -36,10 +35,10 @@
 
 #include "web/UBEmbedContent.h"
 
+
 // forward
 class QNetworkAccessManager;
 class QNetworkReply;
-class QWebEngineView;
 
 /**********************************************************************************
   ----------------------------------------------------------------
@@ -70,33 +69,32 @@ class UBEmbedParser : public QObject
     Q_OBJECT
 
 public:
-    explicit UBEmbedParser(QWebEngineView* parent, const char* name="UBEmbedParser");
-    ~UBEmbedParser();
+    explicit UBEmbedParser(QObject* parent = nullptr, const char* name="UBEmbedParser");
 
+    virtual ~UBEmbedParser();
     bool hasEmbeddedContent() const;
-    QList<UBEmbedContent> embeddedContent();
+    QList<UBEmbedContent> embeddedContent() const;
 
 signals:
-    void parseResult(QWebEngineView* view, bool hasEmbeddedContent);
+    void parseResult(bool hasEmbeddedContent);
+    void cancelled();
+
+public slots:
+    void parse(const QString& html);
 
 private slots:
-    void onLoadFinished();
-    void parse(const QString& html);
     void fetchOEmbed(const QString& url);
     void onFinished(QNetworkReply* reply);
 
 private:
-    UBEmbedContent getJSONInfos(const QString& json) const;
-    UBEmbedContent getXMLInfos(const QString& xml) const;
+    UBEmbedContent getJSONInfo(const QString& json) const;
+    UBEmbedContent getXMLInfo(const QString& xml) const;
     UBEmbedContent createIframeContent(const QString& html) const;
 
 private:
-    QWebEngineView* mView;
     QList<UBEmbedContent> mContents;
     QList<QString> mParsedTitles;
     QNetworkAccessManager* mpNam;
     bool mParsing;
     int mPending;
 };
-
-#endif // UBOEMBEDPARSER_H

--- a/src/web/UBWebController.h
+++ b/src/web/UBWebController.h
@@ -36,15 +36,17 @@
 #include <QWebEnginePage>
 #include <QWebEngineUrlRequestInterceptor>
 
-#include "UBEmbedParser.h"
+#include "UBEmbedContent.h"
 #include "simplebrowser/downloadmanagerwidget.h"
 
 class BrowserWindow;
 class WebView;
 class QMenu;
 class QWebEngineProfile;
+class QWebEngineView;
 class UBApplication;
 class UBEmbedController;
+class UBEmbedParser;
 class UBMainWindow;
 class UBWebToolsPalette;
 class UBServerXMLHttpRequest;
@@ -65,7 +67,6 @@ private:
 class UBWebController : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(CookiePolicy)
 
     public:
         enum CookiePolicy {
@@ -73,6 +74,7 @@ class UBWebController : public QObject
             DenyThirdParty,
             AcceptAll
         };
+        Q_ENUM(CookiePolicy)
 
         UBWebController(UBMainWindow* mainWindow);
         virtual ~UBWebController();
@@ -88,7 +90,7 @@ class UBWebController : public QObject
         void show();
         QWidget* controlView() const;
         QWebEngineProfile* webProfile() const;
-        QList<UBEmbedContent> getEmbeddedContent(const QWebEngineView* view);
+        QList<UBEmbedContent> getEmbeddedContent(const QWebEngineView* view) const;
         BrowserWindow* browserWindow() const;
         QWebEnginePage::PermissionPolicy hasFeaturePermission(const QUrl &securityOrigin, QWebEnginePage::Feature feature);
         void setFeaturePermission(const QUrl &securityOrigin, QWebEnginePage::Feature feature, QWebEnginePage::PermissionPolicy policy);
@@ -118,6 +120,7 @@ class UBWebController : public QObject
     private:
         void webBrowserInstance();
         UBEmbedParser* embedParser(const QWebEngineView* view) const;
+        void updateEmbeddableContent(const QWebEngineView* view) const;
         static QUrl guessUrlFromString(const QString &string);
 
     private slots:


### PR DESCRIPTION
On the way to handling URLs pointing to web pages (content type is `text/html`) this PR also provides some fixes and refactoring as well as class documentation. It contains four commits:

### Fix: no drag operations after pasting a URL to an inaccessible resource

After pasting a URL to an inaccessible URL to the board, e.g. one which returns a 404 error, any operations involving dragging on the board have been blocked due to inappropriate handling of the error case. The first commit fixes this issue.

### Refactor: decouple embed parsing from web engine

The `QEmbedController`  and `QEmbedParser` had references to `QWebEngineView`. Architecturally this is not necessary. All these classes should do is to parse a piece of HTML and extract embeddable content, to control the embed dialog and to create the widgets.

This refactoring therefore moves these dependencies out of those classes. 

Additionally it adds some style changes and fixes some typos. Especially it does:

- Remove an unnecessary `#include "web/UBEmbedParser.h"` from `UBGraphicsScene`.
- Clean-up includes in `UBEmbedController.cpp`.
- Use the Qt5 style of `connect` using compile-time checked function pointers.
- Reorder function declarations and implementations, so that they have the same sequence in the header and the source.
- Add new public slots to set title and URL of web page.
- Add `const` to parameters and functions where possible.
- Always align `*` or `&` in function parameters to the type and not the name. Just a matter of taste, but we should be consistent.
- Always use braces after `if`, avoid single line bodies. This helps avoiding problems when later additional lines might be added.
- Avoid calling static function with an object.
- Use `#pragma once` instead of `#ifndef` guards. There was already a symbol used which did not match the class name.
- Include what you need instead of module includes like `QtGui`. See [Beware of Qt Module-wide Includes](https://www.kdab.com/beware-of-qt-module-wide-includes/) for reasons.
- Don't indent after first brace in class declaration.
- Abort parsing oEmbed when new HTML is provided.
- Avoid `clazy` warnings. They might indicate possible problems or performance drawbacks.

### Feat: Handle paste or drop of web page URL to board

After these preparations, implementation of this feature is easy:

- Add a mime type for `text/html` to `UBMimeType`.
- Add `UBEmbedController` to `UBBoardController` to provide the embed dialog and create the widget.
- Add `UBEmbedParser` to `UBBoardController` to parse the provided data.

### Docs: Documentation

`UBEmbedController` and `UBEmbedParser` have been annotated with Doxygen style documentation in the header. Just as a very first step...

### Further options

While implementing this I also thought about the following: 

- Currently the embed dialog does not have a "Cancel" button. It can however be cancelled using the "Close" button. But IMHO all dialogs should have a "Cancel" button if they can be cancelled.
- Currently a widget is always created in the library and as well placed on the board. Should there be options to only add it to the board or only add it to the library?