### PR TITLE
Fix glitches when moving items below live thumbnails

### DIFF
--- a/src/gui/UBThumbnailWidget.cpp
+++ b/src/gui/UBThumbnailWidget.cpp
@@ -37,6 +37,7 @@
 #include <QWidget>
 
 #include "board/UBBoardController.h"
+#include "board/UBBoardView.h"
 
 #include "core/UBSettings.h"
 #include "core/UBApplication.h"
@@ -1066,6 +1067,7 @@ UBDraggableLivePixmapItem::UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsS
     , mScene(pageScene)
     , mPageNumber(new UBThumbnailTextItem(index))
     , mExposed(false)
+    , ignoreNextEvent(false)
 {
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setAcceptDrops(true);
@@ -1212,10 +1214,21 @@ void UBDraggableLivePixmapItem::updatePixmap(const QRectF &region)
 
         if (pixmapRect.isValid())
         {
-            QPainter painter(&pixmap);
-            QRectF sceneRect = mTransform.inverted().mapRect(pixmapRect);
-            mScene->render(&painter, pixmapRect, sceneRect);
-            setPixmap(pixmap);
+            if (ignoreNextEvent)
+            {
+                ignoreNextEvent = false;
+            }
+            else
+            {
+                QPainter painter(&pixmap);
+                QRectF sceneRect = mTransform.inverted().mapRect(pixmapRect);
+                mScene->render(&painter, pixmapRect, sceneRect);
+
+                UBApplication::boardController->controlView()->setUpdatesEnabled(false);
+                ignoreNextEvent = true; // ignore paint event induced by enabling updates
+                setPixmap(pixmap);
+                UBApplication::boardController->controlView()->setUpdatesEnabled(true);
+            }
         }
     }
 }

--- a/src/gui/UBThumbnailWidget.h
+++ b/src/gui/UBThumbnailWidget.h
@@ -622,6 +622,7 @@ class UBDraggableLivePixmapItem : public UBDraggableThumbnailItem
         QTransform mTransform;
         QTimer updateTimer;
         int updateCount;
+        bool ignoreNextEvent;
 };
 
 namespace UBThumbnailUI


### PR DESCRIPTION
I think I finally found a solution for the problem with glitches when moving items below a live thumbnail, especially in large zoom factors. See https://github.com/letsfindaway/OpenBoard/issues/143#issuecomment-1771092503. We have to

- disable updates of board while updating thumbnail, and
- ignore the next repaint event on the board induced by re-enabling updates for thumbnail update.