### PR TITLE
fix: sync onboard state with internal action

### DIFF
--- a/src/frameworks/UBPlatformUtils.h
+++ b/src/frameworks/UBPlatformUtils.h
@@ -219,6 +219,24 @@ public:
 #endif
 };
 
+#ifdef Q_OS_LINUX
+#include <QDBusConnection>
+
+class OnboardListener : public QObject
+{
+    Q_OBJECT
+
+public:
+    OnboardListener(const QDBusConnection& connection, QObject* parent = nullptr);
+
+public slots:
+    void onboardPropertiesChanged(QString interface, QMap<QString, QVariant> properties) const;
+
+private:
+    QDBusConnection mConnection;
+};
+
+#endif
 
 
 #endif /* UBPLATFORMUTILS_H_ */

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -33,6 +33,7 @@
 #include <QApplication>
 #include <QDBusConnectionInterface>
 #include <QDBusInterface>
+#include <QDBusMetaType>
 
 #include <unistd.h>
 #include <X11/keysym.h>
@@ -41,7 +42,9 @@
 #include "core/UBApplication.h"
 #include "core/UBDisplayManager.h"
 #include "core/UBSettings.h"
+#include "gui/UBMainWindow.h"
 
+static OnboardListener* listener = nullptr;
 
 void UBPlatformUtils::init()
 {
@@ -471,6 +474,11 @@ void UBPlatformUtils::showOSK(bool show)
         if (dbus.isValid())
         {
             dbus.call("Show");
+
+            if (!listener)
+            {
+                listener = new OnboardListener(dbus.connection(), qApp);
+            }
         }
         else
         {
@@ -490,5 +498,34 @@ void UBPlatformUtils::showOSK(bool show)
     else
     {
         qDebug() << "onboard not registered/installed";
+    }
+}
+
+OnboardListener::OnboardListener(const QDBusConnection& connection, QObject* parent)
+        : QObject{parent}
+        , mConnection{connection}
+{
+    qDBusRegisterMetaType<QMap<QString, QVariant>>();
+    const auto ok = mConnection.connect(
+                "org.onboard.Onboard", "/org/onboard/Onboard/Keyboard",
+                "org.freedesktop.DBus.Properties", "PropertiesChanged",
+                this, SLOT(onboardPropertiesChanged(QString,QMap<QString,QVariant>)));
+    if (!ok)
+    {
+        qDebug() << "Could not connect to DBus service listening for onboard properties";
+    }
+}
+
+void OnboardListener::onboardPropertiesChanged(QString interface, QMap<QString, QVariant> properties) const
+{
+    if (interface == "org.onboard.Onboard.Keyboard" && properties.contains("Visible"))
+    {
+        const auto onboardVisible = properties.value("Visible").toBool();
+        const auto oskAction = UBApplication::mainWindow->actionVirtualKeyboard;
+
+        if (oskAction->isChecked() != onboardVisible)
+        {
+            oskAction->trigger();
+        }
     }
 }


### PR DESCRIPTION
The visibility state of the `onboard` keyboard could be changed by means external to OpenBoard, e.g. by simply hiding the keyboard with the :x: key in the upper right corner. Currently OpenBoard cannot detect such changes. In order to make the `onboard` keyboard visible again, the user would have to tap the OpenBoard action twice.

In order to keep states synchronized, this PR
- adds the `OnboardListener` class to listen for visibility changes, and
- triggers (and thus synchronizes) the corresponding action when visibility was changed externally.

This also invokes any other tasks (e.g. update mask in desktop mode) connected to a change in keyboard visibility.