### PR TITLE
Refactor: avoid serious clang warnings

### DIFF
--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -1235,7 +1235,10 @@ UBGraphicsGroupContainerItem *UBCFFSubsetAdaptor::UBCFFSubsetReader::parseIwbGro
         if (pStrokesGroup->childItems().count())
             mCurrentScene->addItem(pStrokesGroup);
         else
+        {
             delete pStrokesGroup;
+            pStrokesGroup = nullptr;
+        }
 
         if (pStrokesGroup)
         {

--- a/src/api/UBWidgetUniboardAPI.cpp
+++ b/src/api/UBWidgetUniboardAPI.cpp
@@ -565,6 +565,7 @@ bool UBWidgetUniboardAPI::ProcessDropEvent(QGraphicsSceneDragDropEvent *event)
 
                 if (!UBFileSystemUtils::copyFile(fileName, destFileName)) {
                     qDebug() << "can't copy from" << fileName << "to" << destFileName;
+                    delete dropMimeData;
                     return false;
                 }
                 downloaded = true;

--- a/src/core/UBDocumentManager.cpp
+++ b/src/core/UBDocumentManager.cpp
@@ -151,7 +151,7 @@ QString UBDocumentManager::importFileFilter(bool notUbx)
 
 QFileInfoList UBDocumentManager::importUbx(const QString &Incomingfile, const QString &destination)
 {
-    UBImportDocumentSetAdaptor *docSetAdaptor;
+    UBImportDocumentSetAdaptor *docSetAdaptor = nullptr;
     foreach (UBImportAdaptor *curAdaptor, mImportAdaptors) {
         docSetAdaptor = qobject_cast<UBImportDocumentSetAdaptor*>(curAdaptor);
         if (docSetAdaptor) {

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -103,8 +103,6 @@ UBPersistenceManager::UBPersistenceManager(QObject *pParent)
     mDocumentTreeStructureModel = new UBDocumentTreeModel(this);
     createDocumentProxiesStructure();
 
-    emit proxyListChanged();
-
     mThread = new QThread;
     mWorker = new UBPersistenceWorker();
     mWorker->moveToThread(mThread);
@@ -632,9 +630,7 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocument(const QStr
     } else if (processInteractiveReplacementDialog(doc) == QDialog::Accepted) {
         addDoc = true;
     }
-    if (addDoc) {
-        emit proxyListChanged();
-    } else {
+    if (!addDoc) {
         deleteDocument(doc);
         doc = 0;
     }
@@ -710,7 +706,6 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocumentFromDir(con
     }
     if (addDoc) {
         UBMetadataDcSubsetAdaptor::persist(doc);
-        emit proxyListChanged();
         emit documentCreated(doc);
     } else {
         deleteDocument(doc);
@@ -761,8 +756,6 @@ std::shared_ptr<UBDocumentProxy> UBPersistenceManager::duplicateDocument(std::sh
     persistDocumentMetadata(copy);
 
     copy->setPageCount(sceneCount(copy));
-
-    emit proxyListChanged();
 
     emit documentCreated(copy);
 

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -158,9 +158,6 @@ class UBPersistenceManager : public QObject
         bool isSceneInCached(std::shared_ptr<UBDocumentProxy>proxy, int index) const;
 
     signals:
-
-        void proxyListChanged();
-
         void documentCreated(std::shared_ptr<UBDocumentProxy> pDocumentProxy);
         void documentMetadataChanged(std::shared_ptr<UBDocumentProxy> pDocumentProxy);
 

--- a/src/desktop/UBCustomCaptureWindow.cpp
+++ b/src/desktop/UBCustomCaptureWindow.cpp
@@ -131,7 +131,7 @@ void UBCustomCaptureWindow::mouseReleaseEvent ( QMouseEvent * event )
     event->accept();
 
     // do not accept very small selection
-    if (!(mSelectionBand->geometry().width() < 6 && mSelectionBand->geometry().height() < 6))
+    if (mSelectionBand && !(mSelectionBand->geometry().width() < 6 && mSelectionBand->geometry().height() < 6))
     {
         accept();
     }

--- a/src/desktop/UBDesktopPalette.cpp
+++ b/src/desktop/UBDesktopPalette.cpp
@@ -137,8 +137,7 @@ void UBDesktopPalette::showHideClick(bool checked)
 
 void UBDesktopPalette::updateShowHideState(bool pShowEnabled)
 {
-    if (mShowHideAction)
-        mShowHideAction->setChecked(pShowEnabled);
+    mShowHideAction->setChecked(pShowEnabled);
 
     if (mShowHideAction->isChecked())
         mShowHideAction->setToolTip(tr("Show Board on Secondary Screen"));

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -1222,6 +1222,11 @@ QModelIndex UBDocumentTreeModel::goTo(const QString &dir)
         if (!searchingNode) {
             UBDocumentTreeNode *newChild = new UBDocumentTreeNode(UBDocumentTreeNode::Catalog, curLevelName);
             parentIndex = addNode(newChild, parentIndex);
+
+            if (!parentIndex.isValid())
+            {
+                delete newChild;
+            }
         }
     }
 
@@ -1266,7 +1271,10 @@ void UBDocumentTreeModel::addDocument(std::shared_ptr<UBDocumentProxy> pProxyDat
         lParent = goTo(docGroupName);
     }
 
-    addNode(freeNode, lParent);
+    if (!addNode(freeNode, lParent).isValid())
+    {
+        delete freeNode;
+    }
 }
 
 void UBDocumentTreeModel::addNewDocument(std::shared_ptr<UBDocumentProxy> pProxyData, const QModelIndex &pParent)
@@ -1281,7 +1289,14 @@ QModelIndex UBDocumentTreeModel::addCatalog(const QString &pName, const QModelIn
     }
 
     UBDocumentTreeNode *catalogNode = new UBDocumentTreeNode(UBDocumentTreeNode::Catalog, pName);
-    return addNode(catalogNode, pParent);
+    QModelIndex index = addNode(catalogNode, pParent);
+
+    if (!index.isValid())
+    {
+        delete catalogNode;
+    }
+
+    return index;
 }
 
 void UBDocumentTreeModel::setNewName(const QModelIndex &index, const QString &newName)
@@ -2230,6 +2245,8 @@ void UBDocumentController::setupViews()
             adaptor->setAssociatedAction(currentExportAction);
         }
 
+        bool exportMenuAttached = false;
+
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         foreach (QObject* menuWidget,  mMainWindow->actionExport->associatedObjects())
 #else
@@ -2244,7 +2261,13 @@ void UBDocumentController::setupViews()
                 tb->setPopupMode(QToolButton::InstantPopup);
 
                 tb->setMenu(exportMenu);
+                exportMenuAttached = true;
             }
+        }
+
+        if (!exportMenuAttached)
+        {
+            delete exportMenu;
         }
 
 #ifdef Q_OS_OSX

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -1569,7 +1569,12 @@ void UBDocumentTreeView::dragMoveEvent(QDragMoveEvent *event)
         if (!docModel || !docModel->isDocument(targetIndex) || docModel->inTrash(targetIndex)) {
             event->ignore();
             event->setDropAction(Qt::IgnoreAction);
-            docModel->setHighLighted(QModelIndex());
+
+            if (docModel)
+            {
+                docModel->setHighLighted(QModelIndex());
+            }
+
             acceptIt = false;
         } else {
             docModel->setHighLighted(targetIndex);
@@ -1605,8 +1610,8 @@ void UBDocumentTreeView::dropEvent(QDropEvent *event)
     bool isUBPage = event->mimeData()->hasFormat(UBApplication::mimeTypeUniboardPage);
 
     //issue 1629 - NNE - 20131212
-    bool targetIsInTrash = docModel->inTrash(targetIndex) || docModel->trashIndex() == targetIndex;
-    bool targetIsInMyDocuments = docModel->inMyDocuments(targetIndex) || docModel->myDocumentsIndex() == targetIndex;
+    bool targetIsInTrash = docModel && (docModel->inTrash(targetIndex) || docModel->trashIndex() == targetIndex);
+    bool targetIsInMyDocuments = docModel && (docModel->inMyDocuments(targetIndex) || docModel->myDocumentsIndex() == targetIndex);
 
     if (!targetIsInMyDocuments && !targetIsInTrash)
         return;
@@ -1829,14 +1834,14 @@ QWidget *UBDocumentTreeItemDelegate::createEditor(QWidget *parent, const QStyleO
         const UBDocumentTreeModel *docModel = 0;
 
         const UBSortFilterProxyModel *proxy = dynamic_cast<const UBSortFilterProxyModel*>(index.model());
+        QModelIndex sourceIndex;
 
         if(proxy){
             docModel = dynamic_cast<UBDocumentTreeModel*>(proxy->sourceModel());
+            sourceIndex = proxy->mapToSource(index);
         }else{
             docModel =  dynamic_cast<const UBDocumentTreeModel*>(index.model());
         }
-
-        QModelIndex sourceIndex = proxy->mapToSource(index);
 
         if (docModel)
         {

--- a/src/domain/UBGraphicsItemDelegate.cpp
+++ b/src/domain/UBGraphicsItemDelegate.cpp
@@ -853,11 +853,14 @@ void UBGraphicsItemDelegate::setLocked(bool pLocked)
 
 void UBGraphicsItemDelegate::updateFrame()
 {
-    if (mFrame && !mFrame->scene() && mDelegated->scene())
-        mDelegated->scene()->addItem(mFrame);
+    if (mFrame)
+    {
+        if (!mFrame->scene() && mDelegated->scene())
+            mDelegated->scene()->addItem(mFrame);
 
-    mFrame->setAntiScale(mAntiScaleRatio);
-    mFrame->positionHandles();
+        mFrame->setAntiScale(mAntiScaleRatio);
+        mFrame->positionHandles();
+    }
 }
 
 void UBGraphicsItemDelegate::updateButtons(bool showUpdated)

--- a/src/domain/UBGraphicsMediaItem.cpp
+++ b/src/domain/UBGraphicsMediaItem.cpp
@@ -49,7 +49,7 @@ bool UBGraphicsMediaItem::sIsMutedByDefault = false;
  */
 UBGraphicsMediaItem* UBGraphicsMediaItem::createMediaItem(const QUrl &pMediaFileUrl, QGraphicsItem* parent)
 {
-    UBGraphicsMediaItem * mediaItem;
+    UBGraphicsMediaItem * mediaItem = nullptr;
 
     QString mediaPath = pMediaFileUrl.toString();
     if ("" == mediaPath)

--- a/src/domain/UBGraphicsMediaItemDelegate.cpp
+++ b/src/domain/UBGraphicsMediaItemDelegate.cpp
@@ -185,22 +185,21 @@ void UBGraphicsMediaItemDelegate::positionHandles()
         mToolBarItem->show();
 
         mToolBarItem->setRect(toolBarRect);
-    }
 
-    int toolBarButtonsWidth = 0;
-    foreach (DelegateButton* button, mToolBarButtons)
-        toolBarButtonsWidth += button->boundingRect().width() + mToolBarItem->getElementsPadding();
+        int toolBarButtonsWidth = 0;
+        foreach (DelegateButton* button, mToolBarButtons)
+            toolBarButtonsWidth += button->boundingRect().width() + mToolBarItem->getElementsPadding();
 
-    QRectF mediaItemRect = mMediaControl->rect();
-    mediaItemRect.setWidth(mediaItem->boundingRect().width() - toolBarButtonsWidth);
-    mediaItemRect.setHeight(mToolBarItem->boundingRect().height());
-    mMediaControl->setRect(mediaItemRect);
+        QRectF mediaItemRect = mMediaControl->rect();
+        mediaItemRect.setWidth(mediaItem->boundingRect().width() - toolBarButtonsWidth);
+        mediaItemRect.setHeight(mToolBarItem->boundingRect().height());
+        mMediaControl->setRect(mediaItemRect);
 
-    mToolBarItem->positionHandles();
-    mMediaControl->positionHandles();
+        mToolBarItem->positionHandles();
+        mMediaControl->positionHandles();
 
-    if (mediaItem)
         mToolBarItem->show();
+    }
 }
 
 void UBGraphicsMediaItemDelegate::remove(bool canUndo)

--- a/src/gui/UBThumbnailWidget.cpp
+++ b/src/gui/UBThumbnailWidget.cpp
@@ -158,6 +158,9 @@ void UBThumbnailWidget::refreshScene()
     {
         QGraphicsItem* item = mGraphicItems.at(i);
 
+        if (!item)
+            continue;
+
         UBSceneThumbnailPixmap *thumbnail = dynamic_cast<UBSceneThumbnailPixmap*>(item);
         if (thumbnail)
             thumbnail->setSceneIndex(i);

--- a/src/gui/UBToolWidget.cpp
+++ b/src/gui/UBToolWidget.cpp
@@ -53,26 +53,6 @@ QPixmap* UBToolWidget::sClosePixmap = 0;
 QPixmap* UBToolWidget::sUnpinPixmap = 0;
 
 
-UBToolWidget::UBToolWidget(const QUrl& pUrl, QWidget *pParent)
-    : QWidget(pParent, Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint)
-    , mWebView(0)
-    , mToolWidget(0)
-    , mShouldMoveWidget(false)
-    , mContentMargin(0)
-    , mFrameWidth(0)
-
-{
-    int widgetType = UBGraphicsWidgetItem::widgetType(pUrl);
-    if (widgetType == UBWidgetType::Apple) // NOTE @letsfindaway obsolete
-        mToolWidget = new UBGraphicsAppleWidgetItem(pUrl);
-    else if (widgetType == UBWidgetType::W3C)
-        mToolWidget = new UBGraphicsW3CWidgetItem(pUrl);
-    else
-        qDebug() << "UBToolWidget::UBToolWidget: Unknown widget Type";
-
-    initialize();
-}
-
 UBToolWidget::UBToolWidget(UBGraphicsWidgetItem *pWidget, QWidget *pParent)
     : QWidget(pParent, Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint)
     , mWebView(0)

--- a/src/gui/UBToolWidget.h
+++ b/src/gui/UBToolWidget.h
@@ -47,7 +47,6 @@ class UBToolWidget : public QWidget
     Q_OBJECT;
 
     public:
-        UBToolWidget(const QUrl& pUrl, QWidget* pParent = 0);
         UBToolWidget(UBGraphicsWidgetItem* pWidget, QWidget* pParent = 0);
         virtual ~UBToolWidget();
 

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -262,15 +262,17 @@ void UBEmbedController::importWidgetInLibrary(const QDir& pSourceDir) const
     }
 
 
-    if (UBApplication::boardController &&
-        UBApplication::boardController->activeScene())
+    if (UBApplication::boardController)
     {
-        UBApplication::boardController->addW3cWidget(QUrl::fromLocalFile(widgetLibraryPath), QPointF());
-        UBDrawingController::drawingController()->setStylusTool(UBStylusTool::Selector);
-    }
+        if (UBApplication::boardController->activeScene())
+        {
+            UBApplication::boardController->addW3cWidget(QUrl::fromLocalFile(widgetLibraryPath), QPointF());
+            UBDrawingController::drawingController()->setStylusTool(UBStylusTool::Selector);
+        }
 
-    UBFeaturesController* featuresController = UBApplication::boardController->paletteManager()->featuresWidget()->getFeaturesController();
-    featuresController->addUserWidgetToLibrary(widgetLibraryPath, mTrapFlashUi->widgetNameLineEdit->text());
+        UBFeaturesController* featuresController = UBApplication::boardController->paletteManager()->featuresWidget()->getFeaturesController();
+        featuresController->addUserWidgetToLibrary(widgetLibraryPath, mTrapFlashUi->widgetNameLineEdit->text());
+    }
 }
 
 

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -715,9 +715,12 @@ void UBWebController::loadUrl(const QUrl& url)
 WebView* UBWebController::createNewTab()
 {
     if (mCurrentWebBrowser)
+    {
         UBApplication::applicationController->showInternet();
+        return mCurrentWebBrowser->tabWidget()->createTab();
+    }
 
-    return mCurrentWebBrowser->tabWidget()->createTab();
+    return nullptr;
 }
 
 

--- a/src/web/simplebrowser/WBHistory.cpp
+++ b/src/web/simplebrowser/WBHistory.cpp
@@ -274,7 +274,7 @@ void WBHistoryManager::clear()
     m_fullSave = true;
     m_saveTimer->changeOccurred();
     m_saveTimer->saveIfNeccessary();
-    historyReset();
+    emit historyReset();
 }
 
 void WBHistoryManager::loadSettings()


### PR DESCRIPTION
This PR avoids some `clang-tidy` and `clazy` warning messages indicating potential serious problems:

- `clang-analyzer-core.CallAndMessage`: potential call using `nullptr`
- `clang-analyzer-core.uninitialized.Branch`: potential uninitialized value in branch condition
- `clang-analyzer-core.uninitialized.UndefReturn`: potentially undefined return value
- `clang-analyzer-cplusplus.NewDelete`:potential double-free or use-after-free problem
- `clang-analyzer-cplusplus.NewDeleteLeaks`: potential memory leak
- `clazy-incorrect-emit`: incorrect or missing `emit`

It's the first part of my work on https://github.com/letsfindaway/OpenBoard/issues/148, where I try to identify and mitigate problematic code.