### PR TITLE
fix: initial state of startup hints visibility checkbox

### DIFF
--- a/src/gui/UBStartupHintsPalette.cpp
+++ b/src/gui/UBStartupHintsPalette.cpp
@@ -65,7 +65,7 @@ UBStartupHintsPalette::UBStartupHintsPalette(QWidget *parent) :
     mButtonLayout = new QHBoxLayout();
     mLayout->addLayout(mButtonLayout);
     mShowNextTime = new QCheckBox(tr("Visible next time"),this);
-    mShowNextTime->setCheckState(Qt::Checked);
+    mShowNextTime->setChecked(UBSettings::settings()->appStartupHintsEnabled->get().toBool());
     connect(mShowNextTime,SIGNAL(stateChanged(int)),this,SLOT(onShowNextTimeStateChanged(int)));
     mButtonLayout->addStretch();
     mButtonLayout->addWidget(mShowNextTime);


### PR DESCRIPTION
When opening the startup hints using the OpenBoard menu, the checkbox "Visible next time" is always checked. Instead I would expect that it represents the current status of the `EnableStartupHints` setting.

This simple PR sets the checked state of the startup hints visibility checkbox according to the `EnableStartupHints` setting.

I have based my branch on `master`, so that it can be applied to either `dev` or `1.7.1-dev`.