### PR TITLE
fix: shared_ptr in threads, circular references, others

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -3282,7 +3282,7 @@ UBGraphicsTriangle* UBSvgSubsetAdaptor::UBSvgSubsetReader::triangleFromSvg()
 
 UBGraphicsCache* UBSvgSubsetAdaptor::UBSvgSubsetReader::cacheFromSvg()
 {
-    UBGraphicsCache* pCache = UBGraphicsCache::instance(mScene);
+    UBGraphicsCache* pCache = mScene->graphicsCache();
     pCache->setData(UBGraphicsItemData::ItemLayerType, QVariant(UBItemLayerType::Tool));
 
     graphicsItemFromSvg(pCache);

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -128,6 +128,7 @@ UBApplicationController::~UBApplicationController()
         delete view;
     }
     delete mMirror;
+    delete mUninoteController;
 
     delete(mOpenSankoreImporter);
     mOpenSankoreImporter = NULL;

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -193,6 +193,7 @@ private:
         QProgressDialog mProgress;
         QFutureWatcher<void> futureWatcher;
         UBPersistenceWorker* mWorker;
+        QList<std::shared_ptr<UBGraphicsScene>> mScenesToSave;
 
         QThread* mThread;
         bool mIsWorkerFinished;
@@ -207,7 +208,7 @@ private:
         void errorString(QString error);
         void onSceneLoaded(QByteArray,std::shared_ptr<UBDocumentProxy>,int);
         void onWorkerFinished();
-
+        void onScenePersisted(UBGraphicsScene* scene);
 };
 
 

--- a/src/core/UBPersistenceWorker.cpp
+++ b/src/core/UBPersistenceWorker.cpp
@@ -37,7 +37,7 @@ UBPersistenceWorker::UBPersistenceWorker(QObject *parent) :
 {
 }
 
-void UBPersistenceWorker::saveScene(std::shared_ptr<UBDocumentProxy> proxy, std::shared_ptr<UBGraphicsScene> scene, const int pageIndex)
+void UBPersistenceWorker::saveScene(std::shared_ptr<UBDocumentProxy> proxy, UBGraphicsScene *scene, const int pageIndex)
 {
     PersistenceInformation entry = {WriteScene, proxy, scene, pageIndex};
 
@@ -74,7 +74,7 @@ void UBPersistenceWorker::process()
     do{
         PersistenceInformation info = saves.takeFirst();
         if(info.action == WriteScene){
-            UBSvgSubsetAdaptor::persistScene(info.proxy, info.scene, info.sceneIndex);
+            UBSvgSubsetAdaptor::persistScene(info.proxy, info.scene->shared_from_this(), info.sceneIndex);
             emit scenePersisted(info.scene);
         }
         else if (info.action == ReadScene){

--- a/src/core/UBPersistenceWorker.h
+++ b/src/core/UBPersistenceWorker.h
@@ -43,7 +43,7 @@ typedef enum{
 typedef struct{
     ActionType action;
     std::shared_ptr<UBDocumentProxy> proxy;
-    std::shared_ptr<UBGraphicsScene> scene;
+    UBGraphicsScene* scene;
     int sceneIndex;
 }PersistenceInformation;
 
@@ -53,7 +53,7 @@ class UBPersistenceWorker : public QObject
 public:
     explicit UBPersistenceWorker(QObject *parent = 0);
 
-    void saveScene(std::shared_ptr<UBDocumentProxy> proxy, std::shared_ptr<UBGraphicsScene> scene, const int pageIndex);
+    void saveScene(std::shared_ptr<UBDocumentProxy> proxy, UBGraphicsScene* scene, const int pageIndex);
     void readScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
     void saveMetadata(std::shared_ptr<UBDocumentProxy> proxy);
 
@@ -61,7 +61,7 @@ signals:
    void finished();
    void error(QString string);
    void sceneLoaded(QByteArray text,std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
-   void scenePersisted(std::shared_ptr<UBGraphicsScene> scene);
+   void scenePersisted(UBGraphicsScene* scene);
    void metadataPersisted(std::shared_ptr<UBDocumentProxy> proxy);
 
 public slots:

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -35,7 +35,6 @@
 #include "core/UB.h"
 
 #include "UBItem.h"
-#include "tools/UBGraphicsCurtainItem.h"
 
 class UBGraphicsPixmapItem;
 class UBGraphicsSvgItem;
@@ -247,6 +246,7 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
 
         void addMask(const QPointF &center = QPointF());
         void addCache();
+        UBGraphicsCache* graphicsCache();
 
         class SceneViewState
         {
@@ -498,6 +498,8 @@ public slots:
         bool mDrawWithCompass;
         UBGraphicsPolygonItem *mCurrentPolygon;
         UBSelectionFrame *mSelectionFrame;
+
+        UBGraphicsCache* mGraphicsCache;
 };
 
 

--- a/src/domain/UBGraphicsStroke.cpp
+++ b/src/domain/UBGraphicsStroke.cpp
@@ -262,6 +262,8 @@ UBGraphicsStroke* UBGraphicsStroke::simplify()
     QList<strokePoint> newStrokePoints;
     int i(0);
 
+    auto scene = mScene.lock();
+
     while (i < points.size()) {
         bool drawCurve = false;
 
@@ -283,7 +285,7 @@ UBGraphicsStroke* UBGraphicsStroke::simplify()
             drawCurve = true;
 
         if (drawCurve) {
-            UBGraphicsPolygonItem* poly = mScene->polygonToPolygonItem(UBGeometryUtils::curveToPolygon(newStrokePoints, true, true));
+            UBGraphicsPolygonItem* poly = scene->polygonToPolygonItem(UBGeometryUtils::curveToPolygon(newStrokePoints, true, true));
             //poly->setColor(QColor(rand()%256, rand()%256, rand()%256, poly->brush().color().alpha())); // useful for debugging
 
             // Subtract overlapping polygons if the stroke is translucent
@@ -301,7 +303,7 @@ UBGraphicsStroke* UBGraphicsStroke::simplify()
     }
 
     if (newStrokePoints.size() > 0) {
-        UBGraphicsPolygonItem* poly = mScene->polygonToPolygonItem(UBGeometryUtils::curveToPolygon(newStrokePoints, true, true));
+        UBGraphicsPolygonItem* poly = scene->polygonToPolygonItem(UBGeometryUtils::curveToPolygon(newStrokePoints, true, true));
 
         if (!poly->brush().isOpaque()) {
             foreach(UBGraphicsPolygonItem* prev, newPolygons)

--- a/src/domain/UBGraphicsStroke.h
+++ b/src/domain/UBGraphicsStroke.h
@@ -70,7 +70,7 @@ class UBGraphicsStroke
 
     private:
 
-        std::shared_ptr<UBGraphicsScene> mScene;
+        std::weak_ptr<UBGraphicsScene> mScene;
 
         QList<UBGraphicsPolygonItem*> mPolygons;
 

--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -504,9 +504,8 @@ QString UBGraphicsWidgetItem::iconFilePath(const QUrl& pUrl)
     return file;
 }
 
-void UBGraphicsWidgetItem::activeSceneChanged()
+void UBGraphicsWidgetItem::initAPI()
 {
-    qDebug() << "Active scene changed, register/update API";
     registerAPI();
 }
 
@@ -1019,8 +1018,6 @@ UBGraphicsW3CWidgetItem::UBGraphicsW3CWidgetItem(const QUrl& pWidgetUrl, QGraphi
 
     if (!f.exists())
         mMainHtmlUrl = QUrl(mMainHtmlFileName);
-
-    connect(UBApplication::boardController, SIGNAL(activeSceneChanged()), this, SLOT(activeSceneChanged()));
 
     mWebEngineView->load(mMainHtmlUrl);
 

--- a/src/domain/UBGraphicsWidgetItem.h
+++ b/src/domain/UBGraphicsWidgetItem.h
@@ -138,7 +138,7 @@ class UBGraphicsWidgetItem : public QGraphicsProxyWidget, public UBItem, public 
         static QString iconFilePath(const QUrl& pUrl);
 
     public slots:
-        void activeSceneChanged();
+        void initAPI();
         void freeze();
         void unFreeze();
         void setWebActive(bool active);

--- a/src/podcast/UBPodcastController.cpp
+++ b/src/podcast/UBPodcastController.cpp
@@ -456,6 +456,8 @@ void UBPodcastController::stop()
 
         mVideoEncoder->stop();
     }
+
+    mSourceScene = nullptr;
 }
 
 

--- a/src/tools/UBGraphicsCache.cpp
+++ b/src/tools/UBGraphicsCache.cpp
@@ -35,25 +35,14 @@
 
 #include "board/UBBoardController.h"
 #include "board/UBBoardView.h"
-#include "domain/UBGraphicsScene.h"
 
 #include "core/memcheck.h"
 
-QMap<std::shared_ptr<UBGraphicsScene>, UBGraphicsCache*> UBGraphicsCache::sInstances;
-
-UBGraphicsCache* UBGraphicsCache::instance(std::shared_ptr<UBGraphicsScene> scene)
-{
-    if (!sInstances.contains(scene))
-        sInstances.insert(scene, new UBGraphicsCache(scene));
-    return sInstances[scene];
-}
-
-UBGraphicsCache::UBGraphicsCache(std::shared_ptr<UBGraphicsScene> scene) : QGraphicsRectItem()
+UBGraphicsCache::UBGraphicsCache() : QGraphicsRectItem()
   , mMaskColor(Qt::black)
   , mMaskShape(eMaskShape_Circle)
   , mShapeWidth(100)
   , mDrawMask(false)
-  , mScene(scene)
 {
     // Get the board size and pass it to the shape
     QRect boardRect = UBApplication::boardController->displayView()->rect();
@@ -64,12 +53,11 @@ UBGraphicsCache::UBGraphicsCache(std::shared_ptr<UBGraphicsScene> scene) : QGrap
 
 UBGraphicsCache::~UBGraphicsCache()
 {
-    sInstances.remove(mScene);
 }
 
 UBItem* UBGraphicsCache::deepCopy() const
 {
-    UBGraphicsCache* copy = new UBGraphicsCache(mScene);
+    UBGraphicsCache* copy = new UBGraphicsCache();
 
     copyItemParameters(copy);
 

--- a/src/tools/UBGraphicsCache.h
+++ b/src/tools/UBGraphicsCache.h
@@ -45,7 +45,7 @@ typedef enum
 class UBGraphicsCache : public QGraphicsRectItem, public UBItem
 {
 public:
-    static UBGraphicsCache* instance(std::shared_ptr<UBGraphicsScene> scene);
+    UBGraphicsCache();
     ~UBGraphicsCache();
 
     enum { Type = UBGraphicsItemType::cacheItemType };
@@ -70,8 +70,6 @@ protected:
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
 
 private:
-    static QMap<std::shared_ptr<UBGraphicsScene>, UBGraphicsCache*> sInstances;
-
     QColor mMaskColor;
     eMaskShape mMaskShape;
     int mShapeWidth;
@@ -79,11 +77,7 @@ private:
     QPointF mShapePos;
     int mOldShapeWidth;
     QPointF mOldShapePos;
-    std::shared_ptr<UBGraphicsScene> mScene;
-    
 
-    UBGraphicsCache(std::shared_ptr<UBGraphicsScene> scene);
-    
     void init();
     QRectF updateRect(QPointF currentPoint);
 };


### PR DESCRIPTION
Another PR to stabilize the usage of `shared_ptr`:

- break `shared_ptr` cycles in `UBGraphicsStroke`
- break `shared_ptr` cycles in `UBGraphicsCache`
- maintain ownership of `UBGraphicsCache` in `UBGraphicsScene`
- do not pass `shared_ptr` to other threads (`UBPersistenceWorker`)
- better handling of scene for `UBWidgetUniboardAPI`
- release scene after encoding in `UBPodcastController`

A detailed description is available here: https://github.com/letsfindaway/OpenBoard/issues/132#issuecomment-1553012031