### PR TITLE
New bold, italic and underline shortcuts for text box.

### DIFF
--- a/resources/forms/mainWindow.ui
+++ b/resources/forms/mainWindow.ui
@@ -1433,7 +1433,7 @@
     <string>Annotate Document</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+I</string>
+    <string>Ctrl+P</string>
    </property>
   </action>
   <action name="actionEraser">

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -250,14 +250,12 @@ void UBBoardView::keyPressEvent (QKeyEvent *event)
             switch (event->key ())
             {
             case Qt::Key_Plus:
-            case Qt::Key_I:
             {
                 mController->zoomIn ();
                 event->accept ();
                 break;
             }
             case Qt::Key_Minus:
-            case Qt::Key_O:
             {
                 mController->zoomOut ();
                 event->accept ();

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -139,44 +139,6 @@ QFont UBGraphicsTextItem::createDefaultFont()
     return font;
 }
 
-bool UBGraphicsTextItem::event(QEvent *ev)
-{
-    if(ev->type() == QEvent::ShortcutOverride && isSelected())
-    {
-        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(ev);
-        QKeySequence::StandardKey shortcuts[] = {QKeySequence::StandardKey::Bold,
-                                                 QKeySequence::StandardKey::Italic,
-                                                 QKeySequence::StandardKey::Underline};
-        QKeySequence::StandardKey key = QKeySequence::StandardKey::UnknownKey;
-        for(int i=0; i<3; i++)
-            if(keyEvent->matches(shortcuts[i]))
-            {
-                key = shortcuts[i];
-                break;
-            }
-        if(key != QKeySequence::StandardKey::UnknownKey)
-        {
-            QTextCursor curCursor = textCursor();
-            QTextCharFormat format;
-            QFont ft(curCursor.charFormat().font());
-            if(key == QKeySequence::StandardKey::Bold)
-                ft.setBold(!ft.bold());
-            else if(key == QKeySequence::StandardKey::Italic)
-                ft.setItalic(!ft.italic());
-            else
-                ft.setUnderline(!ft.underline());
-            format.setFont(ft);
-            curCursor.mergeCharFormat(format);
-            setTextCursor(curCursor);
-
-            contentsChanged();
-            ev->accept();
-            return true;
-        }
-    }
-    return QGraphicsTextItem::event(ev);
-}
-
 void UBGraphicsTextItem::recolor()
 {
     UBGraphicsTextItemDelegate * del = dynamic_cast<UBGraphicsTextItemDelegate*>(Delegate());

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -139,44 +139,6 @@ QFont UBGraphicsTextItem::createDefaultFont()
     return font;
 }
 
-bool UBGraphicsTextItem::event(QEvent *ev)
-{
-    if(ev->type() == QEvent::ShortcutOverride && isSelected())
-    {
-        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(ev);
-        QKeySequence::StandardKey shortcuts[] = {QKeySequence::StandardKey::Bold,
-                                                 QKeySequence::StandardKey::Italic,
-                                                 QKeySequence::StandardKey::Underline};
-        QKeySequence::StandardKey key = QKeySequence::StandardKey::UnknownKey;
-        for(int i=0; i<3; i++)
-            if(keyEvent->matches(shortcuts[i]))
-            {
-                key = shortcuts[i];
-                break;
-            }
-        if(key != QKeySequence::StandardKey::UnknownKey)
-        {
-            QTextCursor curCursor = textCursor();
-            QTextCharFormat format;
-            QFont ft(curCursor.charFormat().font());
-            if(key == QKeySequence::StandardKey::Bold)
-                ft.setBold(!ft.bold());
-            else if(key == QKeySequence::StandardKey::Italic)
-                ft.setItalic(!ft.italic());
-            else
-                ft.setUnderline(!ft.underline());
-            format.setFont(ft);
-            curCursor.mergeCharFormat(format);
-            setTextCursor(curCursor);
-
-            contentsChanged();
-            ev->accept();
-            return true;
-        }
-    }
-    return QGraphicsTextItem::event(ev);
-}
-
 void UBGraphicsTextItem::recolor()
 {
     UBGraphicsTextItemDelegate * del = dynamic_cast<UBGraphicsTextItemDelegate*>(Delegate());
@@ -324,6 +286,27 @@ void UBGraphicsTextItem::keyPressEvent(QKeyEvent *event)
 {
     if (Delegate() && !Delegate()->keyPressEvent(event)) {
         qDebug() << "UBGraphicsTextItem::keyPressEvent(QKeyEvent *event) has been rejected by delegate. Don't call base class method";
+        return;
+    }
+
+    if (event->matches (QKeySequence::StandardKey::Bold) ||
+        event->matches (QKeySequence::StandardKey::Underline) ||
+        event->matches (QKeySequence::StandardKey::Italic))
+    {
+        QTextCursor curCursor = textCursor();
+        QTextCharFormat format;
+        QFont ft(curCursor.charFormat().font());
+        if (event->matches (QKeySequence::StandardKey::Bold))
+            ft.setBold(!ft.bold());
+        else if (event->matches (QKeySequence::StandardKey::Underline))
+            ft.setUnderline(!ft.underline());
+        else if (event->matches (QKeySequence::StandardKey::Italic))
+            ft.setItalic(!ft.italic());
+        format.setFont(ft);
+        curCursor.mergeCharFormat(format);
+        setTextCursor(curCursor);
+
+        contentsChanged();
         return;
     }
 

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -139,6 +139,42 @@ QFont UBGraphicsTextItem::createDefaultFont()
     return font;
 }
 
+bool UBGraphicsTextItem::event(QEvent *ev)
+{
+    if(ev->type() == QEvent::ShortcutOverride && isSelected())
+    {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(ev);
+        QKeySequence::StandardKey shortcuts[] = {QKeySequence::StandardKey::Bold,
+                                                 QKeySequence::StandardKey::Italic,
+                                                 QKeySequence::StandardKey::Underline};
+        QKeySequence::StandardKey key = QKeySequence::StandardKey::UnknownKey;
+        for(int i=0; i<3; i++)
+            if(keyEvent->matches(shortcuts[i]))
+            {
+                key = shortcuts[i];
+                break;
+            }
+        if(key != QKeySequence::StandardKey::UnknownKey)
+        {
+            QTextCursor curCursor = textCursor();
+            QTextCharFormat format;
+            QFont ft(curCursor.charFormat().font());
+            if(key == QKeySequence::StandardKey::Bold)
+                ft.setBold(!ft.bold());
+            else if(key == QKeySequence::StandardKey::Italic)
+                ft.setItalic(!ft.italic());
+            else
+                ft.setUnderline(!ft.underline());
+            format.setFont(ft);
+            curCursor.mergeCharFormat(format);
+            setTextCursor(curCursor);
+            contentsChanged();
+            return true;
+        }
+    }
+    return QGraphicsTextItem::event(ev);
+}
+
 void UBGraphicsTextItem::recolor()
 {
     UBGraphicsTextItemDelegate * del = dynamic_cast<UBGraphicsTextItemDelegate*>(Delegate());

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -168,7 +168,9 @@ bool UBGraphicsTextItem::event(QEvent *ev)
             format.setFont(ft);
             curCursor.mergeCharFormat(format);
             setTextCursor(curCursor);
+
             contentsChanged();
+            ev->accept();
             return true;
         }
     }

--- a/src/domain/UBGraphicsTextItem.h
+++ b/src/domain/UBGraphicsTextItem.h
@@ -109,6 +109,9 @@ class UBGraphicsTextItem : public QGraphicsTextItem, public UBItem, public UBRes
     signals:
         void textUndoCommandAdded(UBGraphicsTextItem *textItem);
 
+    protected:
+        virtual bool event(QEvent *ev) override;
+
     private slots:
         void undoCommandAdded();
         void documentSizeChanged(const QSizeF & newSize);

--- a/src/domain/UBGraphicsTextItem.h
+++ b/src/domain/UBGraphicsTextItem.h
@@ -109,9 +109,6 @@ class UBGraphicsTextItem : public QGraphicsTextItem, public UBItem, public UBRes
     signals:
         void textUndoCommandAdded(UBGraphicsTextItem *textItem);
 
-    protected:
-        bool event(QEvent *ev) override;
-
     private slots:
         void undoCommandAdded();
         void documentSizeChanged(const QSizeF & newSize);

--- a/src/domain/UBGraphicsTextItem.h
+++ b/src/domain/UBGraphicsTextItem.h
@@ -110,7 +110,7 @@ class UBGraphicsTextItem : public QGraphicsTextItem, public UBItem, public UBRes
         void textUndoCommandAdded(UBGraphicsTextItem *textItem);
 
     protected:
-        virtual bool event(QEvent *ev) override;
+        bool event(QEvent *ev) override;
 
     private slots:
         void undoCommandAdded();


### PR DESCRIPTION
My usecase is : 
I used to change the format of the text. For example, some words in bold or italic or underlined. And I want to go fast without opening the font dialog.
 
The idea is to implement the reception of events in the `UBGraphicsTextItem`. And we do the text modification if the event is a `bold` or `italic` or `underline` shortcut. 
I do not know if it will be better to do it in `UBGraphicsTextItemDelegate`.

It works fine in my side on linux and Qt 5 and 6.
The only issue is due to other `Ctrl+I` shortcut to set the stylus. The `italic` shortcut set the text in italic but also switches in stylus mode and the Text box loses the focus. 