### PR TITLE
workaround: position of drop down menu in widgets

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -155,6 +155,13 @@ void UBBoardView::init ()
     connect (UBSettings::settings ()->boardUseHighResTabletEvent, SIGNAL (changed (QVariant)),
              this, SLOT (settingChanged (QVariant)));
 
+    connect(mController, &UBBoardController::controlViewportChanged, this, [this](){
+        if (scene())
+        {
+            scene()->controlViewportChanged();
+        }
+    });
+
     setOptimizationFlags (QGraphicsView::IndirectPainting | QGraphicsView::DontSavePainterState); // enable UBBoardView::drawItems filter
     setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
     setWindowFlags (Qt::FramelessWindowHint);
@@ -1862,6 +1869,12 @@ void UBBoardView::drawBackground (QPainter *painter, const QRectF &rect)
             painter->drawRect (pageRect);
         }
     }
+}
+
+void UBBoardView::scrollContentsBy(int dx, int dy)
+{
+    QGraphicsView::scrollContentsBy(dx, dy);
+    scene()->controlViewportChanged();
 }
 
 void UBBoardView::settingChanged (QVariant newValue)

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -117,6 +117,8 @@ protected:
 
     virtual void drawBackground(QPainter *painter, const QRectF &rect);
 
+    virtual void scrollContentsBy(int dx, int dy);
+
 private:
 
     void init();

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2407,6 +2407,20 @@ void UBGraphicsScene::stylusToolChanged(int tool, int previousTool)
     }
 }
 
+void UBGraphicsScene::controlViewportChanged()
+{
+    // inform all UBGraphicsWidgetItems about viewport change
+    // partial workaround for QTBUG-109068
+    foreach (QGraphicsItem *item, items())
+    {
+        if (item->type() == UBGraphicsWidgetItem::Type)
+        {
+            UBGraphicsWidgetItem* widgetItem = qgraphicsitem_cast<UBGraphicsWidgetItem *>(item);
+            widgetItem->updatePosition();
+        }
+    }
+}
+
 void UBGraphicsScene::addCompass(QPointF center)
 {
     UBGraphicsCompass* compass = new UBGraphicsCompass(); // mem : owned and destroyed by the scene

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -389,6 +389,8 @@ public slots:
 
         void stylusToolChanged(int tool, int previousTool);
 
+        void controlViewportChanged();
+
     protected:
 
         UBGraphicsPolygonItem* lineToPolygonItem(const QLineF& pLine, const qreal& pWidth);

--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -384,6 +384,15 @@ void UBGraphicsWidgetItem::saveSnapshot() const
     }
 }
 
+void UBGraphicsWidgetItem::updatePosition()
+{
+    // partial workaround for QTBUG-109068 to forward the position of the item
+    // on the scene to the QWebEngineView
+    QSize actualSize = size().toSize();
+    mWebEngineView->resize(actualSize - QSize(1,1));
+    mWebEngineView->resize(actualSize);
+}
+
 void UBGraphicsWidgetItem::setSnapshot(const QPixmap& pix, bool frozen)
 {
     mSnapshot = pix;
@@ -740,11 +749,7 @@ void UBGraphicsWidgetItem::mainFrameLoadFinished (bool ok)
 
     // repaint when initial rendering is done
     update();
-
-    // Workaround: slightly change size to make sure QWebEngineView knows size and position
-    QSize actualSize = size().toSize();
-    mWebEngineView->resize(actualSize - QSize(1,1));
-    mWebEngineView->resize(actualSize);
+    updatePosition();
 }
 
 void UBGraphicsWidgetItem::wheelEvent(QGraphicsSceneWheelEvent *event)
@@ -764,10 +769,7 @@ QVariant UBGraphicsWidgetItem::itemChange(GraphicsItemChange change, const QVari
         else if (scene()->activeWindow() == this)
             scene()->setActiveWindow(nullptr);
     } else if (change == QGraphicsItem::ItemTransformHasChanged) {
-        // Workaround: slightly change size to make sure QWebEngineView knows size and position
-        QSize actualSize = size().toSize();
-        mWebEngineView->resize(actualSize - QSize(1,1));
-        mWebEngineView->resize(actualSize);
+        updatePosition();
     }
 
     QVariant newValue = Delegate()->itemChange(change, value);

--- a/src/domain/UBGraphicsWidgetItem.h
+++ b/src/domain/UBGraphicsWidgetItem.h
@@ -128,6 +128,8 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
         const QPixmap& takeSnapshot();
         void saveSnapshot() const;
 
+        void updatePosition();
+
         virtual UBItem* deepCopy() const override = 0;
         virtual UBGraphicsScene* scene() override;
 


### PR DESCRIPTION
This PR tries to mitigate [QTBUG-109068](https://bugreports.qt.io/browse/QTBUG-109068) at least partially. It forwards the widget position to the `QWebEngineView` when

- the widget is moved,
- the viewport is changed using the hand tool, the arrow keys or  the mouse wheel.

It does not mitigate the problem with drop down menus when zooming, as there is no known workaround for this.

Changes involve:

- Inform widgets about viewport changes.
- Move workaround to common `updatePosition()` function.