### PR TITLE
fix: update German translation of hints and tips

### DIFF
--- a/resources/startupHints/locales/de/1.html
+++ b/resources/startupHints/locales/de/1.html
@@ -15,8 +15,8 @@
 		<div class="image"><img src="../../assets/hint1/openboard-logo.png" alt=""></div>
 		<br>
 		<p>Hier sind einige Tipps und Tricks, die Ihnen helfen sollen, sich mit OpenBoard vertraut zu machen.</p>
-		<p>OpenBoard ist ein interaktives Whiteboard, das von Lehrern für Lehrer entwickelt wurde. Es besteht aus vier Modi: dem Tafelmodus, dem Desktopmodus, dem Dokumentenmodus und dem Webmodus.</p>
-		<p>Beginnen wir mit dem ersten und wichtigsten: dem Tabellenmodus.</p>
+		<p>OpenBoard ist ein interaktives Whiteboard, das von Lehrern für Lehrer entwickelt wurde. Es besteht aus vier Modi: dem Boardmodus, dem Desktopmodus, dem Dokumentenmodus und dem Internetmodus.</p>
+		<p>Beginnen wir mit dem ersten und wichtigsten: dem Boardmodus.</p>
 	</main>
 	<footer>
 		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können dieses Fenster jederzeit wieder über die Schaltfläche "Tipps und Tricks" im OpenBoard-Menü (<span class="icon"><img src="../../assets/hint1/menu.png" alt="the OpenBoard menu"></span>) öffnen.<span>

--- a/resources/startupHints/locales/de/10.html
+++ b/resources/startupHints/locales/de/10.html
@@ -12,13 +12,13 @@
 		<h1 class="title">Applikationen</h1>
 	</header>
 	<main>
-		<p>OpenBoard bietet verschiedene Apps und Werkzeuge. Sie können auf diese zugreifen, indem Sie <span class="icon"><img src="../../assets/common/ApplicationsCategory.png" alt=""></span> in der OpenBoard-Bibliothek auf klicken</p>
+		<p>OpenBoard bietet verschiedene Apps und Werkzeuge. Sie können auf diese zugreifen, indem Sie auf <span class="icon"><img src="../../assets/common/ApplicationsCategory.png" alt=""></span> in der OpenBoard-Bibliothek klicken</p>
 		<h3>Standard-Apps</h3>
 		<p>Hier finden Sie geometrische Werkzeuge, einen Taschenrechner, Google Map, einen QR-Code-Generator und vieles mehr! Kombinieren Sie sie, um anregende Lernerfahrungen zu schaffen!</p>
 		<div class="image"><img src="../../assets/hint10/application-gif1.gif" alt=""></div>
 		<h3>Erstellen Sie Apps</h3>
-		<p>Wie im Abschnitt Webmodus erläutert, können Sie eine App von einer Website aus erstellen, indem Sie den internen Browser verwenden oder eine URL mit Kopieren und Einfügen in die Tabelle einfügen.</p>
-		<p>Damit können Sie Ihren Unterricht mit leistungsstarken Online-Tools aufpeppen, die Sie direkt an der Tafel verwenden können! Hier sind einige Illustrationen interessanter Apps (Ziehen Sie sie auf die Tafel, um sie zu testen!) :</p>
+		<p>Wie im Abschnitt Internetmodus erläutert, können Sie eine App von einer Website aus erstellen, indem Sie den internen Browser verwenden oder eine URL mit Kopieren und Einfügen auf das Board einfügen.</p>
+		<p>Damit können Sie Ihren Unterricht mit leistungsstarken Online-Tools aufpeppen, die Sie direkt auf dem Board verwenden können! Hier sind einige Beispiele interessanter Apps (Ziehen Sie sie auf das Board, um sie zu testen!) :</p>
 		<ul>
 			<li><a class="non-clickable" href="https://scratch.mit.edu/">Scratch</a></li>
 			<li><a class="non-clickable" href="https://phet.colorado.edu">Die PhET-Simulationen</a></li>

--- a/resources/startupHints/locales/de/11.html
+++ b/resources/startupHints/locales/de/11.html
@@ -16,12 +16,12 @@
 		<p>OpenBoard bietet Ihnen die Möglichkeit, Audio- und Videoaufnahmen von Ihrem Unterricht zu machen.</p>
 		<p>Dies kann zum Beispiel nützlich sein, um zusätzliche Übungen oder eine Information über einen Videoclip zu teilen oder eine Unterrichtsstunde aufzuzeichnen, um sie mit abwesenden Schülern zu teilen.</p>
 		
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Im Tabellenmodus werden die Symbolleisten und Paletten nicht im Videoclip erscheinen, sodass Sie sich keine Gedanken darüber machen müssen! Dasselbe gilt für den internen Browser, wo nur die aktive Registerkarte erfasst wird.</span>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Im Boardmodus werden die Symbolleisten und Paletten nicht im Videoclip erscheinen, sodass Sie sich keine Gedanken darüber machen müssen! Dasselbe gilt für den internen Browser, wo nur die aktive Registerkarte erfasst wird.</span>
 		
 		<p>Sie können auf dieses Tool wie folgt zugreifen:</p>
 		<div class="image"><img src="../../assets/hint11/podcast-gif1.gif" alt=""></div>
 
-		<p>Sie werden folgende Schnittstelle in der rechten unteren Ecke der Tabelle sehen:</p>
+		<p>Sie werden folgende Schnittstelle in der rechten unteren Ecke des Boards sehen:</p>
 		<div class="image"><img src="../../assets/hint11/podcast2.png" alt=""></div>
 
 		<p>Klicken Sie auf die rote Schaltfläche, um die Aufnahme zu starten.</p>

--- a/resources/startupHints/locales/de/12.html
+++ b/resources/startupHints/locales/de/12.html
@@ -20,7 +20,7 @@
 		
 		<h3>Schnell von einem Dokument zum anderen wechseln</h3>
 		<p>Ihre Lieblingsdokumente erscheinen in der OpenBoard-Bibliothek unter <span class="icon"><img src="../../assets/common/FavoritesCategory.png" alt=""></span><br>
-		Jedes dieser OpenBoard-Dokumente (<span class="icon"><img src="../../assets/common/openboard-document.png" alt=""></span>) kann dann per Drag & Drop auf die Tafel gezogen werden!</p>
+		Jedes dieser OpenBoard-Dokumente (<span class="icon"><img src="../../assets/common/openboard-document.png" alt=""></span>) kann dann per Drag & Drop auf das Board gezogen werden!</p>
 		<div class="image"><img src="../../assets/hint12/favorites2.png" alt=""></div>
 
 		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können die Suchleiste am unteren Rand der OpenBoard Bibliothek verwenden, um ein Dokument anhand seines Namens zu finden</span>

--- a/resources/startupHints/locales/de/2.html
+++ b/resources/startupHints/locales/de/2.html
@@ -2,14 +2,14 @@
 <html>
 <head>
     <meta charset="UTF-8">
-     <title>Tabellen-Modus</title>
+     <title>Board-Modus</title>
      <link rel="stylesheet" href="css/style.css" type="text/css">
      <meta name="viewport" content="width=device-width" />
 </head>
 
 <body>
 	<header>
-		<h1 class="title">Tabellen-Modus</h1>
+		<h1 class="title">Board-Modus</h1>
 	</header>
 	<main>
 		<h3>Die Stiftpalette</h3>
@@ -22,21 +22,21 @@
 			<li><span class="icon"><img src="../../assets/common/handPlay.png" alt=""></span>  ist der magische Finger. Sie können Objekte bewegen oder mit ihnen interagieren, ohne dass Sie sie auswählen müssen.</li>
 			<li><span class="icon"><img src="../../assets/common/hand.png" alt=""></span> ist die Hand. Damit können Sie die Seite bewegen. Sehr nützlich, wenn sie mit den Zoomfunktionen kombiniert wird!</li>
 			<li><span class="icon"><img src="../../assets/common/zoomIn.png" alt=""></span><span class="icon"><img src="../../assets/common/zoomOut.png" alt=""></span>  geben Ihnen die Möglichkeit, ein- und auszuzoomen. Wählen Sie einfach den gewünschten Effekt aus und klicken Sie auf die Stelle, auf die Sie ihn anwenden möchten!</li>
-			<li><span class="icon"><img src="../../assets/common/laser.png" alt=""></span>  ist ein Laserpointer, der nützlich ist, um auf Elemente auf der Tafel zu zeigen, ohne mit diesen zu interagieren.</li>
+			<li><span class="icon"><img src="../../assets/common/laser.png" alt=""></span>  ist ein Laserpointer, der nützlich ist, um auf Elemente auf dem Board zu zeigen, ohne mit diesen zu interagieren.</li>
 			<li><span class="icon"><img src="../../assets/common/line.png" alt=""></span>  wird zum einfachen Zeichnen von geraden Linien verwendet.</li>
 			<li><span class="icon"><img src="../../assets/common/text.png" alt=""></span>  ist eine Textbox, die es ermöglicht, mit der Tastatur statt mit einem Bleistift zu schreiben.</li>
 		</ul>
 
-		<h3>Die Leiste der Tabelle</h3>
-		<p>Mit der Tabellenleiste können Sie unter anderem die Farbe und/oder die Größe des Stifts und Markers ändern.</p>
+		<h3>Die Werkzeugleiste des Boards</h3>
+		<p>Mit der Werkzeugleiste können Sie unter anderem die Farbe und Größe des Stifts und Markers ändern.</p>
 		<div class="image"><img id="bo9" src="../../assets/hint2/bo9.png" alt=""></div>
 
-		<p>Dort finden Sie auch die Möglichkeit, den Hintergrund der Tabelle zu ändern, indem Sie auf <span class="icon"><img src="../../assets/common/background.png" alt=""></span></p>
+		<p>Dort finden Sie auch die Möglichkeit, den Hintergrund des Boards zu ändern, indem Sie auf <span class="icon"><img src="../../assets/common/background.png" alt=""></span> klicken.</p>
 		<div class="image"><img src="../../assets/hint2/bo-gif1.gif" alt=""></div>
 		
-		<p>Außerdem finden Sie hier Funktionen wie Rückgängigmachen/Wiederherstellen, Erstellen und von Seite zu Seite Navigieren, Löschen der Tabelle, ...</p>
+		<p>Außerdem finden Sie hier Funktionen wie Rückgängigmachen/Wiederherstellen, Erstellen und von Seite zu Seite Navigieren, Löschen des Boards, ...</p>
 		
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können spezifischere Elemente der Tabelle vollständig löschen, indem Sie einen langen Klick auf machen <span class="icon"><img src="../../assets/common/clearPage.png" alt="the erase icon"></span>. Einige zusätzliche Funktionen, die auch für <span class="icon"><img src="../../assets/common/newDocument.png" alt="the erase icon"></span> !</span>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können spezifischere Elemente des Boards vollständig löschen, indem Sie einen langen Klick auf <span class="icon"><img src="../../assets/common/clearPage.png" alt="the erase icon"></span> machen. Einige zusätzliche Funktionen erreichen Sie so auch für <span class="icon"><img src="../../assets/common/newDocument.png" alt="the new page icon"></span> !</span>
 	</main>
 	<footer>
 

--- a/resources/startupHints/locales/de/3.html
+++ b/resources/startupHints/locales/de/3.html
@@ -2,14 +2,14 @@
 <html>
 <head>
     <meta charset="UTF-8">
-     <title>Büro-Modus</title>
+     <title>Desktop-Modus</title>
      <link rel="stylesheet" href="css/style.css" type="text/css">
      <meta name="viewport" content="width=device-width" />
 </head>
 
 <body>
 	<header>
-		<h1 class="title">Büro-Modus</h1>
+		<h1 class="title">Desktop-Modus</h1>
 	</header>
 	<main>
 		<h3>Mit anderen Apps interagieren</h3>
@@ -21,7 +21,7 @@
 		<div>Sie können jede Software mit Anmerkungen versehen, indem Sie den Bleistift (<span class="icon"><img src="../../assets/common/penArrow.svg" alt=""></span>) oder den Marker (<span class="icon"><img src="../../assets/common/markerArrow.svg" alt=""></span>) verwenden.</div>
 		<div class="image"><img src="../../assets/hint3/bureau-gif1.gif" alt=""></div>
 
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können auf weitere Optionen für <span class="icon"><img src="../../assets/common/penArrow.svg" alt="the pen"></span>, <span class="icon"><img src="../../assets/common/markerArrow.svg" alt="the marker"></span>, <span class="icon"><img src="../../assets/common/eraserArrow.svg" alt="the eraser"></span>, und zugreifen, indem Sie sie mit einem langen Klick anklicken oder auf den kleinen schwarzen Pfeil klicken.</span>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können auf weitere Optionen für <span class="icon"><img src="../../assets/common/penArrow.svg" alt="the pen"></span>, <span class="icon"><img src="../../assets/common/markerArrow.svg" alt="the marker"></span>, und <span class="icon"><img src="../../assets/common/eraserArrow.svg" alt="the eraser"></span> zugreifen, indem Sie sie mit einem langen Klick anklicken oder auf den kleinen schwarzen Pfeil klicken.</span>
 	</main>
 	<footer>
 

--- a/resources/startupHints/locales/de/4.html
+++ b/resources/startupHints/locales/de/4.html
@@ -12,11 +12,11 @@
 		<h1 class="title">Dokumenten-Modus</h1>
 	</header>
 	<main>
-		<p>OpenBoard bietet einen Dokumentenmanager. Sie können darauf zugreifen, indem Sie einfach auf <span class="icon"><img src="../../assets/common/documents.png" alt=""></span></p>
+		<p>OpenBoard bietet einen Dokumentenmanager. Sie können darauf zugreifen, indem Sie einfach auf <span class="icon"><img src="../../assets/common/documents.png" alt=""></span> klicken.</p>
 		<div class="image"><img src="../../assets/hint4/document1.png" alt=""></div>
 		
 		<h3>Legen Sie Ordner an und organisieren Sie Ihre Arbeit</h3>
-		<p>Sie können einen Ordner erstellen, indem Sie auf klicken. Benennen Sie ihn und ziehen Sie Ihre Dokumente per Drag & Drop hinein. Auf die gleiche Weise können Sie einen ganzen Ordner in einen anderen verschieben.</p>
+		<p>Sie können einen Ordner erstellen, indem Sie auf "Neuer Ordner" klicken. Benennen Sie ihn und ziehen Sie Ihre Dokumente per Drag & Drop hinein. Auf die gleiche Weise können Sie einen ganzen Ordner in einen anderen verschieben.</p>
 		<div class="image"><img src="../../assets/hint4/gif-document1.gif" alt=""></div>
 
 		<h3>Seitenverwaltung</h3>

--- a/resources/startupHints/locales/de/5.html
+++ b/resources/startupHints/locales/de/5.html
@@ -16,10 +16,10 @@
 		<div class="image"><img id="importation1" src="../../assets/hint5/img1.png" alt=""></div>
 
 		<h3>Import</h3>
-		<p>Sie können PDF-Dateien (<span class="file-extension">.pdf</span>), Bilder (<span class="file-extension">.png</span>, <span class="file-extension">.jpg</span>), OpenBoard-Dokumente (<span class="file-extension">.ubz</span>) oder OpenBoard-Ordner (<span class="file-extension">.ubx</span>), importieren, indem Sie  anklicken <span class="icon"><img src="../../assets/common/import.png" alt=""></span></p>
+		<p>Sie können PDF-Dateien (<span class="file-extension">.pdf</span>), Bilder (<span class="file-extension">.png</span>, <span class="file-extension">.jpg</span>), OpenBoard-Dokumente (<span class="file-extension">.ubz</span>) oder OpenBoard-Ordner (<span class="file-extension">.ubx</span>) importieren, indem Sie <span class="icon"><img src="../../assets/common/import.png" alt=""></span> anklicken.</p>
 		<div class="image"><img src="../../assets/hint5/gif1.gif" alt=""></div>
 		<p>Beachten Sie, dass Sie auch ein OpenBoard-Dokument (<span class="file-extension">.ubz</span>) importieren können, indem Sie darauf doppelklicken. Dies startet OpenBoard, wenn es nicht bereits gestartet ist, und importiert es (oder schlägt vor, die Datei zu ersetzen, wenn sie bereits vorhanden ist).</p>
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können auch mehrere Elemente auf einmal importieren, ohne dass Sie auf <span class="icon"><img src="../../assets/common/import.png" alt=""></span> immer und immer wieder klicken müssen.</span>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie können auch mehrere Elemente auf einmal importieren, ohne dass Sie immer und immer wieder auf <span class="icon"><img src="../../assets/common/import.png" alt=""></span> klicken müssen.</span>
 		<h3>Export</h3>
 		<p>Sie können ein OpenBoard-Dokument im PDF- oder UBZ-Format und einen OpenBoard-Ordner im UBX-Format exportieren. So können Sie zum Beispiel :
 			<ul>
@@ -30,7 +30,7 @@
 		</p>
 		<div class="image"><img src="../../assets/hint5/gif2.gif" alt=""></div>
 		
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Exportieren Sie alle Ihre Dokumente, indem Sie auf den Stammordner "Meine Dokumente" klicken, bevor Sie auf klicken, um sie im UBX-Format zu exportieren. Sie können sie dann auf einem anderen Computer importieren. Dies ist auch eine gute Möglichkeit, ein Archiv oder eine Sicherungskopie Ihrer gesamten Arbeit zu erstellen!</span>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Exportieren Sie alle Ihre Dokumente, indem Sie auf den Stammordner "Meine Dokumente" klicken, bevor Sie auf <span class="icon"><img src="../../assets/common/export.png" alt=""></span> klicken, um sie im UBX-Format zu exportieren. Sie können sie dann auf einem anderen Computer importieren. Dies ist auch eine gute Möglichkeit, ein Archiv oder eine Sicherungskopie Ihrer gesamten Arbeit zu erstellen!</span>
 	</main>
 	<footer>
 

--- a/resources/startupHints/locales/de/6.html
+++ b/resources/startupHints/locales/de/6.html
@@ -2,34 +2,34 @@
 <html>
 <head>
     <meta charset="UTF-8">
-     <title>Web-Modus</title>
+     <title>Internet-Modus</title>
      <link rel="stylesheet" href="css/style.css" type="text/css">
      <meta name="viewport" content="width=device-width" />
 </head>
 
 <body>
 	<header>
-		<h1 class="title">Web-Modus</h1>
+		<h1 class="title">Internet-Modus</h1>
 	</header>
 	<main>
-		Der Webmodus ist ein interner Browser, der einen traditionelleren Browser um einige sehr interessante Funktionen erweitert.
+		Der Internetmodus ist ein interner Browser, der einen traditionelleren Browser um einige sehr interessante Funktionen erweitert.
 		<h3>Verwendung des internen Browsers</h3>
 		<p>Mithilfe des internen Browsers haben Sie die Möglichkeit, das Internet zu durchsuchen, ohne OpenBoard zu minimieren oder zu verlassen, mit zusätzlichen Funktionen, die es Ihnen ermöglichen, einen Teil oder den gesamten Bildschirm zu erfassen oder Apps von Websites zu erstellen und sie dem Board hinzuzufügen!</p>
 		
 		<div class="image"><img src="../../assets/hint6/app1.png" alt=""></div>
 		
 		<h3>Eine App erstellen</h3>
-		<p>Sie können eine App von jeder beliebigen Website aus erstellen, um sie der Tafel hinzuzufügen und mit ihr zu interagieren, genau wie mit den Standardanwendungen.</p>
+		<p>Sie können eine App von jeder beliebigen Website aus erstellen, um sie dem Board hinzuzufügen und mit ihr zu interagieren, genau wie mit den Standardanwendungen.</p>
 		<p>Gehen Sie dazu auf die Website, die Sie erfassen möchten, klicken Sie auf <span class="icon"><img src="../../assets/hint6/addToolToLibrary.png" alt="Capture Web Content"></span> und bestätigen Sie ihre Erstellung, indem Sie auf "Anwendung erstellen" klicken.</p>
 		<div class="image"><img src="../../assets/hint6/app-gif2.gif" alt=""></div>
 
-		<p>Wenn eine Anwendung erstellt wird, wird sie automatisch in der OpenBoard-Bibliothek gespeichert, sodass Sie sie in jedem beliebigen Dokument wiederverwenden können. Sie finden sie unter dem Ordner "Apps" in einem Unterordner namens "Web".</p>
+		<p>Wenn eine Anwendung erstellt wird, wird sie automatisch in der OpenBoard-Bibliothek gespeichert, sodass Sie sie in jedem beliebigen Dokument wiederverwenden können. Sie finden sie unter dem Ordner "Anwendungen" in einem Unterordner namens "Internet".</p>
 		
 		<div class="image"><img src="../../assets/hint6/app-gif3.gif" alt=""></div>
 		
 		<h3>Verwendung des externen Browsers</h3>
-		<p>Sie können auch einen externen Browser verwenden, indem Sie die entsprechende Option in den Einstellungen ankreuzen. Wenn Sie auf klicken, wird Ihr bevorzugter Browser dann im Desktopmodus gestartet.</p>
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Wenn Sie einen externen Browser verwenden, können Sie immer noch eine App von einer Website aus erstellen, indem Sie die URL in der Adresszeile Ihres Browsers kopieren und sie dann einfügen, wenn Sie wieder im Tabellenmodus sind!</span>
+		<p>Sie können auch einen externen Browser verwenden, indem Sie die entsprechende Option in den Einstellungen ankreuzen. Wenn Sie auf <span class="icon"><img src="../../assets/common/web.png" alt=""></span> klicken, wird Ihr bevorzugter Browser dann im Desktopmodus gestartet.</p>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Wenn Sie einen externen Browser verwenden, können Sie immer noch eine App von einer Website aus erstellen, indem Sie die URL in der Adresszeile Ihres Browsers kopieren und sie dann einfügen, wenn Sie wieder im Boardmodus sind!</span>
 	</main>
 	<footer>
 

--- a/resources/startupHints/locales/de/7.html
+++ b/resources/startupHints/locales/de/7.html
@@ -13,7 +13,7 @@
 	</header>
 	<main>
 		Eine der grundlegenden, aber wirklich nützlichen Funktionen von OpenBoard ist der Screenshot. Damit können Sie während Ihres Unterrichts einen Schnappschuss von einem beliebigen Zustand des Boards erstellen.
-		<h3>Im Tabellenmodus</h3>
+		<h3>Im Boardmodus</h3>
 		<p>Suchen Sie <span class="icon"><img src="../../assets/common/captureAreaBoard.png" alt="the screen capture icon"></span> in der Stiftpalette,  klicken Sie darauf und wählen Sie den Bereich aus, den Sie erfassen möchten. Anschließend werden Ihnen drei Optionen angeboten :</p>
 		<ul>
 			<li><b>Zur aktuellen Seite hinzufügen</b></li>
@@ -26,16 +26,16 @@
 		
 		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Sie müssen sich keine Gedanken um die Stiftpalette, die Seitenvorschau oder die Registerkarte für die OpenBoard-Bibliothek machen - sie werden nicht von Ihrem Lasso eingefangen!</span>
 
-		<h3>Im Büro-Modus</h3>
-		<p>Dasselbe können Sie im Desktop-Modus tun, um Ihre Arbeit in anderen Programmen zu erfassen. Wechseln Sie in den Desktop-Modus, indem Sie auf <span class="icon"><img src="../../assets/common/display.png" alt=""></span></p>
-		<p>Sie finden zwei Symbole: <span class="icon"><img src="../../assets/common/captureScreen.png" alt=""></span> um den gesamten Bildschirm zu erfassen, und <span class="icon"><img src="../../assets/common/captureAreaDesktop.png" alt=""></span> um nur einen Teil davon zu erfassen. Wie im Tafelmodus müssen Sie auswählen, wo Sie die Aufnahme hinzufügen möchten</p>
+		<h3>Im Desktop-Modus</h3>
+		<p>Dasselbe können Sie im Desktop-Modus tun, um Ihre Arbeit in anderen Programmen zu erfassen. Wechseln Sie in den Desktop-Modus, indem Sie auf <span class="icon"><img src="../../assets/common/display.png" alt=""></span> klicken.</p>
+		<p>Sie finden zwei Symbole: <span class="icon"><img src="../../assets/common/captureScreen.png" alt=""></span> um den gesamten Bildschirm zu erfassen, und <span class="icon"><img src="../../assets/common/captureAreaDesktop.png" alt=""></span> um nur einen Teil davon zu erfassen. Wie im Boardmodus müssen Sie auswählen, wo Sie die Aufnahme hinzufügen möchten</p>
 		
 		<p>Hier eine Illustration des gesamten Prozesses :</p>
 		<div class="image"><img src="../../assets/hint7/capture-gif2.gif" alt=""></div>
 
 
-		<h3>Im Webmodus</h3>
-		<p>In ähnlicher Weise ist dies auch im Webmodus möglich, wo Sie eine Teilaufnahme des Bildschirms machen oder den aktiven Tab des Browsers erfassen können, indem Sie <span class="icon"><img src="../../assets/common/captureWindow.png" alt=""></span> anklicken</p>
+		<h3>Im Internetmodus</h3>
+		<p>In ähnlicher Weise ist dies auch im Internetmodus möglich, wo Sie eine Teilaufnahme des Bildschirms machen oder den aktiven Tab des Browsers erfassen können, indem Sie <span class="icon"><img src="../../assets/common/captureWindow.png" alt=""></span> anklicken</p>
 	</main>
 	<footer>
 

--- a/resources/startupHints/locales/de/8.html
+++ b/resources/startupHints/locales/de/8.html
@@ -12,19 +12,19 @@
 		<h1 class="title">Bilder</h1>
 	</header>
 	<main>
-		In OpenBoard, Sie können auf Bilder auf verschiedene Arten zugreifen.
-		<h3>Organisieren Sie Ihren Ordner Bilder</h3>
+		In OpenBoard können Sie auf Bilder auf verschiedene Arten zugreifen.
+		<h3>Organisieren Sie Ihren Bilder-Ordner</h3>
 		<p>Screenshots, die der Bibliothek hinzugefügt wurden, finden Sie im Ordner Bilder : <span class="icon"><img src="../../assets/common/PicturesCategory.png" alt=""></span><br>Sie können Unterordner erstellen, indem Sie <span class="icon"><img src="../../assets/common/miniNewFolder.png" alt=""></span> ganz unten in der Bibliothek verwenden. Ziehen Sie dann Ihre Bilder per Drag & Drop in die verschiedenen Ordner, die Sie erstellt haben.</p>
 		<div class="image"><img src="../../assets/hint8/image-gif1.gif" alt=""></div>
 		
-		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Egal, wo Sie sich in der OpenBoard-Bibliothek befinden, die Bilder, die Sie hinzufügen, werden automatisch innerhalb des Ordners platziert , so dass die Bibliothek organisiert bleibt.</span>
+		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Egal, wo Sie sich in der OpenBoard-Bibliothek befinden, die Bilder, die Sie hinzufügen, werden automatisch innerhalb des Bilder-Ordners platziert , so dass die Bibliothek organisiert bleibt.</span>
 
 		<h3>Fügen Sie Bilder von Ihrem Computer hinzu</h3>
 		<p>Sie können auch Bilder von Ihrem Computer hinzufügen, wie hier dargestellt :</p>
 		<div class="image"><img src="../../assets/hint8/image-gif3.gif" alt=""></div>
 
 		<h3>Fügen Sie Bilder aus Suchmaschinen hinzu</h3>
-		<p>Schließlich können Sie auch nach lizenzfreien Bildern suchen und diese zur Tabelle hinzufügen, indem Sie die Suchmaschinen im Ordner "Websuche" verwenden: <span class="icon"><img src="../../assets/common/PicturesCategory.png" alt=""></span></p>
+		<p>Schließlich können Sie auch nach lizenzfreien Bildern suchen und diese zum Board hinzufügen, indem Sie die Suchmaschinen im Ordner "Websuche" verwenden: <span class="icon"><img src="../../assets/common/PicturesCategory.png" alt=""></span></p>
 		<div class="image"><img src="../../assets/hint8/image-gif2.gif" alt=""></div>
 
 		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Anstatt Drag-and-Drop zu verwenden, klicken Sie einfach auf ein Bild, das als Suchergebnis erscheint, um Details zu sehen und Optionen wie Zur Bibliothek hinzufügen zu finden. Nützlich bei der Vorbereitung einer Unterrichtsstunde!</span>

--- a/resources/startupHints/locales/de/9.html
+++ b/resources/startupHints/locales/de/9.html
@@ -12,7 +12,7 @@
 		<h1 class="title">Interaktivitäten</h1>
 	</header>
 	<main>
-		Für jüngere Schülerinnen und Schüler finden Sie eine Reihe von anpassbaren Anwendungen, die speziell auf sie zugeschnitten sind.
+		Für jüngere Schülerinnen und Schüler finden Sie eine Reihe von anpassbaren Anwendungen, die speziell auf diese Zielgruppe zugeschnitten sind.
 		<h3>Die interaktiven Übungen von OpenBoard</h3>
 		<p>Mit diesen Interaktivitäten können Sie verschiedene Arten von Übungen erstellen. Dabei kann es sich um Kategorisierung, Kopfrechnen, Auswendiglernen usw. handeln.</p>
 		<p>Die Interaktivitäten befinden sich in der OpenBoard-Bibliothek: Klicken Sie auf <span class="icon"><img src="../../assets/common/InteractivesCategory.png" alt=""></span>, um sie zu finden.</p>
@@ -20,7 +20,7 @@
 		<h3>Beispiele</h3>
 		<p>Wir werden eine Übung erstellen, die die Interaktivität "<strong>Cat</strong>egorize <strong>pict</strong>ures" (übersetzt: Bilder kategorisieren) verwendet: <span class="icon"><img src="../../assets/hint9/cat-pict.png" alt=""></span></p>
 		<span class="tip"><span class="icon"><img src="../../assets/common/tip.png" alt=""></span>Probieren Sie es aus! Verschieben Sie dieses Fenster auf eine Seite und reproduzieren Sie das Beispiel auf der Pinnwand!</span>
-		<p>Zunächst ziehen Sie die Interaktivität per Drag & Drop auf die Tafel und klicken auf "Bearbeiten".</p>
+		<p>Zunächst ziehen Sie die Interaktivität per Drag & Drop auf das Board und klicken auf "Bearbeiten".</p>
 		<p>Ändern Sie dann die Namen der Kategorien nach Bedarf :</p>
 		<div class="image"><img id="interactivite3" src="../../assets/hint9/interactivite3.png" alt=""></div>
 

--- a/resources/startupHints/locales/de/error.html
+++ b/resources/startupHints/locales/de/error.html
@@ -2,14 +2,14 @@
 <HTML>
 <HEAD>
 	<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
-	<TITLE>erreur</TITLE>
+	<TITLE>Fehler</TITLE>
 	<META NAME="GENERATOR" CONTENT="OpenOffice.org 3.4.1  (Unix)">
 	<META NAME="CREATED" CONTENT="0;0">
 	<META NAME="CHANGED" CONTENT="20130429;6074300">
 </HEAD>
-<BODY LANG="en" DIR="LTR">
-<P STYLE="margin-bottom: 0in">Quelque chose s'est mal passé ...
-Vérifier l'existence de vos conseils dans le dossier
-/Resources/startupHints/ …</P>
+<BODY LANG="de" DIR="LTR">
+<P STYLE="margin-bottom: 0in">Etwas ist schief gelaufen ...
+Überprüfen Sie die Existenz Ihrer Tipps im Ordner
+/resources/startupHints/ …</P>
 </BODY>
 </HTML>


### PR DESCRIPTION
- harmonize name of modes: Board, Dokumente, Desktop, Internet
- correct some sentence structure
- add missing icon references
- translate the error page