### PR TITLE
Hover over screen selection buttons

### DIFF
--- a/src/core/UBDisplayManager.cpp
+++ b/src/core/UBDisplayManager.cpp
@@ -332,6 +332,8 @@ void UBDisplayManager::positionScreens()
 
         // Sometimes moving control screen to the left won't operate...
         // found out that resetting the geometry solves theses cases better than "showNormal() workaround"
+        // however there are cases when "showNormal()" is required to update control screen position, so doing both
+        controlWidget->showNormal();
         controlWidget->setGeometry(QRect());
 
         QRect geometry = screenGeometry(ScreenRole::Control);


### PR DESCRIPTION
During screen selection, change the cursor shape over the screen selection buttons.

Additionally this PR fixes some issues with screen selection which occur only in debug mode.

The second commit improves positioning of the control screen during screen configuration: There are cases when resetting the geometry does not help and `showNormal()` is still required.