### PR TITLE
Fix shared ptr

### DIFF
--- a/src/adaptors/UBExportDocumentSetAdaptor.cpp
+++ b/src/adaptors/UBExportDocumentSetAdaptor.cpp
@@ -86,7 +86,7 @@ void UBExportDocumentSetAdaptor::persist(std::shared_ptr<UBDocumentProxy> pDocum
         }
 
         UBDocumentTreeNode* node = treeModel->nodeFromIndex(treeViewParentIndex);
-        std::shared_ptr<UBDocumentProxy> proxy = std::make_shared<UBDocumentProxy>(UBDocumentProxy());
+        std::shared_ptr<UBDocumentProxy> proxy = std::make_shared<UBDocumentProxy>();
         proxy->setMetaData(UBSettings::documentName, node->displayName());
         filename = askForFileName(proxy, tr("Export as UBX File"));
     }

--- a/src/adaptors/UBImportCFF.cpp
+++ b/src/adaptors/UBImportCFF.cpp
@@ -121,7 +121,7 @@ bool UBImportCFF::addFileToDocument(std::shared_ptr<UBDocumentProxy> pDocument, 
         //TODO convert expanded CFF file content to the destination document
         //create destination document proxy
         //fill metadata and save
-        std::shared_ptr<UBDocumentProxy> destDocument = std::make_shared<UBDocumentProxy>(UBDocumentProxy(UBPersistenceManager::persistenceManager()->generateUniqueDocumentPath()));
+        std::shared_ptr<UBDocumentProxy> destDocument = std::make_shared<UBDocumentProxy>(UBPersistenceManager::persistenceManager()->generateUniqueDocumentPath());
         QDir dir;
         dir.mkdir(destDocument->persistencePath());
 
@@ -265,7 +265,7 @@ std::shared_ptr<UBDocumentProxy> UBImportCFF::importFile(const QFile& pFile, con
     else{
         //create destination document proxy
         //fill metadata and save
-        std::shared_ptr<UBDocumentProxy> destDocument = std::make_shared<UBDocumentProxy>(UBDocumentProxy(UBPersistenceManager::persistenceManager()->generateUniqueDocumentPath()));
+        std::shared_ptr<UBDocumentProxy> destDocument = std::make_shared<UBDocumentProxy>(UBPersistenceManager::persistenceManager()->generateUniqueDocumentPath());
         QDir dir;
         dir.mkdir(destDocument->persistencePath());
         if (pGroup.length() > 0)

--- a/src/api/UBWidgetUniboardAPI.h
+++ b/src/api/UBWidgetUniboardAPI.h
@@ -283,7 +283,7 @@ private:
         bool supportedTypeHeader(const QString &) const;
         QString boolToStr(bool value) const {return value ? "true" : "false";}
 
-        std::shared_ptr<UBGraphicsScene> mScene;
+        std::weak_ptr<UBGraphicsScene> mScene;
 
         UBGraphicsWidgetItem* mGraphicsWidget;
 

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -284,7 +284,7 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocumentProxyStruct
             return nullptr;
         }
 
-        std::shared_ptr<UBDocumentProxy> docProxy = std::make_shared<UBDocumentProxy>(UBDocumentProxy(fullPath));
+        std::shared_ptr<UBDocumentProxy> docProxy = std::make_shared<UBDocumentProxy>(fullPath);
         foreach(QString key, metadatas.keys())
         {
             docProxy->setMetaData(key, metadatas.value(key));
@@ -593,12 +593,12 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocument(const QStr
 {
     std::shared_ptr<UBDocumentProxy> doc;
     if(directory.length() != 0 ){
-        doc = std::make_shared<UBDocumentProxy>(UBDocumentProxy(directory));
+        doc = std::make_shared<UBDocumentProxy>(directory);
         doc->setPageCount(pageCount);
     }
     else{
         checkIfDocumentRepositoryExists();
-        doc = std::make_shared<UBDocumentProxy>(UBDocumentProxy());
+        doc = std::make_shared<UBDocumentProxy>();
     }
 
     if (pGroupName.length() > 0)
@@ -669,7 +669,7 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocumentFromDir(con
 {
     checkIfDocumentRepositoryExists();
 
-    std::shared_ptr<UBDocumentProxy> doc = std::make_shared<UBDocumentProxy>(UBDocumentProxy(pDocumentDirectory)); // deleted in UBPersistenceManager::destructor
+    std::shared_ptr<UBDocumentProxy> doc = std::make_shared<UBDocumentProxy>(pDocumentDirectory); // deleted in UBPersistenceManager::destructor
 
     QMap<QString, QVariant> metadatas = UBMetadataDcSubsetAdaptor::load(pDocumentDirectory);
 
@@ -741,7 +741,7 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::duplicateDocument(std::sh
 {
     checkIfDocumentRepositoryExists();
 
-    std::shared_ptr<UBDocumentProxy> copy = std::make_shared<UBDocumentProxy>(UBDocumentProxy());
+    std::shared_ptr<UBDocumentProxy> copy = std::make_shared<UBDocumentProxy>();
 
     generatePathIfNeeded(copy);
 

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -311,8 +311,7 @@ UBDocumentTreeNode *UBDocumentTreeNode::clone()
     return new UBDocumentTreeNode(this->mType
                                   , this->mName
                                   , this->mDisplayName
-                                  , this->mProxy ? std::make_shared<UBDocumentProxy>(UBDocumentProxy(*this->mProxy))
-                                                 : nullptr);
+                                  , this->mProxy);
 }
 
 QString UBDocumentTreeNode::dirPathInHierarchy()

--- a/src/document/UBDocumentProxy.cpp
+++ b/src/document/UBDocumentProxy.cpp
@@ -52,17 +52,6 @@ UBDocumentProxy::UBDocumentProxy()
     init();
 }
 
-UBDocumentProxy::UBDocumentProxy(const UBDocumentProxy &rValue)
-{
-    mPersistencePath = rValue.mPersistencePath;
-    mMetaDatas = rValue.mMetaDatas;
-    mIsModified = rValue.mIsModified;
-    mPageCount = rValue.mPageCount;
-    mNeedsCleanup = rValue.mNeedsCleanup;
-    mLastVisitedIndex = rValue.mLastVisitedIndex;
-    mIsInFavoriteList = rValue.mIsInFavoriteList;
-}
-
 
 UBDocumentProxy::UBDocumentProxy(const QString& pPersistancePath)
     : mPageCount(0)
@@ -102,7 +91,7 @@ UBDocumentProxy::~UBDocumentProxy()
 
 std::shared_ptr<UBDocumentProxy> UBDocumentProxy::deepCopy() const
 {
-    std::shared_ptr<UBDocumentProxy> copy = std::make_shared<UBDocumentProxy>(UBDocumentProxy());
+    std::shared_ptr<UBDocumentProxy> copy = std::make_shared<UBDocumentProxy>();
 
     copy->mPersistencePath = QString(mPersistencePath);
     copy->mMetaDatas = QMap<QString, QVariant>(mMetaDatas);

--- a/src/document/UBDocumentProxy.h
+++ b/src/document/UBDocumentProxy.h
@@ -43,10 +43,11 @@ class UBDocumentProxy
     public:
 
         UBDocumentProxy();
-        UBDocumentProxy(const UBDocumentProxy &rValue);
+        UBDocumentProxy(const UBDocumentProxy &rValue) = delete;
+        UBDocumentProxy& operator= (const UBDocumentProxy&) = delete;
         UBDocumentProxy(const QString& pPersistencePath);
 
-        virtual ~UBDocumentProxy();
+        ~UBDocumentProxy();
 
         std::shared_ptr<UBDocumentProxy> deepCopy() const;
         bool theSameDocument(std::shared_ptr<UBDocumentProxy> proxy);


### PR DESCRIPTION
This PR fixes two issues in `shared_ptr` handling:

- It avoids copying the `UBDocumentProxy` objects during construction via `make_shared`.
- It breaks a circular reference between web widgets and scene.

See also https://github.com/letsfindaway/OpenBoard/issues/132

The first commit fixes the calls to `make_shared`. It also makes the `UBDocumentProxy` uncopyable and unassignable to prevent such things to happen inadvertently.

The second commit uses a `weak_ptr` to the scene in the `UBWidgetUniboardAPI` to break the circular reference.