### PR TITLE
The grid size is now stored in the configuration.

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -153,10 +153,6 @@ void UBBoardController::init()
 
     setActiveDocumentScene(doc);
 
-    connect(UBApplication::displayManager, &UBDisplayManager::screenRolesAssigned, this, [this](){
-        initBackgroundGridSize();
-    });
-
     undoRedoStateChange(true);
 
 }
@@ -170,7 +166,7 @@ UBBoardController::~UBBoardController()
 /**
  * @brief Set the default background grid size to appear as roughly 1cm on screen
  */
-void UBBoardController::initBackgroundGridSize()
+int UBBoardController::determineBackgroundGridSize() const
 {
     // Besides adjusting for DPI, we also need to scale the grid size by the ratio of the control view size
     // to document size. Here we approximate this ratio as (document resolution) / (screen resolution).
@@ -188,10 +184,7 @@ void UBBoardController::initBackgroundGridSize()
 
     int gridSize = (resolutionRatio * 10. * dpi) / UBGeometryUtils::inchSize;
 
-    UBSettings::settings()->crossSize = gridSize;
-    UBSettings::settings()->defaultCrossSize = gridSize;
-    mActiveScene->setBackgroundGridSize(gridSize);
-
+    return gridSize;
     //qDebug() << "grid size: " << gridSize;
 }
 

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -256,6 +256,9 @@ class UBBoardController : public UBDocumentContainer
 
         void saveData(SaveFlags fls = sf_none);
 
+        int determineBackgroundGridSize() const;
+
+
         //void regenerateThumbnails();
 
     signals:
@@ -291,7 +294,6 @@ class UBBoardController : public UBDocumentContainer
         void appMainModeChanged(UBApplicationController::MainMode);
 
     private:
-        void initBackgroundGridSize();
         void updatePageSizeState();
         void saveViewState();
         int autosaveTimeoutFromSettings();

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -1028,7 +1028,7 @@ std::shared_ptr<UBGraphicsScene> UBPersistenceManager::createDocumentSceneAt(std
     newScene->setBackground(UBSettings::settings()->isDarkBackground(),
             UBSettings::settings()->UBSettings::pageBackground());
 
-    newScene->setBackgroundGridSize(UBSettings::settings()->crossSize);
+    newScene->setBackgroundGridSize(UBSettings::settings()->crossSize->get().toInt());
 
     proxy->incPageCount();
 

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -219,6 +219,7 @@ void UBPreferencesController::wire()
     mPreferencesUI->crossColorDarkBackgroundFrame->setPalette(darkBackgroundPalette);
     mPreferencesUI->crossColorDarkBackgroundLabel->setPalette(darkBackgroundPalette);
 
+
     QList<QColor> gridLightBackgroundColors = settings->boardGridLightBackgroundColors->colors();
     QColor selectedCrossColorLightBackground(settings->boardCrossColorLightBackground->get().toString());
 

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -46,8 +46,6 @@
 QPointer<UBSettings> UBSettings::sSingleton = 0;
 
 int UBSettings::pointerDiameter = 40;
-int UBSettings::crossSize = 24;
-int UBSettings::defaultCrossSize = 24;
 int UBSettings::minCrossSize = 12;
 int UBSettings::maxCrossSize = 96; //TODO: user-settable?
 bool UBSettings::intermediateLines = false;
@@ -303,6 +301,8 @@ void UBSettings::init()
 
     boardCrossColorDarkBackground = new UBSetting(this, "Board", "CrossColorDarkBackground", "#C8C0C0C0");
     boardCrossColorLightBackground = new UBSetting(this, "Board", "CrossColorLightBackground", "#A5E1FF");
+
+    crossSize = new UBSetting(this, "Board", "GridSize", 40);
 
     QStringList gridLightBackgroundColors;
     gridLightBackgroundColors << "#000000" << "#FF0000" << "#004080" << "#008000" << "#FFDD00" << "#C87400" << "#800040" << "#008080" << "#A5E1FF";

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -191,8 +191,6 @@ class UBSettings : public QObject
         static QColor documentSizeMarkColorLightBackground;
 
         // Background grid
-        static int crossSize;
-        static int defaultCrossSize;
         static int minCrossSize;
         static int maxCrossSize;
         static bool intermediateLines;
@@ -305,6 +303,8 @@ class UBSettings : public QObject
 
         UBSetting* boardCrossColorDarkBackground;
         UBSetting* boardCrossColorLightBackground;
+
+        UBSetting* crossSize;
 
         UBColorListSetting* boardGridLightBackgroundColors;
         UBColorListSetting* boardGridDarkBackgroundColors;

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -362,7 +362,7 @@ UBGraphicsScene::UBGraphicsScene(std::shared_ptr<UBDocumentProxy> document, bool
             UBApplication::applicationController->initialVScroll()));
     }
 
-    mBackgroundGridSize = UBSettings::settings()->crossSize;
+    mBackgroundGridSize = UBSettings::settings()->crossSize->get().toInt();
     mIntermediateLines = UBSettings::settings()->intermediateLines;
 
 //    Just for debug. Do not delete please

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -157,14 +157,15 @@ void UBBackgroundPalette::showEvent(QShowEvent* event)
 
 void UBBackgroundPalette::sliderValueChanged(int value)
 {
+    UBSettings::settings()->crossSize->setInt(value);
     UBApplication::boardController->activeScene()->setBackgroundGridSize(value);
-    UBSettings::settings()->crossSize = value; // since this function is called (indirectly, by refresh) when we switch scenes, the settings will always have the current scene's cross size.
 }
 
 void UBBackgroundPalette::defaultBackgroundGridSize()
 {
-    mSlider->setValue(UBSettings::settings()->defaultCrossSize);
-    sliderValueChanged(UBSettings::settings()->defaultCrossSize);
+    int crossSize = UBApplication::boardController->determineBackgroundGridSize();
+    mSlider->setValue(crossSize);
+    sliderValueChanged(crossSize);
 }
 
 void UBBackgroundPalette::toggleIntermediateLines(bool checked)


### PR DESCRIPTION
At startup of the application, the grid is calculated differently on different systems. The intended behaviour is that 1cm on screen is one grid space. That works perfectly. But in practice this is not often needed. And unfortunately the behaviour has a negative side effect: If you open the same file on different systems with different screen configurations (which is a typical use case for teachers), and create new pages, these pages get a another grid size than the already existing pages. That is a bit confusing. And especially when the ruler is used the behaviour is not nice, because on different systems it measures different sizes.

I propose to change the behaviour as follows.

The grid size is remembered. The grid size changes only when the user explicitly sets a new value with the slider. At next startup this value is kept. The nice 1cm calculation only happens when the user clicks on the "set default size" button. The start value for the grid is 40, because that value should be comfortable for most people.

I implemented this. The code simplifies a bit, because now we don't have to store the default value any more. Interestingly the connection to the signal UBDisplayManager::screenRolesAssigned becomes obsolete. It makes no sense any more to automatically update the grid size, when the screen configuration changes.