### PR TITLE
Fix frozen objects and illegal widget file name

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -241,11 +241,6 @@ void UBBoardView::keyPressEvent (QKeyEvent *event)
             mController->addScene ();
             break;
         }
-        case Qt::Key_Control:
-        case Qt::Key_Shift:
-        {
-            setMultiselection(true);
-        }break;
         }
 
 
@@ -304,21 +299,8 @@ void UBBoardView::keyPressEvent (QKeyEvent *event)
             }
         }
     }
-
-    // if ctrl of shift was pressed combined with other keys - we need to disable multiple selection.
-    if (event->isAccepted())
-        setMultiselection(false);
 }
 
-
-void UBBoardView::keyReleaseEvent(QKeyEvent *event)
-{
-
-    if (Qt::Key_Shift == event->key() ||Qt::Key_Control == event->key())
-        setMultiselection(false);
-
-    QGraphicsView::keyReleaseEvent(event);
-}
 
 bool UBBoardView::event (QEvent * e)
 {
@@ -1055,6 +1037,8 @@ void UBBoardView::mousePressEvent (QMouseEvent *event)
         event->accept ();
         return;
     }
+
+    setMultiselection(event->modifiers() & (Qt::ControlModifier | Qt::ShiftModifier));
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QPointF eventPosition = event->position();

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -93,7 +93,6 @@ protected:
     virtual bool event (QEvent * e);
 
     virtual void keyPressEvent(QKeyEvent *event);
-    virtual void keyReleaseEvent(QKeyEvent *event);
     virtual void tabletEvent(QTabletEvent * event);
     virtual void mouseDoubleClickEvent(QMouseEvent *event);
     virtual void mousePressEvent(QMouseEvent *event);

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -92,6 +92,7 @@ void UBEmbedController::showEmbedDialog()
         mTrapDialog = new QDialog(mParentWidget, flag);
         mTrapFlashUi = new Ui::trapFlashDialog();
         mTrapFlashUi->setupUi(mTrapDialog);
+        mTrapFlashUi->widgetNameLineEdit->setMaxLength(240);
 
         int viewWidth = mParentWidget->width() / 2;
         int viewHeight = mParentWidget->height() * 2. / 3.;
@@ -152,9 +153,12 @@ void UBEmbedController::textChanged(const QString& newText)
     static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
-    if (new_text.indexOf(regExp) > -1)
+    static const QRegularExpression entityRegExp("&.*?;");
+
+    if (new_text.indexOf(regExp) > -1 || new_text.indexOf(entityRegExp) > -1)
     {
         new_text.remove(regExp);
+        new_text.replace(entityRegExp, "_");
         mTrapFlashUi->widgetNameLineEdit->setText(new_text);
         QToolTip::showText(mTrapFlashUi->widgetNameLineEdit->mapToGlobal(QPoint()), tr("Application name can`t contain any of the following characters:\r\n") + illegalCharList);
     }


### PR DESCRIPTION
This PR fixes two issues:

- #774 
- https://github.com/letsfindaway/OpenBoard/issues/134

The first issue was caused by a missing `keyReleaseEvent` for the `Ctrl` key when pasting a URL via `Ctrl-V`. This caused that the `UBBoardView` was still in multi-selection mode and mouse events were not forwarded to the widget or its delegate.

The first commit fixes this issue. The state of the `Ctrl` key is now determined from the `QMouseEvent::modifiers()` instead from key events. This solution is robust against missing key events and is most probably what you want.

The second issue could occur when creating a widget from a web page with a very long title or a title with some special characters or HTML entities, as the title is used as folder name for the newly created widget. In this case, either the folder could not be created from the title, as it was too long, or the browser could not open the HTML page with that file name, as it contained an HTML entity which is interpreted by the browser, but not by the file system.

The second commit fixes this issue. It limits the size of the widget name to 240 characters. Additionally, it replaces any occurrence of an HTML entity by an underscore.