### PR TITLE
Hide cross-hair cursor when lifting pen if preview circle on

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -425,6 +425,13 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
         scene ()->setToolCursor (currentTool);
         setToolCursor (currentTool);
 
+        if (currentTool == UBStylusTool::Marker) {
+            scene()->drawMarkerCircle(scenePos);
+        }
+        else if (currentTool == UBStylusTool::Pen) {
+            scene()->drawPenCircle(scenePos);
+        }
+
         scene ()->inputDeviceRelease ();
 
         mPendingStylusReleaseEvent = false;
@@ -1329,6 +1336,15 @@ void UBBoardView::mouseReleaseEvent (QMouseEvent *event)
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)UBDrawingController::drawingController ()->stylusTool ();
 
     setToolCursor (currentTool);
+
+    QPointF scenePos = mapToScene(event->pos());
+    if (currentTool == UBStylusTool::Marker) {
+        scene()->drawMarkerCircle(scenePos);
+    }
+    else if (currentTool == UBStylusTool::Pen) {
+        scene()->drawPenCircle(scenePos);
+    }
+
     // first/ propagate device release to the scene
     if (scene())
         scene()->inputDeviceRelease();

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -377,6 +377,8 @@ public slots:
         void textUndoCommandAdded(UBGraphicsTextItem *textItem);
 
         void setToolCursor(int tool);
+        void drawMarkerCircle(const QPointF& pEndPoint);
+        void drawPenCircle(const QPointF& pEndPoint);
 
         void selectionChangedProcessing();
         void moveMagnifier();
@@ -407,8 +409,6 @@ public slots:
         void redrawEraser(bool pressed);
         void hideEraser();
         void drawPointer(const QPointF& pEndPoint, bool isFirstDraw = false);
-        void drawMarkerCircle(const QPointF& pEndPoint);
-        void drawPenCircle(const QPointF& pEndPoint);
         void hideMarkerCircle();
         void hidePenCircle();
         void DisposeMagnifierQWidgets();


### PR DESCRIPTION
* src/board/UBBoardView.cpp (UBBoardView::tabletEvent, UBBoardView::mouseReleaseEvent): Call UBGraphicsScene::drawMarkerCircle or UBGraphicsScene::drawPenCircle after setting the tool cursor, in order to hide the cross-hairs cursor and show the preview circle if it is turned on.
* src/domain/UBGraphicsScene.h (class UBGraphicsScene): Make drawMarkerCircle and drawPenCircle public functions.