### PR TITLE
Remove Masking in Desktop mode

### DIFF
--- a/src/core/UB.h
+++ b/src/core/UB.h
@@ -35,10 +35,6 @@
 
 #define UB_MAX_ZOOM 9
 
-#if defined(Q_OS_LINUX) || (defined(Q_OS_OSX) && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)))
-#define UB_REQUIRES_MASK_UPDATE 1
-#endif
-
 struct UBMimeType
 {
     enum Enum

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -655,6 +655,7 @@ void UBDesktopAnnotationController::selectorActionPressed()
 
 void UBDesktopAnnotationController::selectorActionReleased()
 {
+    mDesktopPalette->minimizeMe(eMinimizedLocation_None);
     UBApplication::mainWindow->actionSelector->setChecked(true);
     switchCursor(UBStylusTool::Selector);
 }
@@ -701,6 +702,7 @@ void UBDesktopAnnotationController::switchCursor(const int tool)
 {
     mTransparentDrawingScene->setToolCursor(tool);
     mTransparentDrawingView->setToolCursor(tool);
+    UBApplication::mainWindow->actionSelector->setChecked(false);
 }
 
 /**
@@ -747,6 +749,7 @@ void UBDesktopAnnotationController::onDesktopPaletteMaximized()
         connect(pPointerButton, SIGNAL(pressed()), this, SLOT(pointerActionPressed()));
         connect(pPointerButton, SIGNAL(released()), this, SLOT(pointerActionReleased()));
     }
+    UBApplication::mainWindow->actionSelector->setChecked(false);
 }
 
 /**

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -533,7 +533,6 @@ void UBDesktopAnnotationController::penActionReleased()
         }
         mPendingPenButtonPressed = false;
     }
-    UBApplication::mainWindow->actionPen->setChecked(true);
 
     switchCursor(UBStylusTool::Pen);
 }
@@ -587,7 +586,6 @@ void UBDesktopAnnotationController::eraserActionReleased()
         }
         mPendingEraserButtonPressed = false;
     }
-    UBApplication::mainWindow->actionEraser->setChecked(true);
 
     switchCursor(UBStylusTool::Eraser);
 }
@@ -643,7 +641,6 @@ void UBDesktopAnnotationController::markerActionReleased()
         }
         mPendingMarkerButtonPressed = false;
     }
-    UBApplication::mainWindow->actionMarker->setChecked(true);
 
     switchCursor(UBStylusTool::Marker);
 }
@@ -656,7 +653,6 @@ void UBDesktopAnnotationController::selectorActionPressed()
 void UBDesktopAnnotationController::selectorActionReleased()
 {
     mDesktopPalette->minimizeMe(eMinimizedLocation_None);
-    UBApplication::mainWindow->actionSelector->setChecked(true);
     switchCursor(UBStylusTool::Selector);
 }
 
@@ -668,7 +664,6 @@ void UBDesktopAnnotationController::pointerActionPressed()
 
 void UBDesktopAnnotationController::pointerActionReleased()
 {
-    UBApplication::mainWindow->actionPointer->setChecked(true);
     switchCursor(UBStylusTool::Pointer);
 }
 
@@ -702,7 +697,6 @@ void UBDesktopAnnotationController::switchCursor(const int tool)
 {
     mTransparentDrawingScene->setToolCursor(tool);
     mTransparentDrawingView->setToolCursor(tool);
-    UBApplication::mainWindow->actionSelector->setChecked(false);
 }
 
 /**
@@ -749,7 +743,6 @@ void UBDesktopAnnotationController::onDesktopPaletteMaximized()
         connect(pPointerButton, SIGNAL(pressed()), this, SLOT(pointerActionPressed()));
         connect(pPointerButton, SIGNAL(released()), this, SLOT(pointerActionReleased()));
     }
-    UBApplication::mainWindow->actionSelector->setChecked(false);
 }
 
 /**

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -533,7 +533,7 @@ void UBDesktopAnnotationController::penActionReleased()
         }
         mPendingPenButtonPressed = false;
     }
-
+    UBApplication::mainWindow->actionPen->setChecked(true);
     switchCursor(UBStylusTool::Pen);
 }
 
@@ -586,7 +586,7 @@ void UBDesktopAnnotationController::eraserActionReleased()
         }
         mPendingEraserButtonPressed = false;
     }
-
+    UBApplication::mainWindow->actionEraser->setChecked(true);
     switchCursor(UBStylusTool::Eraser);
 }
 
@@ -641,7 +641,7 @@ void UBDesktopAnnotationController::markerActionReleased()
         }
         mPendingMarkerButtonPressed = false;
     }
-
+    UBApplication::mainWindow->actionMarker->setChecked(true);
     switchCursor(UBStylusTool::Marker);
 }
 
@@ -654,8 +654,26 @@ void UBDesktopAnnotationController::selectorActionReleased()
 {
     mDesktopPalette->minimizeMe(eMinimizedLocation_None);
     switchCursor(UBStylusTool::Selector);
-}
 
+    mTransparentDrawingView->setWindowFlag(Qt::WindowTransparentForInput);
+    mTransparentDrawingView->setWindowFlag(Qt::WindowDoesNotAcceptFocus);
+    mDesktopPalette->setAttribute(Qt::WA_TranslucentBackground);
+    mDesktopPalette->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+    mDesktopPalette->show();
+    mTransparentDrawingView->show();
+    UBApplication::mainWindow->actionSelector->setChecked(true);
+
+}
+void UBDesktopAnnotationController::selectorModeLeaved()
+{
+
+    mTransparentDrawingView->setWindowFlag(Qt::WindowTransparentForInput, false);
+    mTransparentDrawingView->setWindowFlag(Qt::WindowDoesNotAcceptFocus, false);
+    mTransparentDrawingView->show();
+    mDesktopPalette->setWindowFlags(Qt::Widget);
+    mDesktopPalette->show();
+
+}
 
 void UBDesktopAnnotationController::pointerActionPressed()
 {
@@ -664,6 +682,7 @@ void UBDesktopAnnotationController::pointerActionPressed()
 
 void UBDesktopAnnotationController::pointerActionReleased()
 {
+    UBApplication::mainWindow->actionPointer->setChecked(true);
     switchCursor(UBStylusTool::Pointer);
 }
 
@@ -695,6 +714,7 @@ void UBDesktopAnnotationController::togglePropertyPalette(UBActionPalette *palet
 
 void UBDesktopAnnotationController::switchCursor(const int tool)
 {
+    selectorModeLeaved();
     mTransparentDrawingScene->setToolCursor(tool);
     mTransparentDrawingView->setToolCursor(tool);
 }

--- a/src/desktop/UBDesktopAnnotationController.cpp
+++ b/src/desktop/UBDesktopAnnotationController.cpp
@@ -111,12 +111,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     {
         connect( UBApplication::boardController->paletteManager()->mKeyboardPalette, SIGNAL(keyboardActivated(bool)), 
                  mTransparentDrawingView, SLOT(virtualKeyboardActivated(bool)));
-
-#ifdef UB_REQUIRES_MASK_UPDATE
-        connect(UBApplication::boardController->paletteManager()->mKeyboardPalette, SIGNAL(moved(QPoint)), this, SLOT(refreshMask()));
-        connect(UBApplication::mainWindow->actionVirtualKeyboard, SIGNAL(triggered(bool)), this, SLOT(refreshMask()));
-        connect(mDesktopPalette,SIGNAL(refreshMask()), this, SLOT(refreshMask()));
-#endif
     }
 
     connect(mDesktopPalette, SIGNAL(uniboardClick()), this, SLOT(goToUniboard()));
@@ -167,11 +161,6 @@ UBDesktopAnnotationController::UBDesktopAnnotationController(QObject *parent, UB
     connect(&mHoldTimerMarker, SIGNAL(timeout()), this, SLOT(markerActionReleased()));
     connect(&mHoldTimerEraser, SIGNAL(timeout()), this, SLOT(eraserActionReleased()));
 
-#ifdef UB_REQUIRES_MASK_UPDATE
-    connect(mDesktopPalette, SIGNAL(moving()), this, SLOT(refreshMask()));
-    connect(UBApplication::boardController->paletteManager()->rightPalette(), SIGNAL(resized()), this, SLOT(refreshMask()));
-    connect(UBApplication::boardController->paletteManager()->addItemPalette(), SIGNAL(closed()), this, SLOT(refreshMask()));
-#endif
     onDesktopPaletteMaximized();
 
     // FIX #633: Ensure that these palettes stay on top of the other elements
@@ -346,9 +335,6 @@ void UBDesktopAnnotationController::showWindow()
 
     mDesktopPalette->appear();
 
-#ifdef UB_REQUIRES_MASK_UPDATE
-    updateMask(true);
-#endif // UB_REQUIRES_MASK_UPDATE
 }
 
 
@@ -392,9 +378,6 @@ void UBDesktopAnnotationController::updateBackground()
             || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Selector)
     {
         newBrush = QBrush(Qt::transparent);
-#ifdef UB_REQUIRES_MASK_UPDATE
-        updateMask(true);
-#endif //UB_REQUIRES_MASK_UPDATE
     }
     else
     {
@@ -403,9 +386,6 @@ void UBDesktopAnnotationController::updateBackground()
 #else
         newBrush = QBrush(QColor(127, 127, 127, 1));
 #endif
-#ifdef UB_REQUIRES_MASK_UPDATE
-        updateMask(false);
-#endif //UB_REQUIRES_MASK_UPDATE
     }
 
     if (mTransparentDrawingScene && mTransparentDrawingScene->backgroundBrush() != newBrush)
@@ -820,136 +800,6 @@ void UBDesktopAnnotationController::onTransparentWidgetResized()
 
     UBApplication::boardController->paletteManager()->leftPalette()->resize(lW+1, rH);
     UBApplication::boardController->paletteManager()->leftPalette()->resize(lW, rH);
-}
-
-void UBDesktopAnnotationController::updateMask(bool bTransparent)
-{
-    if(bTransparent)
-    {
-        // Here we have to generate a new mask This method is certainly resource
-        // consuming but for the moment this is the only solution that I found.
-        mMask = QPixmap(mTransparentDrawingView->width(), mTransparentDrawingView->height());
-        mMask.fill(Qt::transparent);
-
-        QPainter p;
-
-        p.begin(&mMask);
-
-        p.setPen(Qt::red);
-        p.setBrush(QBrush(Qt::red));
-
-        // Here we draw the widget mask
-        if(mDesktopPalette->isVisible())
-        {
-            p.drawRect(mDesktopPalette->geometry().x(), mDesktopPalette->geometry().y(), mDesktopPalette->width(), mDesktopPalette->height());
-        }
-        if(UBApplication::boardController->paletteManager()->mKeyboardPalette->isVisible())
-        {
-            p.drawRect(UBApplication::boardController->paletteManager()->mKeyboardPalette->geometry().x(), UBApplication::boardController->paletteManager()->mKeyboardPalette->geometry().y(),
-                       UBApplication::boardController->paletteManager()->mKeyboardPalette->width(), UBApplication::boardController->paletteManager()->mKeyboardPalette->height());
-        }
-
-        if(UBApplication::boardController->paletteManager()->leftPalette()->isVisible())
-        {
-            QRect leftPalette(UBApplication::boardController->paletteManager()->leftPalette()->geometry().x(),
-                        UBApplication::boardController->paletteManager()->leftPalette()->geometry().y(),
-                        UBApplication::boardController->paletteManager()->leftPalette()->width(),
-                        UBApplication::boardController->paletteManager()->leftPalette()->height());
-
-            QRect tabsPalette(UBApplication::boardController->paletteManager()->leftPalette()->getTabPaletteRect());
-
-            p.drawRect(leftPalette);
-            p.drawRect(tabsPalette);
-        }
-
-        if(UBApplication::boardController->paletteManager()->rightPalette()->isVisible())
-        {
-            QRect rightPalette(UBApplication::boardController->paletteManager()->rightPalette()->geometry().x(),
-                        UBApplication::boardController->paletteManager()->rightPalette()->geometry().y(),
-                        UBApplication::boardController->paletteManager()->rightPalette()->width(),
-                        UBApplication::boardController->paletteManager()->rightPalette()->height());
-
-            QRect tabsPalette(UBApplication::boardController->paletteManager()->rightPalette()->getTabPaletteRect());
-
-            p.drawRect(rightPalette);
-            p.drawRect(tabsPalette);
-        }
-
-        //Rquiered only for compiz wm
-        //TODO. Window manager detection screen
-
-        if (UBApplication::boardController->paletteManager()->addItemPalette()->isVisible()) {
-            p.drawRect(UBApplication::boardController->paletteManager()->addItemPalette()->geometry());
-        }
-
-
-        p.end();
-
-        // Then we add the annotations. We create another painter because we need to
-        // apply transformations on it for coordinates matching
-        QPainter annotationPainter;
-
-        QTransform trans;
-        trans.translate(mTransparentDrawingView->width()/2, mTransparentDrawingView->height()/2);
-
-        annotationPainter.begin(&mMask);
-        annotationPainter.setPen(Qt::red);
-        annotationPainter.setBrush(Qt::red);
-
-        annotationPainter.setTransform(trans);
-
-        QList<QGraphicsItem*> allItems = mTransparentDrawingScene->items();
-
-        for(int i = 0; i < allItems.size(); i++)
-        {
-            QGraphicsItem* pCrntItem = allItems.at(i);
-
-            if(pCrntItem->isVisible() && pCrntItem->type() == UBGraphicsPolygonItem::Type)
-            {
-                QPainterPath crntPath = pCrntItem->shape();
-                QRectF rect = crntPath.boundingRect();
-
-                annotationPainter.drawRect(rect);
-            }
-        }
-
-        annotationPainter.end();
-
-        mTransparentDrawingView->setMask(mMask.mask());
-    }
-    else
-    {
-        mMask = QPixmap(mTransparentDrawingView->width(), mTransparentDrawingView->height());
-        mMask.fill(Qt::transparent);
-
-        QPainter p;
-
-        p.begin(&mMask);
-
-        p.setPen(Qt::red);
-        p.setBrush(QBrush(Qt::red));
-
-        p.drawRect(0, 0, mTransparentDrawingView->width(), mTransparentDrawingView->height());
-        p.end();
-
-        mTransparentDrawingView->setMask(mMask.mask());
-    }
-}
-
-void UBDesktopAnnotationController::refreshMask()
-{
-    if (mTransparentDrawingScene && mTransparentDrawingView->isVisible()) {
-        if(mIsFullyTransparent
-                || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Selector
-                //Needed to work correctly when another actions on stylus are checked
-                || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Eraser
-                || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Pointer
-                || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Pen
-                || UBDrawingController::drawingController()->stylusTool() == UBStylusTool::Marker)
-        {
-            updateMask(true);
-        }
-    }
 }
 
 void UBDesktopAnnotationController::onToolClicked()

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -125,13 +125,11 @@ class UBDesktopAnnotationController : public QObject
         void onDesktopPaletteMaximized();
         void onDesktopPaletteMinimize();
         void onTransparentWidgetResized();
-        void refreshMask();
         void onToolClicked();
 
     private:
         void setAssociatedPalettePosition(UBActionPalette* palette, const QString& actionName);
         void togglePropertyPalette(UBActionPalette* palette);
-        void updateMask(bool bTransparent);
 
         UBDesktopPalette *mDesktopPalette;
         //UBKeyboardPalette *mKeyboardPalette;
@@ -158,8 +156,6 @@ class UBDesktopAnnotationController : public QObject
 
         int mBoardStylusTool;
         int mDesktopStylusTool;
-
-        QPixmap mMask;
 
 };
 

--- a/src/desktop/UBDesktopAnnotationController.h
+++ b/src/desktop/UBDesktopAnnotationController.h
@@ -118,6 +118,7 @@ class UBDesktopAnnotationController : public QObject
         void eraserActionReleased();
         void selectorActionPressed();
         void selectorActionReleased();
+        void selectorModeLeaved();
         void pointerActionPressed();
         void pointerActionReleased();
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -33,12 +33,8 @@
 
 #include "frameworks/UBPlatformUtils.h"
 
-#include "core/UBSettings.h"
-#include "core/UBSetting.h"
 #include "core/UBApplication.h"
 #include "core/UBApplicationController.h"
-
-#include "board/UBDrawingController.h"
 
 #include "gui/UBMainWindow.h"
 

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -172,10 +172,6 @@ void UBDesktopPalette::minimizeMe(eMinimizedLocation location)
     setActions(actions);
 
     adjustSizeAndPosition();
-
-#ifdef UB_REQUIRES_MASK_UPDATE
-        emit refreshMask();
-#endif
 }
 
 //  Called when the user wants to maximize the palette
@@ -203,9 +199,6 @@ void UBDesktopPalette::maximizeMe()
 
     // Notify that the maximization has been done
     emit maximized();
-#ifdef UB_REQUIRES_MASK_UPDATE
-        emit refreshMask();
-#endif
 }
 
 void UBDesktopPalette::showEvent(QShowEvent *event)


### PR DESCRIPTION
I fixed the problem that you cannot click through the board in desktop mode. For me it works now. But I can only test it on X11 Linux. All this is very platform dependent. Someone must test this on Windows, Wayland Linux and MacOS, with Qt6, in the presenter mode and carefully review my changes. I think, my commit is quite a risky thing. So I don't know if and how you developers prefer to change such things. At some time this thing must be fixed.

Honestly I would recommend you to make the floating palettes not children of the board, before accepting my commit. Because in the current way, there happen too many things, which we don't have fully under control. The floating palettes disappear or become irresponsive together with the board. But you never want that. And you also don't want such a complicated masking mechanism. My solution is that the palette becomes a Qt-Window temporarily, but leaving the parent in. That works currently. But I would not be surprised if in future Qt versions this cheat stops working.