### PR TITLE
fix: sporadic crash due to dangling connection

### DIFF
--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -98,7 +98,7 @@ UBApplicationController::UBApplicationController(UBBoardView *pControlView,
     connect(displayManager, SIGNAL(screenLayoutChanged()), this, SLOT(screenLayoutChanged()));
     connect(displayManager, SIGNAL(screenLayoutChanged()), mUninoteController, SLOT(screenLayoutChanged()));
     connect(displayManager, SIGNAL(screenLayoutChanged()), UBApplication::webController, SLOT(screenLayoutChanged()));
-    connect(displayManager, &UBDisplayManager::availableScreenCountChanged, [this](){
+    connect(displayManager, &UBDisplayManager::availableScreenCountChanged,this,  [this](){
         initPreviousViews();
         UBApplication::displayManager->setPreviousDisplaysWidgets(mPreviousViews);
     });

--- a/src/domain/UBWebEngineView.cpp
+++ b/src/domain/UBWebEngineView.cpp
@@ -65,7 +65,7 @@ void UBWebEngineView::inspectPage()
 
         page()->setDevToolsPage(inspector->page());
 
-        connect(mInspectorWindow, &QObject::destroyed, [this](){
+        connect(mInspectorWindow, &QObject::destroyed, this, [this](){
             page()->setDevToolsPage(nullptr);
             mInspectorWindow = nullptr;
         });
@@ -107,7 +107,7 @@ void UBWebEngineView::contextMenuEvent(QContextMenuEvent *event)
     // add web inspector action
     QAction *action = new QAction(menu);
     action->setText(tr("Open Web Inspector"));
-    connect(action, &QAction::triggered, [this]() { inspectPage(); });
+    connect(action, &QAction::triggered, this, [this]() { inspectPage(); });
 
     menu->addSeparator();
     menu->addAction(action);

--- a/src/tools/UBGraphicsAxes.cpp
+++ b/src/tools/UBGraphicsAxes.cpp
@@ -72,7 +72,7 @@ UBGraphicsAxes::UBGraphicsAxes()
     setFlag(QGraphicsItem::ItemIsSelectable, false);
     updateResizeCursor();
 
-    connect(UBApplication::boardController, &UBBoardController::zoomChanged, [this](qreal){
+    connect(UBApplication::boardController, &UBBoardController::zoomChanged, this, [this](qreal){
         // recalculate shape when zoom factor changes
         setRect(mBounds);
     });

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -163,10 +163,10 @@ UBWebController::UBWebController(UBMainWindow* mainWindow)
     // synchronize with QNetworkAccessManager
     QNetworkCookieJar* jar = UBNetworkAccessManager::defaultAccessManager()->cookieJar();
 
-    connect(cookieStore, &QWebEngineCookieStore::cookieAdded, [jar](const QNetworkCookie &cookie){
+    connect(cookieStore, &QWebEngineCookieStore::cookieAdded, jar, [jar](const QNetworkCookie &cookie){
         jar->insertCookie(cookie);
     });
-    connect(cookieStore, &QWebEngineCookieStore::cookieRemoved, [jar](const QNetworkCookie &cookie){
+    connect(cookieStore, &QWebEngineCookieStore::cookieRemoved, jar, [jar](const QNetworkCookie &cookie){
         jar->deleteCookie(cookie);
     });
 
@@ -270,23 +270,23 @@ void UBWebController::webBrowserInstance()
             tabCreated(mCurrentWebBrowser->currentTab());
 
             // connect buttons
-            connect(mMainWindow->actionWebBack, &QAction::triggered, [tabWidget]() {
+            connect(mMainWindow->actionWebBack, &QAction::triggered, tabWidget, [tabWidget]() {
                 tabWidget->triggerWebPageAction(QWebEnginePage::Back);
             });
 
-            connect(mMainWindow->actionWebForward, &QAction::triggered, [tabWidget]() {
+            connect(mMainWindow->actionWebForward, &QAction::triggered, tabWidget, [tabWidget]() {
                 tabWidget->triggerWebPageAction(QWebEnginePage::Forward);
             });
 
-            connect(mMainWindow->actionWebReload, &QAction::triggered, [tabWidget]() {
+            connect(mMainWindow->actionWebReload, &QAction::triggered, tabWidget, [tabWidget]() {
                 tabWidget->triggerWebPageAction(QWebEnginePage::Reload);
             });
 
-            connect(mMainWindow->actionStopLoading, &QAction::triggered, [tabWidget]() {
+            connect(mMainWindow->actionStopLoading, &QAction::triggered, tabWidget, [tabWidget]() {
                 tabWidget->triggerWebPageAction(QWebEnginePage::Stop);
             });
 
-            connect(mMainWindow->actionHome, &QAction::triggered, [this, currentUrl](){
+            connect(mMainWindow->actionHome, &QAction::triggered, this, [this, currentUrl](){
                 mCurrentWebBrowser->currentTab()->load(currentUrl);
             });
 
@@ -331,7 +331,7 @@ void UBWebController::webBrowserInstance()
                 mWebProfile, &QWebEngineProfile::downloadRequested,
                 &mDownloadManagerWidget, &DownloadManagerWidget::downloadRequested);
 
-            connect(mMainWindow->actionWebTools, &QAction::triggered, [this](){
+            connect(mMainWindow->actionWebTools, &QAction::triggered, this, [this](){
                 mToolsCurrentPalette->setVisible(mMainWindow->actionWebTools->isChecked());
             });
         }
@@ -846,7 +846,7 @@ void UBWebController::captureStripe(QPointF pos, QSize size, QPixmap* pix, QPoin
     QString scrollto = QString("window.scrollTo(%1,%2)").arg(pos.x()).arg(pos.y());
     view->page()->runJavaScript(scrollto, [this,pos,size,pix,scrollPosition](const QVariant&){
         // we need some time for rendering - there is no signal when finished, so just wait
-        QTimer::singleShot(100, [this,pos,size,pix,scrollPosition](){
+        QTimer::singleShot(100, this, [this,pos,size,pix,scrollPosition](){
             WebView* view = mCurrentWebBrowser->currentTab();
             QPixmap stripe(size);
 

--- a/src/web/simplebrowser/browserwindow.cpp
+++ b/src/web/simplebrowser/browserwindow.cpp
@@ -110,12 +110,12 @@ void BrowserWindow::init()
     m_statusBar->setVisible(true);
 
     connect(m_tabWidget, &TabWidget::titleChanged, this, &BrowserWindow::handleWebViewTitleChanged);
-    connect(m_tabWidget, &TabWidget::linkHovered, [this](const QString& url) {
+    connect(m_tabWidget, &TabWidget::linkHovered, this, [this](const QString& url) {
         m_statusBar->setVisible(!url.isEmpty());
         m_statusBar->showMessage(url);
     });
     connect(m_tabWidget, &TabWidget::loadProgress, this, &BrowserWindow::handleWebViewLoadProgress);
-    connect(m_tabWidget, &TabWidget::urlChanged, [this](const QUrl &url) {
+    connect(m_tabWidget, &TabWidget::urlChanged, this, [this](const QUrl &url) {
         m_urlLineEdit->setText(url.toDisplayString());
     });
     connect(m_tabWidget, &TabWidget::favIconChanged, m_favAction, &QAction::setIcon);
@@ -130,7 +130,7 @@ void BrowserWindow::init()
     });
 
     handleWebViewTitleChanged(QString());
-    connect(m_tabWidget, &TabWidget::currentChanged, [this](int index){
+    connect(m_tabWidget, &TabWidget::currentChanged, this, [this](int index){
         QWidget* current = m_tabWidget->widget(index);
 
         emit activeViewChange(current);
@@ -178,7 +178,7 @@ QToolBar *BrowserWindow::createToolBar(QWidget *parent)
     downloadsAction->setIcon(QIcon(QStringLiteral(":webbrowser/go-bottom.png")));
     downloadsAction->setToolTip(tr("Show downloads"));
     navigationBar->addAction(downloadsAction);
-    connect(downloadsAction, &QAction::triggered, [this]() {
+    connect(downloadsAction, &QAction::triggered, this, [this]() {
         DownloadManagerWidget* downloadManager = findChild<DownloadManagerWidget*>();
 
         if (downloadManager)
@@ -311,7 +311,7 @@ void BrowserWindow::handleDevToolsRequested(QWebEnginePage *source)
         source->setDevToolsPage(inspector->page());
         source->triggerAction(QWebEnginePage::InspectElement);
 
-        connect(m_inspectorWindow, &QObject::destroyed, [this](){
+        connect(m_inspectorWindow, &QObject::destroyed, this, [this](){
             m_inspectorWindow = nullptr;
         });
     }

--- a/src/web/simplebrowser/downloadwidget.cpp
+++ b/src/web/simplebrowser/downloadwidget.cpp
@@ -68,7 +68,7 @@ DownloadWidget::DownloadWidget(QWebEngineDownloadRequest *download, QWidget *par
     m_dstName->setText(m_download->downloadFileName());
     m_srcUrl->setText(m_download->url().toDisplayString());
 
-    connect(m_cancelButton, &QPushButton::clicked,
+    connect(m_cancelButton, &QPushButton::clicked, this,
             [this](bool) {
         if (m_download->state() == QWebEngineDownloadRequest::DownloadInProgress)
             m_download->cancel();
@@ -101,7 +101,7 @@ DownloadWidget::DownloadWidget(QWebEngineDownloadItem *download, QWidget *parent
     m_dstName->setText(m_download->downloadFileName());
     m_srcUrl->setText(m_download->url().toDisplayString());
 
-    connect(m_cancelButton, &QPushButton::clicked,
+    connect(m_cancelButton, &QPushButton::clicked, this,
             [this](bool) {
         if (m_download->state() == QWebEngineDownloadItem::DownloadInProgress)
             m_download->cancel();
@@ -109,7 +109,7 @@ DownloadWidget::DownloadWidget(QWebEngineDownloadItem *download, QWidget *parent
             emit removeClicked(this);
     });
 
-    connect(m_openButton, &QPushButton::clicked,
+    connect(m_openButton, &QPushButton::clicked, this,
             [this](bool) {
         QUrl url = QUrl::fromLocalFile(QDir(m_download->downloadDirectory()).filePath(m_download->downloadFileName()));
         QDesktopServices::openUrl(url);

--- a/src/web/simplebrowser/tabwidget.cpp
+++ b/src/web/simplebrowser/tabwidget.cpp
@@ -67,7 +67,7 @@ TabWidget::TabWidget(QWebEngineProfile *profile, QWidget *parent)
     tabBar->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(tabBar, &QTabBar::customContextMenuRequested, this, &TabWidget::handleContextMenuRequested);
     connect(tabBar, &QTabBar::tabCloseRequested, this, &TabWidget::closeTab);
-    connect(tabBar, &QTabBar::tabBarDoubleClicked, [this](int index) {
+    connect(tabBar, &QTabBar::tabBarDoubleClicked, this, [this](int index) {
         if (index == -1)
             createTab();
     });
@@ -164,7 +164,7 @@ void TabWidget::setupView(WebView *webView)
 {
     QWebEnginePage *webPage = webView->page();
 
-    connect(webView, &QWebEngineView::titleChanged, [this, webView](const QString &title) {
+    connect(webView, &QWebEngineView::titleChanged, this, [this, webView](const QString &title) {
         int index = indexOf(webView);
         if (index != -1) {
             setTabText(index, title);
@@ -173,33 +173,33 @@ void TabWidget::setupView(WebView *webView)
         if (currentIndex() == index)
             emit titleChanged(title);
     });
-    connect(webView, &QWebEngineView::urlChanged, [this, webView](const QUrl &url) {
+    connect(webView, &QWebEngineView::urlChanged, this, [this, webView](const QUrl &url) {
         int index = indexOf(webView);
         if (index != -1)
             tabBar()->setTabData(index, url);
         if (currentIndex() == index)
             emit urlChanged(url);
     });
-    connect(webView, &QWebEngineView::loadProgress, [this, webView](int progress) {
+    connect(webView, &QWebEngineView::loadProgress, this, [this, webView](int progress) {
         if (currentIndex() == indexOf(webView))
             emit loadProgress(progress);
     });
-    connect(webPage, &QWebEnginePage::linkHovered, [this, webView](const QString &url) {
+    connect(webPage, &QWebEnginePage::linkHovered, this, [this, webView](const QString &url) {
         if (currentIndex() == indexOf(webView))
             emit linkHovered(url);
     });
-    connect(webView, &WebView::favIconChanged, [this, webView](const QIcon &icon) {
+    connect(webView, &WebView::favIconChanged, this, [this, webView](const QIcon &icon) {
         int index = indexOf(webView);
         if (index != -1)
             setTabIcon(index, icon);
         if (currentIndex() == index)
             emit favIconChanged(icon);
     });
-    connect(webView, &WebView::webActionEnabledChanged, [this, webView](QWebEnginePage::WebAction action, bool enabled) {
+    connect(webView, &WebView::webActionEnabledChanged, this, [this, webView](QWebEnginePage::WebAction action, bool enabled) {
         if (currentIndex() ==  indexOf(webView))
             emit webActionEnabledChanged(action,enabled);
     });
-    connect(webPage, &QWebEnginePage::windowCloseRequested, [this, webView]() {
+    connect(webPage, &QWebEnginePage::windowCloseRequested, this, [this, webView]() {
         int index = indexOf(webView);
         if (index >= 0)
             closeTab(index);

--- a/src/web/simplebrowser/webpage.cpp
+++ b/src/web/simplebrowser/webpage.cpp
@@ -73,7 +73,7 @@ WebPage::WebPage(QWebEngineProfile *profile, QObject *parent)
 #if (QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     connect(this, &QWebEnginePage::certificateError, this, &WebPage::handleCertificateError);
 #endif
-    connect(this, &QWebEnginePage::recommendedStateChanged, [this](QWebEnginePage::LifecycleState state){
+    connect(this, &QWebEnginePage::recommendedStateChanged, this, [this](QWebEnginePage::LifecycleState state){
         if (isVisible())
         {
             // keep active while visible

--- a/src/web/simplebrowser/webpopupwindow.cpp
+++ b/src/web/simplebrowser/webpopupwindow.cpp
@@ -78,7 +78,7 @@ WebPopupWindow::WebPopupWindow(QWebEngineProfile *profile)
     m_urlLineEdit->addAction(m_favAction, QLineEdit::LeadingPosition);
 
     connect(m_view, &WebView::titleChanged, this, &QWidget::setWindowTitle);
-    connect(m_view, &WebView::urlChanged, [this](const QUrl &url) {
+    connect(m_view, &WebView::urlChanged, this, [this](const QUrl &url) {
         m_urlLineEdit->setText(url.toDisplayString());
     });
     connect(m_view, &WebView::favIconChanged, m_favAction, &QAction::setIcon);

--- a/src/web/simplebrowser/webview.cpp
+++ b/src/web/simplebrowser/webview.cpp
@@ -77,21 +77,21 @@ WebView::WebView(QWidget *parent)
     : QWebEngineView(parent)
     , m_loadProgress(100)
 {
-    connect(this, &QWebEngineView::loadStarted, [this]() {
+    connect(this, &QWebEngineView::loadStarted, this, [this]() {
         m_loadProgress = 0;
         emit favIconChanged(favIcon());
     });
-    connect(this, &QWebEngineView::loadProgress, [this](int progress) {
+    connect(this, &QWebEngineView::loadProgress, this, [this](int progress) {
         m_loadProgress = progress;
     });
-    connect(this, &QWebEngineView::loadFinished, [this](bool success) {
+    connect(this, &QWebEngineView::loadFinished, this, [this](bool success) {
         m_loadProgress = success ? 100 : -1;
         emit favIconChanged(favIcon());
     });
-    connect(this, &QWebEngineView::iconChanged, [this](const QIcon &) {
+    connect(this, &QWebEngineView::iconChanged, this, [this](const QIcon &) {
         emit favIconChanged(favIcon());
     });
-    connect(this, &QWebEngineView::urlChanged, [this](const QUrl& url){
+    connect(this, &QWebEngineView::urlChanged, this, [this](const QUrl& url){
         BrowserWindow* browser = browserWindow();
 
         if (browser && page() && !page()->profile()->isOffTheRecord()) {
@@ -99,7 +99,7 @@ WebView::WebView(QWidget *parent)
         }
     });
 
-    connect(this, &QWebEngineView::renderProcessTerminated,
+    connect(this, &QWebEngineView::renderProcessTerminated, this,
             [this](QWebEnginePage::RenderProcessTerminationStatus termStatus, int statusCode) {
         QString status;
         switch (termStatus) {
@@ -120,7 +120,7 @@ WebView::WebView(QWidget *parent)
                                                    tr("Render process exited with code: %1\n"
                                                       "Do you want to reload the page ?").arg(statusCode));
         if (btn == QMessageBox::Yes)
-            QTimer::singleShot(0, [this] { reload(); });
+            QTimer::singleShot(0, this, [this] { reload(); });
     });
 }
 
@@ -141,7 +141,7 @@ int WebView::loadProgress() const
 void WebView::createWebActionTrigger(QWebEnginePage *page, QWebEnginePage::WebAction webAction)
 {
     QAction *action = page->action(webAction);
-    connect(action, &QAction::changed, [this, action, webAction]{
+    connect(action, &QAction::changed, this, [this, action, webAction]{
         emit webActionEnabledChanged(webAction, action->isEnabled());
     });
 }
@@ -239,7 +239,7 @@ void WebView::contextMenuEvent(QContextMenuEvent *event)
 
         QAction *action = new QAction(menu);
         action->setText(tr("Open Web Inspector in new window"));
-        connect(action, &QAction::triggered, [this]() { emit devToolsRequested(page()); });
+        connect(action, &QAction::triggered, this, [this]() { emit devToolsRequested(page()); });
 
         QAction *before(inspectElement == actions.cend() ? nullptr : *inspectElement);
         menu->insertAction(before, action);
@@ -293,7 +293,7 @@ void WebView::contextMenuEvent(QContextMenuEvent *event)
     {
         QAction* actionAddToBoard = new QAction(menu);
         actionAddToBoard->setText(tr("Add to board"));
-        connect(actionAddToBoard, &QAction::triggered, [contentUrl](){
+        connect(actionAddToBoard, &QAction::triggered, this, [contentUrl](){
             UBApplication::applicationController->showBoard();
             UBApplication::boardController->downloadURL(contentUrl);
         });


### PR DESCRIPTION
During my tests for the issue with the live thumbnails I got some sporadic crashes while zooming. I now could catch two occurrences and I think I can trace them back to dangling connections pointing to deleted objects. See https://github.com/letsfindaway/OpenBoard/issues/147.

Here is my fix:

- connections to a lambda are only automatically deleted if
  - the sender is deleted or
  - a context parameter is given in the connect call before the lambda
- use `clazy` to find all missing context parameters
- add missing context parameter to lambda connections
- note: not all fixed lines are "dangerous"
  - as many fulfill the first condition
  - they are deleted when the sender is deleted