### PR TITLE
fix: svg serialization of scene

### DIFF
--- a/src/domain/UBGraphicsStrokesGroup.cpp
+++ b/src/domain/UBGraphicsStrokesGroup.cpp
@@ -155,24 +155,39 @@ UBItem* UBGraphicsStrokesGroup::deepCopy() const
     const_cast<UBGraphicsStrokesGroup*>(this)->setPos(0,0);
 
     QList<QGraphicsItem*> chl = childItems();
+    QHash<UBGraphicsStroke*, UBGraphicsStroke*> groupClone;
 
-    UBGraphicsStroke* newStroke = new UBGraphicsStroke;
-
-    foreach(QGraphicsItem *child, chl)
+    foreach (QGraphicsItem* child, chl)
     {
-        UBGraphicsPolygonItem *polygon = dynamic_cast<UBGraphicsPolygonItem*>(child);
+        UBGraphicsPolygonItem* polygon = dynamic_cast<UBGraphicsPolygonItem*>(child);
 
-        if (polygon){
-            UBGraphicsPolygonItem *polygonCopy = dynamic_cast<UBGraphicsPolygonItem*>(polygon->deepCopy());
+        if (polygon)
+        {
+            UBGraphicsPolygonItem* polygonCopy = dynamic_cast<UBGraphicsPolygonItem*>(polygon->deepCopy());
+
             if (polygonCopy)
             {
-                QGraphicsItem* pItem = dynamic_cast<QGraphicsItem*>(polygonCopy);
-                copy->addToGroup(pItem);
+                copy->addToGroup(polygonCopy);
                 polygonCopy->setStrokesGroup(copy);
-                polygonCopy->setStroke(newStroke);
+
+                UBGraphicsStroke* stroke = polygon->stroke();
+
+                if (stroke)
+                {
+                    UBGraphicsStroke* cloneStroke = groupClone.value(stroke);
+
+                    if (!cloneStroke)
+                    {
+                        cloneStroke = stroke->deepCopy();
+                        groupClone.insert(stroke, cloneStroke);
+                    }
+
+                    polygonCopy->setStroke(cloneStroke);
+                }
             }
         }
     }
+
     const_cast<UBGraphicsStrokesGroup*>(this)->setTransform(groupTransform);
     const_cast<UBGraphicsStrokesGroup*>(this)->setPos(groupPos);
     copy->setTransform(groupTransform);


### PR DESCRIPTION
This PR fixes some long standing serialization bugs. Two of them have been described in https://github.com/letsfindaway/OpenBoard/issues/136 and https://github.com/letsfindaway/OpenBoard/issues/137, but these are only effects of underlying problems.

## Stroke and Strokes Group

One thing is the missing understanding of the meaning of `UBGraphicsStroke` and `UBGraphicsStrokesGroup` in the `UBSvgSubsetAdaptor`. The definition of those two is as follows:

- A `UBGraphicsStroke` is the representation of a single stroke, which may be represented by one or more `UBGraphicsPolygonItems`. There are reasons to split a stroke into multiple polygons during drawing, to reduce complexity of a single polygon. The `UBGraphicsStroke` also has a function to simplify it immediately after drawing. For that it not only holds the polygon outline, but also the drawn points. But when drawing a stroke is finished, this class is not actually doing much.
- A `UBGraphicsStrokesGroup` is a collection of one or more polygons related to one or more strokes. It holds together all the polygons, even when e.g parts of a stroke have been deleted by the eraser. Also an arc drawn using the Compass tool creates a strokes group with several strokes: One for the arc and two small lines for the center cross. The strokes group holds them together.

In the persisted document, a strokes group is represented by a SVG `<g>` element. The stroke itself has no representation at all. The polygons are represented by either a `<polygon>` or `<line>` element within the `<g>`.

## Scene items

Another point is the question what items `QGraphicsScene::items()` actually returns. The documentation is not very clear about this and some sources on the Internet are actually wrong about this.

If a scene contains items which themselves have child items, then one could assume, that `scene->items()` only returns the parent items and that we have to recurse into the child items. In some places the OpenBoard also makes this assumption, but it is wrong. `scene->items()` returns **all** items, even child items down all hierarchy levels. This misunderstanding duplicates items in `UBGraphicsScene::sceneDeepCopy()`, which is used when saving a document.

## Solution

This PR solves these issues by the following modifications:

- reconstruct `UBGraphicsStroke` in `deepCopy` of UBGraphicsStrokesGroup
- avoid duplication of items in `UBGraphicsScene::sceneDeepCopy`
- consistent handling of strokes and stroke groups in `UBSvgSubsetAdaptor`
  - a strokes group is serialized as `<g>`
  - `UBGraphicsStroke` is not serialized at all, as it is not relevant for a persisted document
- Persist nominal lines as `<line>`
- Correctly assign z-values to strokes in a group