### PR TITLE
refactor: Remove unneeded -std=c++11 directives / minor cleanup

### DIFF
--- a/src/core/UBTextTools.cpp
+++ b/src/core/UBTextTools.cpp
@@ -34,8 +34,10 @@ QString UBTextTools::cleanHtmlCData(const QString &_html){
 
 
     for(int i = 0; i < _html.length(); i+=1){
-        if(_html.at(i) != '\0')
-            clean.append(_html.at(i));
+        if(_html.at(i).isNull())
+            continue;
+
+        clean.append(_html.at(i));
     }
     return clean;
 }

--- a/src/podcast/podcast.pri
+++ b/src/podcast/podcast.pri
@@ -55,7 +55,4 @@ linux-g++* {
         LIBS -= -lswresample
         LIBS += -lavresample
     }
-
-
-    QMAKE_CXXFLAGS += -std=c++11 # move this to OpenBoard.pro when we can use C++11 on all platforms
 }

--- a/src/singleapplication/singleapplication.pri
+++ b/src/singleapplication/singleapplication.pri
@@ -1,5 +1,4 @@
 QT += core network
-CONFIG += c++11
 
 HEADERS += $$PWD/SingleApplication \
     $$PWD/singleapplication.h \


### PR DESCRIPTION
The modules `podcast.pri` and `singleapplication.pri` specify `c++11` as their standard. This doesn't have any effect since `OpenBoard.pro` defines `c++17`, but is a little confusing at first. Both occurrences found via `grep`.

In `UBTextTools.cpp`, QStrings are cleaned of QChar::Null characters. Make it explicit that these characters are skipped and the normal course of operation is simple copying. This also enables the use of QChar::isNull() which is more robust than comparing against a raw '\0'.
The change is motivated by a patch that's carried by Arch since 2017: [qchar.patch](https://aur.archlinux.org/cgit/aur.git/tree/qchar.patch?h=openboard) It apparently was necessary because  an earlier version of Qt5 failed to build: [Commit introducing qchar.patch](https://aur.archlinux.org/cgit/aur.git/commit/?h=openboard&id=c282e8c9d56903a14496b9a26feef5df0db52709). With this improvement, that shouldn't happen anymore.

No change in behaviour expected. Tested on Arch.