### PR TITLE
fix: PDF export when background PDF was scaled

### DIFF
--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2104,7 +2104,7 @@ void UBGraphicsScene::unsetBackgroundObject()
 QRectF UBGraphicsScene::normalizedSceneRect(qreal ratio)
 {
 
-    QRectF normalizedRect(nominalSize().width() / -2, nominalSize().height() / -2,
+    QRectF normalizedRect(nominalSize().width() / -2., nominalSize().height() / -2.,
         nominalSize().width(), nominalSize().height());
 
     foreach(QGraphicsItem* gi, mFastAccessItems)


### PR DESCRIPTION
I hope this PR now finally fixes the PDF export scaling. The main changes are

- use pageDpi to convert scene units to PDF units
- take the scaling between original PDF and scene into account
- use actual appearance on scene to calculate the scaling factor
- avoid rounding error in UBGraphicsScene::normalizedSceneRect

In fact this reintroduces a former idea, but in a different implementation. originally, the scaling of a PDF document on the scene was computed by getting `m11` of the transformation matrix. There were however cases - and I cannot exactly tell why - when this was not what we see on the screen. Now this factor is computed by using the scene bounding rect of the PDF and its original size as taken from the document.

When interpreting the scene coordinates, we now always use the pageDpi as stored in the document. In some former version (not the last one) the actual screen resolution was used, which of course can be different.

Additional a small rounding error was fixes when computing the normalized scene rect. The effect is barely visible, but for the sake of exactness..

I tested this now with all of the problematic documents we collected and it looks fine on my platform. Please test on your side before merging.