### PR TITLE
feat: Automatically create translations using lrelease

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -3,6 +3,7 @@ TEMPLATE = app
 
 CONFIG += c++17
 CONFIG -= flat
+CONFIG += lrelease
 CONFIG += debug_and_release \
           no_include_pwd
 


### PR DESCRIPTION
Since [QT 5.12](https://code.qt.io/cgit/qt/qtbase.git/tree/dist/changes-5.12.0/?h=v5.12.0), `CONFIG` supports [`lrelease`](https://doc.qt.io/qt-6/qmake-variable-reference.html#config) to include the compiling of translations in the `make` process. This means that
1. `lrelease` doesn't need to be run separately
2. The command is independent of the location of the `lrelease` executable. This is important as Qt6 on Arch Linux puts the executable in a custom directory under `qt6/bin` where it can be found by Qt, but running separately requires changing `$PATH`.

By default, the results are placed in `release/`, and while there is the variable [`QM_FILES_INSTALL_PATH`](https://doc.qt.io/qt-6/qmake-variable-reference.html#qm-files-install-path), it doesn't seem to change that path.

Do you have experience with the config option `lrelease` and `QM_FILES_INSTALL_PATH` to set the result path to `resources/i18n`? I haven't been able to.

-- Vekhir