### PR TITLE
Multiple fixes: irregular z values, palette size, save page size

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -161,6 +161,8 @@ class UBSvgSubsetAdaptor
 
                 void graphicsItemFromSvg(QGraphicsItem* gItem);
 
+                qreal normalizedZValue(bool* hasValue);
+
                 QXmlStreamReader mXmlReader;
                 int mFileVersion;
                 UBDocumentProxy *mProxy;

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2584,6 +2584,13 @@ void UBGraphicsScene::setNominalSize(const QSize& pSize)
     if (nominalSize() != pSize)
     {
         mNominalSize = pSize;
+        setModified(true);    // modifying the size modifies the scene
+
+        // force redrawing the background
+        foreach(QGraphicsView* view, views())
+        {
+            view->resetCachedContent();
+        }
 
         if(mDocument)
             mDocument->setDefaultDocumentSize(pSize);


### PR DESCRIPTION
This PR fixes three independent, but small issues, so I collected them into a single PR. Please let me know if you prefer individual PRs for each of them. The fixes are:

- Fix for #597 which blocked OpenBoard when opening a document with irregular z values.
- Fix for an issue where the palette size was reduced when OpenBoard was started and the palettes are visible. Resize events are now suppressed during repositioning of screens to avoid this.
- Fix for #710 as proposed in my comment on this issue. Changing the page size now sets the document as "modified" and refreshes the cache.
