### PR TITLE
fix: avoid access to uninitialized DisplayManager

### DIFF
--- a/src/adaptors/UBMetadataDcSubsetAdaptor.cpp
+++ b/src/adaptors/UBMetadataDcSubsetAdaptor.cpp
@@ -239,8 +239,7 @@ QMap<QString, QVariant> UBMetadataDcSubsetAdaptor::load(QString pPath)
 
     if (!sizeFound)
     {
-        QSize docSize = UBApplication::displayManager->screenSize(ScreenRole::Control);
-        docSize.setHeight(docSize.height() - 70); // 70 = toolbar height
+        QSize docSize = UBSettings::settings()->pageSize->get().toSize();
 
         qWarning() << "Document size not found, using default view size" << docSize;
 


### PR DESCRIPTION
This PR fixes a minor bug where OpenBoard crashes on startup when trying to parse a document with an invalid document size. This should normally not happen, but such a document could be a leftover from another crash. See https://github.com/letsfindaway/OpenBoard/issues/129 for more details.

This PR fixes that issue. When opening a document with invalid document size, it avoids using the display manager, but uses the default document size from the settings instead.