### PR TITLE
feat: Use pkg-config on Linux

### DIFF
--- a/src/pdf-merger/pdfMerger.pri
+++ b/src/pdf-merger/pdfMerger.pri
@@ -69,21 +69,8 @@ win32 {
    
 }
 
-linux-g++ {
+linux-g++* {
 
-   LIBS += -lz
-
-}
-linux-g++-32 {
-
-   LIBS += -lz
+   PKGCONFIG += zlib
 
 }
-linux-g++-64 {
-
-   LIBS += -lz
-
-}
-
-
-

--- a/src/podcast/podcast.pri
+++ b/src/podcast/podcast.pri
@@ -41,20 +41,7 @@ linux-g++* {
                 src/podcast/ffmpeg/UBMicrophoneInput.cpp
 
 
-    DEPENDPATH += /usr/lib/x86_64-linux-gnu
-
-    LIBS += -lavformat -lavcodec -lswscale -lavutil \
-            -lva-x11 \
-            -lva \
-            -lxcb-shm \
-            -lxcb-xfixes \
-            -lxcb-render -lxcb-shape -lxcb -lX11 -lasound -lSDL -lx264 -lpthread -lvpx -lvorbisenc -lvorbis -ltheoraenc -ltheoradec -logg -lopus -lmp3lame -lfreetype -lfdk-aac -lass -llzma -lbz2 -lz -ldl -lswresample -lswscale -lavutil -lm
-
-    FFMPEG_VERSION = $$system(ffmpeg --version|& grep -oP "version.*?\K[0-9]\.[0-9]")
-    equals(FFMPEG_VERSION, 2.8) {
-        LIBS -= -lswresample
-        LIBS += -lavresample
-    }
+    PKGCONFIG += libavformat libavcodec libavutil libswresample libswscale
 
 
     QMAKE_CXXFLAGS += -std=c++11 # move this to OpenBoard.pro when we can use C++11 on all platforms


### PR DESCRIPTION
This is mainly motivated by the Arch Linux package of `openboard-git` which has to carry a [patch](https://aur.archlinux.org/cgit/aur.git/tree/quazip.patch?h=openboard-git) to define where `quazip` is found, since Arch Linux packages `quazip` differently from Ubuntu. The use of `pkg-config` makes this patch redundant.

While at it, I also cleaned up the linking for `podcast` and `pdfMerger`, utilizing `pkg-config` and removing unnecessary steps. Especially the commit message for `podcast` goes into great detail as to the reasoning.

Together, there shouldn't be any change in behaviour (except requiring `pkg-config` be installed). In turn, it greatly improves the infrastructure and removes some burden from packagers downstream.
It would be great if this set of patches could make it into 1.7.

This work is partially based on #651.

-- Vekhir