### PR TITLE
fix: eraser not working when completely inside polygon

### DIFF
--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -1045,7 +1045,9 @@ void UBGraphicsScene::eraseLineTo(const QPointF &pEndPoint, const qreal &pWidth)
         else if (eraserPath.intersects(itemPainterPath))
         {
             itemPainterPath.setFillRule(Qt::WindingFill);
-            QPainterPath newPath = itemPainterPath.subtracted(eraserPath);
+            // reverse eraserPath so that it has the opposite orientation of the stroke
+            // necessary for punching a hole with WindingFill rule
+            QPainterPath newPath = itemPainterPath.subtracted(eraserPath.toReversed());
             intersectedItems << pi;
             intersectedPolygons << newPath.simplified().toFillPolygons(pi->sceneTransform().inverted());
         }


### PR DESCRIPTION
This PR fixes a minor issue with the eraser. Sometimes it does not work when the eraser is completely inside a polygon, e.g. a very small eraser outline in a broad marker stroke. See https://github.com/letsfindaway/OpenBoard/issues/153 for a complete description and analysis.

This PR fixes this by reversing the `eraserPath` to have opposite orientation of the stroke. This is necessary for punching a hole with the `WindingFill` rule.