### PR TITLE
Fix broken Qt6 compatibility

### DIFF
--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -36,8 +36,8 @@
 #include <QSvgRenderer>
 #include <QPainter>
 
-#include "UBGlobals.h"
 #include "UBCFFConstants.h"
+#include "core/UB.h"
 
 //THIRD_PARTY_WARNINGS_DISABLE
 #ifdef Q_OS_OSX
@@ -51,11 +51,6 @@
 #endif
 //THIRD_PARTY_WARNINGS_ENABLE
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
 
 UBCFFAdaptor::UBCFFAdaptor()
 {}
@@ -812,7 +807,7 @@ QString UBCFFAdaptor::UBToCFFConverter::getSrcContentFolderName(QString href)
 QString UBCFFAdaptor::UBToCFFConverter::getFileNameFromPath(const QString sPath)
 {
     QString sRet;
-    QStringList sl = sPath.split("/",SplitBehavior::SkipEmptyParts);
+    QStringList sl = sPath.split("/",UB::SplitBehavior::SkipEmptyParts);
 
     if (0 < sl.count())
     {
@@ -835,7 +830,7 @@ QString UBCFFAdaptor::UBToCFFConverter::getFileNameFromPath(const QString sPath)
 
 QString UBCFFAdaptor::UBToCFFConverter::getExtentionFromFileName(const QString &filename)
 {
-    QStringList sl = filename.split("/",SplitBehavior::SkipEmptyParts);
+    QStringList sl = filename.split("/",UB::SplitBehavior::SkipEmptyParts);
 
     if (0 < sl.count())
     {
@@ -882,7 +877,7 @@ QString UBCFFAdaptor::UBToCFFConverter::getElementTypeFromUBZ(const QDomElement 
             if (element.hasAttribute(aUBZHref))
                 sPath = element.attribute(aUBZHref);
 
-            QStringList tsl = sPath.split(".", SplitBehavior::SkipEmptyParts);
+            QStringList tsl = sPath.split(".", UB::SplitBehavior::SkipEmptyParts);
             if (0 < tsl.count())
             {
                 QString elementType = tsl.at(tsl.count()-1);
@@ -918,7 +913,7 @@ bool UBCFFAdaptor::UBToCFFConverter::itIsSupportedFormat(const QString &format) 
 {
     bool bRet;
 
-    QStringList tsl = format.split(".", SplitBehavior::SkipEmptyParts);
+    QStringList tsl = format.split(".", UB::SplitBehavior::SkipEmptyParts);
     if (0 < tsl.count())
         bRet = cffSupportedFileFormats.contains(tsl.at(tsl.count()-1).toLower());       
     else
@@ -1025,7 +1020,7 @@ QTransform UBCFFAdaptor::UBToCFFConverter::getTransformFromUBZ(const QDomElement
     ubzTransform.remove("(");
     ubzTransform.remove(")");
 
-    transformParameters = ubzTransform.split(",", SplitBehavior::SkipEmptyParts);
+    transformParameters = ubzTransform.split(",", UB::SplitBehavior::SkipEmptyParts);
 
     if (6 <= transformParameters.count())
     {
@@ -1244,12 +1239,12 @@ void UBCFFAdaptor::UBToCFFConverter::setCFFTextFromHTMLTextNode(const QDomElemen
                         for (int i = 0; i < attrCount; i++)
                         {
                             // html attributes like: style="font-size:40pt; color:"red";".
-                            QStringList cffAttributes = spanNode.attributes().item(i).nodeValue().split(";", SplitBehavior::SkipEmptyParts);
+                            QStringList cffAttributes = spanNode.attributes().item(i).nodeValue().split(";", UB::SplitBehavior::SkipEmptyParts);
                             {
                                 for (int i = 0; i < cffAttributes.count(); i++)
                                 {                       
                                     QString attr = cffAttributes.at(i).trimmed();
-                                    QStringList AttrVal = attr.split(":", SplitBehavior::SkipEmptyParts);
+                                    QStringList AttrVal = attr.split(":", UB::SplitBehavior::SkipEmptyParts);
                                     if(1 < AttrVal.count())
                                     {    
                                         QString sAttr = ubzAttrNameToCFFAttrName(AttrVal.at(0));
@@ -1832,10 +1827,10 @@ bool UBCFFAdaptor::UBToCFFConverter::parseUBZText(const QDomElement &element, QM
             commonParams.remove(" ");
             commonParams.remove("'");
 
-            QStringList commonAttributes = commonParams.split(";", SplitBehavior::SkipEmptyParts);
+            QStringList commonAttributes = commonParams.split(";", UB::SplitBehavior::SkipEmptyParts);
             for (int i = 0; i < commonAttributes.count(); i++)
             {
-                QStringList AttrVal = commonAttributes.at(i).split(":", SplitBehavior::SkipEmptyParts);
+                QStringList AttrVal = commonAttributes.at(i).split(":", UB::SplitBehavior::SkipEmptyParts);
                 if (1 < AttrVal.count())
                 {                
                     QString sAttr = ubzAttrNameToCFFAttrName(AttrVal.at(0));

--- a/plugins/cffadaptor/src/UBCFFConstants.h
+++ b/plugins/cffadaptor/src/UBCFFConstants.h
@@ -394,12 +394,4 @@ text-align \
 
 const QString ubzContentFolders("audios,videos,images,widgets");
 
-struct UBItemLayerType
-{
-    enum Enum
-    {
-        FixedBackground = -2000, Object = -1000, Graphic = 0, Tool = 1000, Control = 2000
-    };
-};
-
 #endif // UBCFFCONSTANTS_H

--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -120,13 +120,6 @@ static QString aEditable        = "editable";
 static QString apRotate         = "rotate";
 static QString apTranslate      = "translate";
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
-
-
 UBCFFSubsetAdaptor::UBCFFSubsetAdaptor()
 {}
 
@@ -356,10 +349,10 @@ bool UBCFFSubsetAdaptor::UBCFFSubsetReader::parseSvgPolygon(const QDomElement &e
     QPolygonF polygon;
 
     if (!svgPoints.isNull()) {
-        QStringList ts = svgPoints.split(QLatin1Char(' '), SplitBehavior::SkipEmptyParts);
+        QStringList ts = svgPoints.split(QLatin1Char(' '), UB::SplitBehavior::SkipEmptyParts);
 
         foreach(const QString sPoint, ts) {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), SplitBehavior::SkipEmptyParts);
+            QStringList sCoord = sPoint.split(QLatin1Char(','), UB::SplitBehavior::SkipEmptyParts);
             if (sCoord.size() == 2) {
                 QPointF point;
                 point.setX(sCoord.at(0).toFloat());
@@ -472,10 +465,10 @@ bool UBCFFSubsetAdaptor::UBCFFSubsetReader::parseSvgPolyline(const QDomElement &
 
     if (!svgPoints.isNull()) {
         QStringList ts = svgPoints.split(QLatin1Char(' '),
-                                                    SplitBehavior::SkipEmptyParts);
+                                                    UB::SplitBehavior::SkipEmptyParts);
 
         foreach(const QString sPoint, ts) {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), SplitBehavior::SkipEmptyParts);
+            QStringList sCoord = sPoint.split(QLatin1Char(','), UB::SplitBehavior::SkipEmptyParts);
             if (sCoord.size() == 2) {
                 QPointF point;
                 point.setX(sCoord.at(0).toFloat());
@@ -1441,7 +1434,7 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
     qreal angle = 0.0;
     QTransform tr;
 
-    foreach(QString trStr, trString.split(" ", SplitBehavior::SkipEmptyParts))
+    foreach(QString trStr, trString.split(" ", UB::SplitBehavior::SkipEmptyParts))
     {
         //check pattern for strings like 'rotate(10)'
         static const QRegularExpression rotate1(QRegularExpression::anchoredPattern("rotate\\( *([-+]{0,1}[0-9]*\\.{0,1}[0-9]*) *\\)"));
@@ -1486,7 +1479,7 @@ QTransform UBCFFSubsetAdaptor::UBCFFSubsetReader::transformFromString(const QStr
 
 bool UBCFFSubsetAdaptor::UBCFFSubsetReader::getViewBoxDimenstions(const QString& viewBox)
 {
-    QStringList capturedTexts = viewBox.split(" ", SplitBehavior::SkipEmptyParts);
+    QStringList capturedTexts = viewBox.split(" ", UB::SplitBehavior::SkipEmptyParts);
     if (capturedTexts.count())
     {
         if (4 == capturedTexts.count())

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -98,11 +98,6 @@ const QString tStrokeGroup = "strokeGroup";
 const QString tGroups = "groups";
 const QString aId = "id";
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
 
 QString UBSvgSubsetAdaptor::toSvgTransform(const QTransform& matrix)
 {
@@ -431,7 +426,7 @@ std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScen
 
                 if (!svgViewBox.isNull())
                 {
-                    QStringList ts = svgViewBox.toString().split(QLatin1Char(' '), SplitBehavior::SkipEmptyParts);
+                    QStringList ts = svgViewBox.toString().split(QLatin1Char(' '), UB::SplitBehavior::SkipEmptyParts);
 
                     QRectF sceneRect;
                     if (ts.size() >= 4)
@@ -521,7 +516,7 @@ std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScen
                 auto pageNominalSize = mXmlReader.attributes().value(mNamespaceUri, "nominal-size");
                 if (!pageNominalSize.isNull())
                 {
-                    QStringList ts = pageNominalSize.toString().split(QLatin1Char('x'), SplitBehavior::SkipEmptyParts);
+                    QStringList ts = pageNominalSize.toString().split(QLatin1Char('x'), UB::SplitBehavior::SkipEmptyParts);
 
                     QSize sceneSize;
                     if (ts.size() >= 2)
@@ -1731,11 +1726,11 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromPol
 
     if (!svgPoints.isNull())
     {
-        QStringList ts = svgPoints.toString().split(QLatin1Char(' '), SplitBehavior::SkipEmptyParts);
+        QStringList ts = svgPoints.toString().split(QLatin1Char(' '), UB::SplitBehavior::SkipEmptyParts);
 
         foreach(const QString sPoint, ts)
         {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), SplitBehavior::SkipEmptyParts);
+            QStringList sCoord = sPoint.split(QLatin1Char(','), UB::SplitBehavior::SkipEmptyParts);
 
             if (sCoord.size() == 2)
             {
@@ -2003,13 +1998,13 @@ QList<UBGraphicsPolygonItem*> UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItem
     if (!svgPoints.isNull())
     {
         QStringList ts = svgPoints.toString().split(QLatin1Char(' '),
-                                                    SplitBehavior::SkipEmptyParts);
+                                                    UB::SplitBehavior::SkipEmptyParts);
 
         QList<QPointF> points;
 
         foreach(const QString sPoint, ts)
         {
-            QStringList sCoord = sPoint.split(QLatin1Char(','), SplitBehavior::SkipEmptyParts);
+            QStringList sCoord = sPoint.split(QLatin1Char(','), UB::SplitBehavior::SkipEmptyParts);
 
             if (sCoord.size() == 2)
             {

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -227,7 +227,7 @@ void UBSvgSubsetAdaptor::setSceneUuid(std::shared_ptr<UBDocumentProxy> proxy, co
 
     QString newXmlContent = xmlContent.left(quoteStartIndex + 1);
     newXmlContent.append(UBStringUtils::toCanonicalUuid(pUuid));
-    newXmlContent.append(xmlContent.rightRef(xmlContent.length() - quoteEndIndex));
+    newXmlContent.append(xmlContent.right(xmlContent.length() - quoteEndIndex));
 
     if (file.open(QIODevice::WriteOnly | QIODevice::Truncate))
     {
@@ -2832,7 +2832,7 @@ UBGraphicsTextItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::textItemFromSvg()
                     foreach (QString styleToken, fontStyle.toString().split(";")) {
                         styleToken = styleToken.trimmed();
                         if (styleToken.startsWith(sFontSizePrefix) && styleToken.endsWith(sPixelUnit)) {
-                            int fontSize = styleToken.midRef(
+                            int fontSize = styleToken.mid(
                                         sFontSizePrefix.length(),
                                         styleToken.length() - sFontSizePrefix.length() - sPixelUnit.length()).toInt();
                             font.setPixelSize(fontSize);

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -1077,7 +1077,7 @@ void UBBoardController::lastScene()
 void UBBoardController::downloadURL(const QUrl& url, QString contentSourceUrl, const QPointF& pPos, const QSize& pSize, bool isBackground, bool internalData)
 {
     QString sUrl = url.toString();
-    qDebug() << "something has been dropped on the board! Url is: " << sUrl.leftRef(255);
+    qDebug() << "something has been dropped on the board! Url is: " << sUrl.left(255);
 
     QGraphicsItem *oldBackgroundObject = NULL;
     if (isBackground)

--- a/src/core/UB.h
+++ b/src/core/UB.h
@@ -230,4 +230,23 @@ enum UBPageBackground
     ruled
 };
 
+/*
+ * Qt Version Compatibility
+ */
+
+namespace UB {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+typedef Qt::SplitBehaviorFlags SplitBehavior;
+#else
+typedef QString::SplitBehavior SplitBehavior;
+#endif
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+typedef QEvent EnterEvent;
+#else
+typedef QEnterEvent EnterEvent;
+#endif
+
+}
+
 #endif /* UB_H_ */

--- a/src/core/UBForeignObjectsHandler.cpp
+++ b/src/core/UBForeignObjectsHandler.cpp
@@ -55,11 +55,6 @@ const QString thumbSuff = ".png";
 const QString scanDirs = "audios,images,videos,teacherGuideObjects,widgets";
 const QStringList trashFilter = QStringList() << "*.swf";
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
 
 static QString strIdFrom(const QString &filePath)
 {
@@ -270,7 +265,7 @@ private:
     void fitIdsFromFileSystem()
     {
         QString absPrefix = mCurrentDir + "/";
-        QStringList dirsList = scanDirs.split(",", SplitBehavior::SkipEmptyParts);
+        QStringList dirsList = scanDirs.split(",", UB::SplitBehavior::SkipEmptyParts);
         foreach (QString dirName, dirsList) {
             QString absPath = absPrefix + dirName;
             if (!QFile::exists(absPath)) {

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -77,11 +77,6 @@ const QString UBPersistenceManager::fFolders = "folders.xml";
 const QString UBPersistenceManager::tFolder = "folder";
 const QString UBPersistenceManager::aName = "name";
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
 
 UBPersistenceManager * UBPersistenceManager::sSingleton = 0;
 
@@ -454,7 +449,7 @@ QDialog::DialogCode UBPersistenceManager::processInteractiveReplacementDialog(st
 
 QString UBPersistenceManager::adjustDocumentVirtualPath(const QString &str)
 {
-    QStringList pathList = str.split("/", SplitBehavior::SkipEmptyParts);
+    QStringList pathList = str.split("/", UB::SplitBehavior::SkipEmptyParts);
 
     if (pathList.isEmpty()) {
         pathList.append(myDocumentsName);

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -50,11 +50,6 @@
 
 #include "core/memcheck.h"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
 
 qreal UBPreferencesController::sSliderRatio = 10.0;
 qreal UBPreferencesController::sMinPenWidth = 0.5;

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -73,11 +73,6 @@
 
 #include "core/memcheck.h"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-typedef Qt::SplitBehaviorFlags SplitBehavior;
-#else
-typedef QString::SplitBehavior SplitBehavior;
-#endif
 
 static bool lessThan(UBDocumentTreeNode *lValue, UBDocumentTreeNode *rValue)
 {
@@ -1197,7 +1192,7 @@ bool UBDocumentTreeModel::newNodeAllowed(const QModelIndex &pSelectedIndex)  con
 
 QModelIndex UBDocumentTreeModel::goTo(const QString &dir)
 {
-    QStringList pathList = dir.split("/", SplitBehavior::SkipEmptyParts);
+    QStringList pathList = dir.split("/", UB::SplitBehavior::SkipEmptyParts);
 
     if (pathList.isEmpty()) {
         return untitledDocumentsIndex();

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -198,7 +198,11 @@ void UBDockPalette::resizeEvent(QResizeEvent *event)
  * \brief Handle the mouse enter event
  * @param event as the mouse event
  */
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 void UBDockPalette::enterEvent(QEvent *event)
+#else
+void UBDockPalette::enterEvent(QEnterEvent *event)
+#endif
 {
     Q_UNUSED(event);
     // We want to set the cursor as an arrow everytime it enters the palette

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -198,11 +198,7 @@ void UBDockPalette::resizeEvent(QResizeEvent *event)
  * \brief Handle the mouse enter event
  * @param event as the mouse event
  */
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-void UBDockPalette::enterEvent(QEvent *event)
-#else
-void UBDockPalette::enterEvent(QEnterEvent *event)
-#endif
+void UBDockPalette::enterEvent(UB::EnterEvent *event)
 {
     Q_UNUSED(event);
     // We want to set the cursor as an arrow everytime it enters the palette

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -116,11 +116,15 @@ public:
     QRect getTabPaletteRect();
 
     virtual void assignParent(QWidget *widget);
-    virtual void setVisible(bool visible);
+    virtual void setVisible(bool visible) override;
 
-    virtual void paintEvent(QPaintEvent *event);
-    virtual void enterEvent(QEvent *);
-    virtual void leaveEvent(QEvent *);
+    virtual void paintEvent(QPaintEvent *event) override;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    virtual void enterEvent(QEvent *event) override;
+#else
+    virtual void enterEvent(QEnterEvent *event) override;
+#endif
+    virtual void leaveEvent(QEvent *) override;
 
     void setBackgroundBrush(const QBrush& brush);
     void registerWidget(UBDockPaletteWidget* widget);

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -47,6 +47,7 @@ class UBDocumentProxy;
 #include <QVector>
 
 #include "UBDockPaletteWidget.h"
+#include "core/UB.h"
 
 #define TABSIZE        50       //Height of the tab of the palette
 #define CLICKTIME   1000000  //Clicktime to expand or collapse palette
@@ -119,11 +120,7 @@ public:
     virtual void setVisible(bool visible) override;
 
     virtual void paintEvent(QPaintEvent *event) override;
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    virtual void enterEvent(QEvent *event) override;
-#else
-    virtual void enterEvent(QEnterEvent *event) override;
-#endif
+    virtual void enterEvent(UB::EnterEvent *event) override;
     virtual void leaveEvent(QEvent *) override;
 
     void setBackgroundBrush(const QBrush& brush);

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -111,11 +111,7 @@ int UBFloatingPalette::border()
 }
 
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-void UBFloatingPalette::enterEvent(QEvent *event)
-#else
-void UBFloatingPalette::enterEvent(QEnterEvent *event)
-#endif
+void UBFloatingPalette::enterEvent(UB::EnterEvent *event)
 {
     Q_UNUSED(event);
     emit mouseEntered();

--- a/src/gui/UBFloatingPalette.cpp
+++ b/src/gui/UBFloatingPalette.cpp
@@ -111,7 +111,11 @@ int UBFloatingPalette::border()
 }
 
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 void UBFloatingPalette::enterEvent(QEvent *event)
+#else
+void UBFloatingPalette::enterEvent(QEnterEvent *event)
+#endif
 {
     Q_UNUSED(event);
     emit mouseEntered();

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -33,6 +33,8 @@
 #include <QWidget>
 #include <QPoint>
 
+#include "core/UB.h"
+
 typedef enum
 {
     eMinimizedLocation_None,
@@ -50,9 +52,9 @@ class UBFloatingPalette : public QWidget
 
         UBFloatingPalette(Qt::Corner = Qt::TopLeftCorner, QWidget *parent = 0);
 
-        virtual void mouseMoveEvent(QMouseEvent *event);
-        virtual void mousePressEvent(QMouseEvent *event);
-        virtual void mouseReleaseEvent(QMouseEvent *event);
+        virtual void mouseMoveEvent(QMouseEvent *event) override;
+        virtual void mousePressEvent(QMouseEvent *event) override;
+        virtual void mouseReleaseEvent(QMouseEvent *event) override;
 
         /**
          * Add another floating palette to the associated palette. All associated palettes will have the same width
@@ -74,11 +76,7 @@ class UBFloatingPalette : public QWidget
 
     protected:
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-        virtual void enterEvent(QEvent *event) override;
-#else
-        virtual void enterEvent(QEnterEvent *event) override;
-#endif
+        virtual void enterEvent(UB::EnterEvent *event) override;
         virtual void showEvent(QShowEvent *event) override;
         virtual void paintEvent(QPaintEvent *event) override;
 

--- a/src/gui/UBFloatingPalette.h
+++ b/src/gui/UBFloatingPalette.h
@@ -74,9 +74,13 @@ class UBFloatingPalette : public QWidget
 
     protected:
 
-        virtual void enterEvent(QEvent *event);
-        virtual void showEvent(QShowEvent *event);
-        virtual void paintEvent(QPaintEvent *event);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+        virtual void enterEvent(QEvent *event) override;
+#else
+        virtual void enterEvent(QEnterEvent *event) override;
+#endif
+        virtual void showEvent(QShowEvent *event) override;
+        virtual void paintEvent(QPaintEvent *event) override;
 
         virtual int radius();
         virtual int border();

--- a/src/gui/UBKeyboardPalette.cpp
+++ b/src/gui/UBKeyboardPalette.cpp
@@ -222,7 +222,11 @@ void UBKeyboardPalette::setKeyButtonSize(const QString& _strSize)
     }
 }
 
-void UBKeyboardPalette::enterEvent ( QEvent * )
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+void UBKeyboardPalette::enterEvent(QEvent *event)
+#else
+void UBKeyboardPalette::enterEvent(QEnterEvent *event)
+#endif
 {
     if (keyboardActive)
         return;
@@ -500,7 +504,11 @@ void UBKeyboardButton::paintEvent(QPaintEvent*)
     //--------------------------
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 void  UBKeyboardButton::enterEvent ( QEvent*)
+#else
+void UBKeyboardButton::enterEvent(QEnterEvent *event)
+#endif
 {
     bFocused = true;
     update();

--- a/src/gui/UBKeyboardPalette.cpp
+++ b/src/gui/UBKeyboardPalette.cpp
@@ -504,11 +504,7 @@ void UBKeyboardButton::paintEvent(QPaintEvent*)
     //--------------------------
 }
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-void  UBKeyboardButton::enterEvent ( QEvent*)
-#else
-void UBKeyboardButton::enterEvent(QEnterEvent *event)
-#endif
+void UBKeyboardButton::enterEvent(UB::EnterEvent *event)
 {
     bFocused = true;
     update();

--- a/src/gui/UBKeyboardPalette.h
+++ b/src/gui/UBKeyboardPalette.h
@@ -104,8 +104,8 @@ public:
     BTNImages *currBtnImages;
 
     bool isEnabled(){return locales!= NULL;}
-    virtual QSize  sizeHint () const;
-    virtual void adjustSizeAndPosition(bool pUp = true);
+    virtual QSize  sizeHint () const override;
+    virtual void adjustSizeAndPosition(bool pUp = true) override;
     QString getKeyButtonSize() const {return QStringLiteral("%1x%2").arg(btnWidth, btnHeight);}
     void setKeyButtonSize(const QString& strSize);
 
@@ -143,10 +143,14 @@ protected:
     bool languagePopupActive;
     bool keyboardActive;
 // 
-    virtual void  enterEvent ( QEvent * event );
-    virtual void  leaveEvent ( QEvent * event );
-    virtual void  paintEvent(QPaintEvent *event);
-    virtual void  moveEvent ( QMoveEvent * event );
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    virtual void enterEvent(QEvent *event) override;
+#else
+    virtual void enterEvent(QEnterEvent *event) override;
+#endif
+    virtual void  leaveEvent ( QEvent * event ) override;
+    virtual void  paintEvent(QPaintEvent *event) override;
+    virtual void  moveEvent ( QMoveEvent * event ) override;
 
     void sendKeyEvent(KEYCODE keyCode);
 
@@ -196,12 +200,16 @@ protected:
     ContentImage *imgContent;
     QString m_contentImagePath;
 
-    void paintEvent(QPaintEvent *event);
+    void paintEvent(QPaintEvent *event) override;
 
-    virtual void  enterEvent ( QEvent * event );
-    virtual void  leaveEvent ( QEvent * event );
-    virtual void  mousePressEvent ( QMouseEvent * event );
-    virtual void  mouseReleaseEvent ( QMouseEvent * event );
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    virtual void enterEvent(QEvent *event) override;
+#else
+    virtual void enterEvent(QEnterEvent *event) override;
+#endif
+    virtual void  leaveEvent ( QEvent * event ) override;
+    virtual void  mousePressEvent ( QMouseEvent * event ) override;
+    virtual void  mouseReleaseEvent ( QMouseEvent * event ) override;
 
     virtual void onPress() = 0;
     virtual void onRelease() = 0;

--- a/src/gui/UBKeyboardPalette.h
+++ b/src/gui/UBKeyboardPalette.h
@@ -37,6 +37,7 @@
 #include <QMenu>
 #include <QIcon>
 
+#include "core/UB.h"
 #include "frameworks/UBPlatformUtils.h"
 
 class UBKeyButton;
@@ -143,11 +144,7 @@ protected:
     bool languagePopupActive;
     bool keyboardActive;
 // 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    virtual void enterEvent(QEvent *event) override;
-#else
-    virtual void enterEvent(QEnterEvent *event) override;
-#endif
+    virtual void enterEvent(UB::EnterEvent *event) override;
     virtual void  leaveEvent ( QEvent * event ) override;
     virtual void  paintEvent(QPaintEvent *event) override;
     virtual void  moveEvent ( QMoveEvent * event ) override;

--- a/src/gui/UBToolWidget.cpp
+++ b/src/gui/UBToolWidget.cpp
@@ -197,11 +197,7 @@ void UBToolWidget::mouseReleaseEvent(QMouseEvent *event)
 
 }
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-void UBToolWidget::enterEvent(QEvent *event)
-#else
-void UBToolWidget::enterEvent(QEnterEvent *event)
-#endif
+void UBToolWidget::enterEvent(UB::EnterEvent *event)
 {
     Q_UNUSED(event)
 

--- a/src/gui/UBToolWidget.cpp
+++ b/src/gui/UBToolWidget.cpp
@@ -197,7 +197,11 @@ void UBToolWidget::mouseReleaseEvent(QMouseEvent *event)
 
 }
 
-void UBToolWidget::enterEvent(QEvent* event)
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+void UBToolWidget::enterEvent(QEvent *event)
+#else
+void UBToolWidget::enterEvent(QEnterEvent *event)
+#endif
 {
     Q_UNUSED(event)
 

--- a/src/gui/UBToolWidget.h
+++ b/src/gui/UBToolWidget.h
@@ -64,7 +64,11 @@ class UBToolWidget : public QWidget
         virtual void mouseMoveEvent(QMouseEvent *event) override;
         virtual void mouseReleaseEvent(QMouseEvent *event) override;
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         virtual void enterEvent(QEvent *event) override;
+#else
+        virtual void enterEvent(QEnterEvent *event) override;
+#endif
         virtual void leaveEvent(QEvent *event) override;
 
         virtual bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/gui/UBToolWidget.h
+++ b/src/gui/UBToolWidget.h
@@ -33,6 +33,8 @@
 #include <QtGui>
 #include <QWidget>
 
+#include "core/UB.h"
+
 class UBGraphicsWidgetItem;
 class QWidget;
 class UBGraphicsScene;
@@ -64,11 +66,7 @@ class UBToolWidget : public QWidget
         virtual void mouseMoveEvent(QMouseEvent *event) override;
         virtual void mouseReleaseEvent(QMouseEvent *event) override;
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-        virtual void enterEvent(QEvent *event) override;
-#else
-        virtual void enterEvent(QEnterEvent *event) override;
-#endif
+        virtual void enterEvent(UB::EnterEvent *event) override;
         virtual void leaveEvent(QEvent *event) override;
 
         virtual bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/network/UBHttpGet.cpp
+++ b/src/network/UBHttpGet.cpp
@@ -96,7 +96,7 @@ void UBHttpGet::requestFinished()
 
     if (mReply->error() != QNetworkReply::NoError)
     {
-        qWarning() << mReply->url().toString().leftRef(255) << "get finished with error : " << mReply->error();
+        qWarning() << mReply->url().toString().left(255) << "get finished with error : " << mReply->error();
 
         mDownloadedBytes.clear();
 
@@ -107,7 +107,7 @@ void UBHttpGet::requestFinished()
     else
     {
 
-        qDebug() << mReply->url().toString().leftRef(255) << "http get finished ...";
+        qDebug() << mReply->url().toString().left(255) << "http get finished ...";
 
         if (mReply->header(QNetworkRequest::LocationHeader).isValid() && mRedirectionCount < 10)
         {


### PR DESCRIPTION
Unfortunately I have broken Qt6 compatibility with two commits:

- 27ae0146f9407004e9b4c720e0ddc5b94d0c9bfa introduced the `leftRef` calls. These are not necessary and do no longer exist in Qt6.
- 7ba86ecdbece5b88770d614f2a3254c2b236d183 added an `enterEvent`, which has a different parameter type in Qt6. Due to the `override` annotation this was flagged as a compile error. I found some more occurrences of that problem which have not been flagged as a compile error because of the missing `override` annotation.

This PR fixes these issues, which only occur when compiling with Qt6.

- use `QString::left`, `mid` instead of `leftRef`, `midRef` as `QStringRef` is obsolete in Qt6
- use modified signature of `enterEvent`, parameter type is now `QEnterEvent*` instead of `QEvent*`