### PR TITLE
fix: scaling of display view

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -249,7 +249,7 @@ void UBBoardController::setBoxing(QRect displayRect)
 {
     if (displayRect.isNull())
     {
-        mControlLayout->setContentsMargins(0, 0, 0, 0);
+        mControlView->setBoxing({});
         return;
     }
 
@@ -275,7 +275,7 @@ void UBBoardController::setBoxing(QRect displayRect)
             boxWidth = 0;
         }
 
-        mControlLayout->setContentsMargins(boxWidth, 0, boxWidth, 0);
+        mControlView->setBoxing({boxWidth, 0, boxWidth, 0});
     }
     else if (displayRatio > controlRatio)
     {
@@ -287,12 +287,12 @@ void UBBoardController::setBoxing(QRect displayRect)
             boxHeight = 0;
         }
 
-        mControlLayout->setContentsMargins(0, boxHeight, 0, boxHeight);
+        mControlView->setBoxing({0, boxHeight, 0, boxHeight});
     }
     else
     {
         // No boxing
-        mControlLayout->setContentsMargins(0, 0, 0, 0);
+        mControlView->setBoxing({});
     }
 }
 

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -299,7 +299,7 @@ void UBBoardController::setBoxing(QRect displayRect)
 
 QSize UBBoardController::controlViewport()
 {
-    return UBApplication::displayManager->screenSize(ScreenRole::Control);
+    return mControlView->size();
 }
 
 

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -919,6 +919,11 @@ void UBBoardView::setMultiselection(bool enable)
     mMultipleSelectionIsEnabled = enable;
 }
 
+void UBBoardView::setBoxing(const QMargins& margins)
+{
+    mMargins = margins;
+}
+
 // work around for handling tablet events on MAC OS with Qt 4.8.0 and above
 #if defined(Q_OS_OSX)
 bool UBBoardView::directTabletEvent(QEvent *event)
@@ -1708,7 +1713,6 @@ void UBBoardView::drawItems (QPainter *painter, int numItems, QGraphicsItem* ite
     }
 }
 
-
 void UBBoardView::dragMoveEvent(QDragMoveEvent *event)
 {
     QGraphicsView::dragMoveEvent(event);
@@ -1828,6 +1832,54 @@ void UBBoardView::drawBackground (QPainter *painter, const QRectF &rect)
             painter->drawRect (pageRect);
         }
     }
+}
+
+void UBBoardView::drawForeground(QPainter* painter, const QRectF& rect)
+{
+    QTransform transform{viewportTransform()};
+    QRect viewportRect(0, 0, viewport()->width(), viewport()->height());
+    QRectF visible{mapToScene(viewportRect).boundingRect()};
+
+    painter->save();
+    QColor color{0x808080};
+    color.setAlphaF(0.3);
+    QBrush brush{color};
+    painter->setBrush(brush);
+    painter->setPen(Qt::NoPen);
+
+    if (mMargins.left())
+    {
+        QRectF cover{visible};
+        auto leftMargin = mMargins.left() / transform.m11();
+        cover.setRight(cover.left() + leftMargin);
+        painter->drawRect(cover);
+    }
+
+    if (mMargins.right())
+    {
+        QRectF cover{visible};
+        auto rightMargin = mMargins.right() / transform.m11();
+        cover.setLeft(cover.right() - rightMargin);
+        painter->drawRect(cover);
+    }
+
+    if (mMargins.top())
+    {
+        QRectF cover{visible};
+        auto topMargin = mMargins.top() / transform.m22();
+        cover.setBottom(cover.top() + topMargin);
+        painter->drawRect(cover);
+    }
+
+    if (mMargins.bottom())
+    {
+        QRectF cover{visible};
+        auto bottomMargin = mMargins.bottom() / transform.m22();
+        cover.setTop(cover.bottom() - bottomMargin);
+        painter->drawRect(cover);
+    }
+
+    painter->restore();
 }
 
 void UBBoardView::scrollContentsBy(int dx, int dy)

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -64,6 +64,9 @@ public:
 
     void setMultiselection(bool enable);
     bool isMultipleSelectionEnabled() { return mMultipleSelectionIsEnabled; }
+
+    void setBoxing(const QMargins& margins);
+
     // work around for handling tablet events on MAC OS with Qt 4.8.0 and above
 #if defined(Q_OS_OSX)
     bool directTabletEvent(QEvent *event);
@@ -115,6 +118,7 @@ protected:
     virtual void paintEvent(QPaintEvent *event);
 
     virtual void drawBackground(QPainter *painter, const QRectF &rect);
+    virtual void drawForeground(QPainter *painter, const QRectF &rect);
 
     virtual void scrollContentsBy(int dx, int dy);
 
@@ -202,6 +206,8 @@ private:
     bool bIsControl;
     bool bIsDesktop;
     bool mRubberBandInPlayMode;
+
+    QMargins mMargins{};
 
     static bool hasSelectedParents(QGraphicsItem * item);
 

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -240,7 +240,7 @@ void UBApplicationController::adjustDisplayView()
         qreal hFactor = ((qreal)displaySize.width()) / ((qreal)pageSize.width());
         qreal vFactor = ((qreal)displaySize.height()) / ((qreal)pageSize.height());
 
-        systemDisplayViewScaleFactor = qMin(hFactor, vFactor);
+        systemDisplayViewScaleFactor = qMax(hFactor, vFactor);
 
         QTransform tr;
         qreal scaleFactor = systemDisplayViewScaleFactor

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -234,7 +234,7 @@ void UBApplicationController::adjustDisplayView()
     {
         qreal systemDisplayViewScaleFactor = 1.0;
 
-        QSize pageSize = UBApplication::boardController->activeScene()->nominalSize();
+        QSize pageSize = mControlView->size();
         QSize displaySize = mDisplayView->size();
 
         qreal hFactor = ((qreal)displaySize.width()) / ((qreal)pageSize.width());
@@ -243,19 +243,19 @@ void UBApplicationController::adjustDisplayView()
         systemDisplayViewScaleFactor = qMin(hFactor, vFactor);
 
         QTransform tr;
-        qreal scaleFactor = systemDisplayViewScaleFactor * UBApplication::boardController->currentZoom();
+        qreal scaleFactor = systemDisplayViewScaleFactor
+                * UBApplication::boardController->currentZoom()
+                * UBApplication::boardController->systemScaleFactor();
 
         tr.scale(scaleFactor, scaleFactor);
-
-        QRect rect = mControlView->rect();
-        QPoint center(rect.x() + rect.width() / 2, rect.y() + rect.height() / 2);
 
         QTransform recentTransform = mDisplayView->transform();
 
         if (recentTransform != tr)
             mDisplayView->setTransform(tr);
 
-        mDisplayView->centerOn(mControlView->mapToScene(center));
+        QRect rect = mControlView->rect();
+        mDisplayView->centerOn(mControlView->mapToScene(rect.center()));
     }
 }
 

--- a/src/core/UBDisplayManager.h
+++ b/src/core/UBDisplayManager.h
@@ -84,7 +84,7 @@ class UBDisplayManager : public QObject
 
         bool hasDisplay()
         {
-            return mScreensByRole.value(ScreenRole::Display);
+            return mUseMultiScreen && mScreensByRole.value(ScreenRole::Display);
         }
 
         bool hasPrevious()


### PR DESCRIPTION
This PR fixes the display view scaling issue reported in #887 as follows:

- scaling shall be based on control view size instead of page size
- scaling has to take into account the system scale factor
- refactor: use `center()` function of `QRect` instead of own calculation

The problem (and also the resolution using this PR) can be verified in a setup where control and display screen have different aspect ratios.