### PR TITLE
fix: consider image rotation

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -1172,9 +1172,12 @@ UBItem *UBBoardController::downloadFinished(bool pSuccess, QUrl sourceUrl, QUrl 
         if(pData.length() == 0){
             pix.load(sourceUrl.toLocalFile());
         }
-        else{
-            QImage img;
-            img.loadFromData(pData);
+        else
+        {
+            QBuffer buffer(&pData);
+            QImageReader rdr(&buffer);
+            rdr.setAutoTransform(true);
+            QImage img = rdr.read();
             pix = QPixmap::fromImage(img);
         }
 


### PR DESCRIPTION
Currently transformation of images dropped on the board which is contained in image metadata (EXIF) is not considered by OpenBoard. This PR changes the way how images are loaded to consider such data.

- consider transformations contained in image metadata (EXIF)
- use QImageReader to control transformation

This PR fixes #744.