### PR TITLE
perf: store images in source format

### DIFF
--- a/src/adaptors/UBImportImage.cpp
+++ b/src/adaptors/UBImportImage.cpp
@@ -102,6 +102,7 @@ QList<UBGraphicsItem*> UBImportImage::import(const QUuid& uuid, const QString& f
     UBGraphicsPixmapItem* pixmapItem = new UBGraphicsPixmapItem();
     pixmapItem->setPixmap(pix);
     result << pixmapItem;
+    mLastFilePath = filePath;
 
     return result;
 }
@@ -110,11 +111,17 @@ void UBImportImage::placeImportedItemToScene(UBGraphicsScene* scene, UBGraphicsI
 {
     UBGraphicsPixmapItem* pixmapItem = (UBGraphicsPixmapItem*)item;
 
-     UBGraphicsPixmapItem* sceneItem = scene->addPixmap(pixmapItem->pixmap(), NULL, QPointF(0, 0),1.0,false,true);
-     scene->setAsBackgroundObject(sceneItem, true);
+    QFile file(mLastFilePath);
 
-     // Only stored pixmap, should be deleted now
-     delete pixmapItem;
+    if (file.open(QFile::ReadOnly))
+    {
+        QByteArray data = file.readAll();
+        UBGraphicsPixmapItem* sceneItem = scene->addImage(data, nullptr, QPointF(0, 0), 1.0, false, true);
+        scene->setAsBackgroundObject(sceneItem, true);
+    }
+
+    // Only stored pixmap, should be deleted now
+    delete pixmapItem;
 }
 
 const QString& UBImportImage::folderToCopy()

--- a/src/adaptors/UBImportImage.h
+++ b/src/adaptors/UBImportImage.h
@@ -49,6 +49,9 @@ class UBImportImage : public UBPageBasedImportAdaptor
         virtual QList<UBGraphicsItem*> import(const QUuid& uuid, const QString& filePath);
         virtual void placeImportedItemToScene(UBGraphicsScene* scene, UBGraphicsItem* item);
         virtual const QString& folderToCopy();
+
+    private:
+        QString mLastFilePath;
 };
 
 #endif /* UBIMPORTIMAGE_H_ */

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -881,23 +881,35 @@ void UBBoardPaletteManager::addItemToNewPage()
 
 void UBBoardPaletteManager::addItemToLibrary()
 {
+    QByteArray data;
+
     if(mPixmap.isNull())
     {
-       mPixmap = QPixmap(mItemUrl.toLocalFile());
-    }
+        QFile file(mItemUrl.toLocalFile());
 
-    if(!mPixmap.isNull())
+        if (file.open(QFile::ReadOnly))
+        {
+            data = file.readAll();
+            file.close();
+        }
+    }
+    else
     {
         if(mScaleFactor != 1.)
         {
              mPixmap = mPixmap.scaled(mScaleFactor * mPixmap.width(), mScaleFactor* mPixmap.height()
                      , Qt::KeepAspectRatio, Qt::SmoothTransformation);
         }
-        QImage image = mPixmap.toImage();
 
+        QBuffer buffer(&data);
+        mPixmap.save(&buffer, "png");
+    }
+
+    if(!data.isEmpty())
+    {
         QDateTime now = QDateTime::currentDateTime();
         QString capturedName  = tr("CapturedImage") + "-" + now.toString("dd-MM-yyyy hh-mm-ss") + ".png";
-        mpFeaturesWidget->importImage(image, capturedName);
+        mpFeaturesWidget->importImage(data, capturedName);
     }
     else
     {

--- a/src/board/UBFeaturesController.cpp
+++ b/src/board/UBFeaturesController.cpp
@@ -1161,9 +1161,9 @@ void UBFeaturesController::moveExternalData(const QUrl &url, const UBFeature &de
 
     UBFeature dest = destination;
 
-    if ( destination != trashElement && destination != UBFeature()
-       /*&& !destination.getFullVirtualPath().startsWith( possibleDest.getFullVirtualPath(), Qt::CaseInsensitive )*/ )
+    if (!destination.getFullVirtualPath().startsWith(possibleDest.getFullVirtualPath(), Qt::CaseInsensitive))
     {
+        // use proposed folder if destination is not a subfolder of that
         dest = possibleDest;
     }
 

--- a/src/board/UBFeaturesController.h
+++ b/src/board/UBFeaturesController.h
@@ -200,8 +200,8 @@ public:
     void addToFavorite(const QUrl &path , const QString &name = QString(), bool temporaryAdded = false);
     void removeFromFavorite(const QUrl &path, bool deleteManualy = false);
     void storeAsFavorite(UBFeature feature);
-    void importImage(const QImage &image, const QString &fileName = QString());
-    void importImage( const QImage &image, const UBFeature &destination, const QString &fileName = QString() );
+    void importImage(const QByteArray& imageData, const QString &fileName = QString());
+    void importImage(const QByteArray& imageData, const UBFeature &destination, const QString &fileName = QString() );
     QStringList getFileNamesInFolders();
 
     void fileSystemScan(const QUrl &currPath, const QString & currVirtualPath);

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -929,13 +929,20 @@ void UBPersistenceManager::duplicateDocumentScene(UBDocumentProxy* proxy, int in
 
         UBGraphicsPixmapItem* pixmapItem = qgraphicsitem_cast<UBGraphicsPixmapItem*>(item);
         if(pixmapItem){
-            QString source = proxy->persistencePath() + "/" +  UBPersistenceManager::imageDirectory + "/" + pixmapItem->uuid().toString() + ".png";
-            QString destination = source;
-            QUuid newUuid = QUuid::createUuid();
-            QString fileName = QFileInfo(source).completeBaseName();
-            destination = destination.replace(fileName,newUuid.toString());
-            QFile::copy(source,destination);
-            pixmapItem->setUuid(newUuid);
+            QDir imageDir = proxy->persistencePath() + "/" + UBPersistenceManager::imageDirectory;
+            QStringList imageFiles = imageDir.entryList({pixmapItem->uuid().toString() + ".*"});
+
+            if (!imageFiles.isEmpty())
+            {
+                QString source = proxy->persistencePath() + "/" +  UBPersistenceManager::imageDirectory + "/" + imageFiles.last();
+                QString destination = source;
+                QUuid newUuid = QUuid::createUuid();
+                QString fileName = QFileInfo(source).completeBaseName();
+                destination = destination.replace(fileName,newUuid.toString());
+                QFile::copy(source,destination);
+                pixmapItem->setUuid(newUuid);
+            }
+
             continue;
         }
 

--- a/src/domain/UBGraphicsPixmapItem.cpp
+++ b/src/domain/UBGraphicsPixmapItem.cpp
@@ -189,7 +189,11 @@ qreal UBGraphicsPixmapItem::opacity() const
 
 void UBGraphicsPixmapItem::clearSource()
 {
-    QString fileName = UBPersistenceManager::imageDirectory + "/" + uuid().toString() + ".png";
-    QString diskPath =  UBApplication::boardController->selectedDocument()->persistencePath() + "/" + fileName;
-    UBFileSystemUtils::deleteFile(diskPath);
+    QDir imageDir = UBApplication::boardController->selectedDocument()->persistencePath() + "/" + UBPersistenceManager::imageDirectory;
+    const QStringList imageFiles = imageDir.entryList({uuid().toString() + ".*"});
+
+    for (const auto& imageFile : imageFiles)
+    {
+        UBFileSystemUtils::deleteFile(imageFile);
+    }
 }

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -375,6 +375,13 @@ public slots:
             bool pUseAnimation = false,
             bool useProxyForDocumentPath = false);
 
+        UBGraphicsPixmapItem* addImage(QByteArray pData,
+            QGraphicsItem* replaceFor,
+            const QPointF& pPos = QPointF(0,0),
+            qreal scaleFactor = 1.0,
+            bool pUseAnimation = false,
+            bool useProxyForDocumentPath = false);
+
         void textUndoCommandAdded(UBGraphicsTextItem *textItem);
 
         void setToolCursor(int tool);

--- a/src/gui/UBFeaturesWidget.h
+++ b/src/gui/UBFeaturesWidget.h
@@ -93,7 +93,7 @@ public:
             || mode == eUBDockPaletteWidget_DESKTOP;
     }
     UBFeaturesController * getFeaturesController() const { return controller; }
-    void importImage(const QImage &image, const QString &fileName = QString());
+    void importImage(const QByteArray& imageData, const QString &fileName = QString());
 
     static const int minThumbnailSize = 20;
     static const int maxThumbnailSize = 100;


### PR DESCRIPTION
This PR addresses the storage consumption of OpenBoard documents containing images. 

Currently, all images are converted to PNG and stored as such. So JPEG images with a reasonable large resolution end up using much disk space.

This PR

- avoids conversion of any image to PNG, as it needs a lot of disk space,
- stores imported or dropped image files as their original data in the OpenBoard document,
- while OpenBoard versions before 1.7.0 can still read the documents.

The core change is a new function `addImage` in `UBGraphicsScene`, which shall replace `addPixmap` in as many cases as possible. Instead of a pixmap, it takes a `QByteArray` of the image data. All other parameters are the same. The data is stored to disk as is.

The code for importing an image, for reading and writing a document, for DnD handling and pasting is adapted accordingly.

This PR obsoletes #746, as it also contains this fix. Only one of these two PRs shall be merged, preferably this one.