### PR TITLE
Dependency and documentation changes for a Qt6 build on Ubuntu 23.10 or upcoming 24.04 LTS (Noble Numbat)

### DIFF
--- a/OpenBoard.pro
+++ b/OpenBoard.pro
@@ -10,11 +10,7 @@ CONFIG += debug_and_release \
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x050900
 DEFINES += QT_DEPRECATED_WARNINGS
 
-VERSION_MAJ = 1
-VERSION_MIN = 7
-VERSION_PATCH = 0
-VERSION_TYPE = r # a = alpha, b = beta, rc = release candidate, r = release, other => error
-VERSION_BUILD = 231102
+include(version.txt)
 
 VERSION = "$${VERSION_MAJ}.$${VERSION_MIN}.$${VERSION_PATCH}-$${VERSION_TYPE}.$${VERSION_BUILD}"
 
@@ -466,8 +462,8 @@ linux-g++* {
     LIBS += -lX11
 
     greaterThan(QT_MAJOR_VERSION, 5) {
-        LIBS += -lquazip6
-        INCLUDEPATH += "/usr/include/quazip6"
+        LIBS += -lquazip1-qt6
+        INCLUDEPATH += "/usr/include/QuaZip-Qt6-1.4/quazip"
     } else {
         LIBS += -lquazip5
         INCLUDEPATH += "/usr/include/quazip5"

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
@@ -77,8 +77,15 @@ instead
 
 ## Compile OpenBoard
 
-Once the installations and git clone operation are complete, you should be
-able to continue by following
 
-[the compile instructions in OpenBoard's original document](Build-OpenBoard-on-Ubuntu.md#compile-openboard)
+
+Once the installations and git clone operation are complete, you should be
+able to continue by running the following commands:
+```
+qmake6 OpenBoard.pro
+make
+``` 
+
+and then continuing with
+[the compile instructions in OpenBoard's original document](Build-OpenBoard-on-Ubuntu.md#compile-openboard).
 

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
@@ -34,7 +34,7 @@ installation of Qt, qmake and the dependencies of the OpenBoard software itself.
 For simplicity, all installations are bundled in a single command here:
 
 ```
-sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpoppler-cpp-dev libpoppler-private-dev libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev libquazip5-dev libxcb-shape0-dev libxcb-xfixes0-dev qt6-tools-dev qt6-svg-dev
+sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpoppler-cpp-dev libpoppler-private-dev libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev libquazip5-dev libxcb-shape0-dev libxcb-xfixes0-dev qt6-tools-dev qt6-svg-dev qt6-multimedia-dev qt6-webengine-dev
 ```
 
 After this installation has completed, run the following command to verify the version number and home directory for the Ubuntu Qt build:
@@ -88,4 +88,14 @@ make
 
 and then continuing with
 [the compile instructions in OpenBoard's original document](Build-OpenBoard-on-Ubuntu.md#compile-openboard).
+
+As of the current version the following error messages are returned from the 'qmake6' command:
+> Info: creating stash file /home/tim/github/OpenBoard/.qmake.stash
+> Cannot read /home/tim/github/OpenBoard/version.txt: No such file or directory
+> /bin/sh: 1: Syntax error: "&" unexpected
+> /bin/sh: 1: Syntax error: "&" unexpected
+> /bin/sh: 1: Syntax error: "&" unexpected
+These do not appear to reflect a fatal error - qmake6 generates a 
+Makefile and the 'make' command succeeds.
+
 

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
@@ -40,7 +40,7 @@ sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpo
 After this installation has completed, run the following command to verify the version number and home directory for the Ubuntu Qt build:
 
 ```
-qmake 6 -v
+qmake6 -v
 ```
 
 on the system(s) where this process has been tested to date this command reports something like:

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
@@ -34,7 +34,7 @@ installation of Qt, qmake and the dependencies of the OpenBoard software itself.
 For simplicity, all installations are bundled in a single command here:
 
 ```
-sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpoppler-cpp-dev libpoppler-private-dev libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev libquazip5-dev libxcb-shape0-dev libxcb-xfixes0-dev qt6-tools-dev qt6-svg-dev qt6-multimedia-dev qt6-webengine-dev
+sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpoppler-cpp-dev libpoppler-private-dev libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev libquazip5-dev libxcb-shape0-dev libxcb-xfixes0-dev qt6-tools-dev qt6-svg-dev qt6-multimedia-dev qt6-webengine-dev libquazip1-qt6-dev
 ```
 
 After this installation has completed, run the following command to verify the version number and home directory for the Ubuntu Qt build:

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu-with-Qt6.md
@@ -1,0 +1,84 @@
+These instructions are based on trial-and-error builds on Ubuntu 23.10 and pre-release nighly builds of Ubuntu 24.04.
+
+[OpenBoard's default instructions](Build-OpenBoard-on-Ubuntu.md) 
+for building their software from source are based on 
+Qt 5.15.X, which was the default Qt for Ubuntu 2022.4 LTS.  
+
+With the upcoming release of Ubuntu 2024.4, the 
+[Qt Group end of life policy](https://www.qt.io/blog/qt-5.15-extended-support-for-subscription-license-holders) 
+makes this Qt version less than ideal (final patch release for extended 
+support subscribers will go out in May 2025, users who don't have an 
+extended support agreement are already out of support as at March 2024).  
+
+OpenBoard's primary README.md reports that the software can be built against Qt6, this 
+page describes one possible process for doing this on recent and future Ubuntu 
+(i.e. the non-LTS 2023.10, the pre-release nightly builds of candidates to become 
+2024.04 LTS).  The process will the hopefully be applicable to 2024.04 LTS releases when 
+they become available during April 2024.
+
+Openboard's instructions for building from Qt 5.15.3 include the following note:
+
+> **Important note** : The QtWebEngine binary provided by Qt does not come with proprietary codecs enabled, which means that you won't be able to play videos using a > proprietary codec for sound or video. Some major video platforms like Vimeo and PeerTube won't work. If you want them to work, you'll have to build QtWebEngine from > source. To do so, follow [this link](https://github.com/OpenBoard-org/OpenBoard/wiki/Build-Qt-WebEngine-on-Ubuntu-20.04)
+
+Presumably a new version of the QtWebEngine build document will be required for users
+who require a build under with proprietary codec support under Qt6, this new document 
+version does not yet exist. 
+
+## Prepare your environment
+
+### Install Qt6, qmake6 and OpenBoard dependencies
+
+OpenBoard's instructions for building against Qt5.15.X provide separate sections for
+installation of Qt, qmake and the dependencies of the OpenBoard software itself.
+
+For simplicity, all installations are bundled in a single command here:
+
+```
+sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpoppler-cpp-dev libpoppler-private-dev libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev libquazip5-dev libxcb-shape0-dev libxcb-xfixes0-dev qt6-tools-dev qt6-svg-dev
+```
+
+After this installation has completed, run the following command to verify the version number and home directory for the Ubuntu Qt build:
+
+```
+qmake 6 -v
+```
+
+on the system(s) where this process has been tested to date this command reports something like:
+
+```
+QMake version 3.1
+Using Qt version 6.4.2 in /usr/lib/x86_64-linux-gnu
+```
+
+## Download OpenBoard sources
+```
+# place yourself in the directory you want 
+# (in this example at user's home directory)
+cd
+
+# create the folder
+mkdir openboard
+
+# enter in it
+cd openboard
+
+# download openboard sources
+https://github.com/tim-littlefair/OpenBoard.git
+```
+
+**Important note** : A pull request will be submitted to the upstream OpenBoard project
+containing this document and the minor changes to OpenBoard.pro required to get the build 
+working - if/when the upstream maintainers accept and merge this PR the sources should
+be downloaded using 
+```
+git clone https://github.com/OpenBoard-org/OpenBoard.git
+```
+instead
+
+## Compile OpenBoard
+
+Once the installations and git clone operation are complete, you should be
+able to continue by following
+
+[the compile instructions in OpenBoard's original document](Build-OpenBoard-on-Ubuntu.md#compile-openboard)
+

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu.md
@@ -2,9 +2,13 @@ These instructions were written for and tested on Ubuntu 22.04 but should at lea
 
 ## Prepare your environment
 ### Install Qt
-We'll use Ubuntu's default version of Qt (Qt 5.15.3).
+We'll use the default version of Qt in Ubuntu 20.04 LTS and 2022.04 LTS (Qt 5.15.X).
 
 If you want or need to install another version of Qt, please refer to [this section](#install-another-version-of-qt)
+
+There are also 
+[experimental instructions in a separate document for building against Qt6](Build-OpenBoard-on-Ubuntu-with-Qt6.md)
+for future Ubuntu versions where Qt5 passes out of support and/or becomes deprecated in Ubuntu.
 ### Install qmake
 
 ```

--- a/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu.md
+++ b/suggested-wiki-changes/Build-OpenBoard-on-Ubuntu.md
@@ -1,0 +1,182 @@
+These instructions were written for and tested on Ubuntu 22.04 but should at least guide you on any other Debian-like distribution. 
+
+## Prepare your environment
+### Install Qt
+We'll use Ubuntu's default version of Qt (Qt 5.15.3).
+
+If you want or need to install another version of Qt, please refer to [this section](#install-another-version-of-qt)
+### Install qmake
+
+```
+sudo apt install qt5-qmake
+```
+If you type `qmake -v` on a terminal, it should returns something like this :
+```
+QMake version x.y
+Using Qt version <Qt_version> in <path_to_your_Qt_lib_folder>/lib
+```
+
+## Install OpenBoard dependencies
+```
+# what is going to be installed :
+- build-essential # Informational list of build-essential packages (needed to build debian (.deb) packages)
+- libgl1-mesa-dev # free implementation of the OpenGL API -- GLX development files
+- libssl-dev # Secure Sockets Layer toolkit - development files
+- libpoppler-dev # PDF rendering library -- development files
+- libpoppler-cpp-dev # PDF rendering library -- development files (CPP interface)
+- libpoppler-private-dev # PDF rendering library -- private development files
+- libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev
+  libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev 
+  libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev # ffmpeg libraries and associated dependencies
+- libquazip5-dev # C++ wrapper for ZIP/UNZIP (development files)
+- libxcb-shape0-dev # X C Binding, shape extension, development files
+- libxcb-xfixes0-dev # X C Binding, xfixes extension, development files
+- libqt5svg5-dev qttools5-dev qtmultimedia5-dev qtwebengine5-dev # Additional Qt libs needed for OpenBoard
+
+# execute the following command line to install all of the above
+
+sudo apt install build-essential libgl1-mesa-dev libssl-dev libpoppler-dev libpoppler-cpp-dev libpoppler-private-dev libavcodec-dev libavformat-dev libswscale-dev libpaper-dev libva-dev libxcb-shm0-dev libasound2-dev libx264-dev libvpx-dev libvorbis-dev  libtheora-dev libmp3lame-dev libsdl1.2-dev libopus-dev  libfdk-aac-dev libass-dev liblzma-dev libbz2-dev libquazip5-dev libxcb-shape0-dev libxcb-xfixes0-dev libqt5svg5-dev qttools5-dev qtmultimedia5-dev qtwebengine5-dev
+
+```
+
+## Download OpenBoard sources
+```
+# place yourself in the directory you want 
+# (in this example at user's home directory)
+cd
+
+# create the folder
+mkdir openboard
+
+# enter in it
+cd openboard
+
+# download openboard sources
+git clone https://github.com/OpenBoard-org/OpenBoard.git
+```
+
+## Compile OpenBoard
+``` 
+cd <path_to_openboard>
+cd Openboard
+```
+
+Then, you can compile OpenBoard
+```
+qmake OpenBoard.pro
+make
+``` 
+
+If you want to populate OpenBoard's library with its default applications, sounds, and so on, you'll have to copy them from the `resources` directory to the location of the executable : 
+
+```
+cp -r resources/library build/linux/release/product/
+```
+
+If you want to use different translations : 
+```
+cp -r resources/i18n build/linux/release/product/
+```
+
+You will find the executable in the following directory : 
+```
+cd build/linux/release/product/
+```
+
+and can execute the version of OpenBoard you compiled yourself like following : 
+```
+# supposing you placed yourself in build/linux/release/product/
+
+./OpenBoard
+
+# or in another language
+./OpenBoard -lang ja
+```
+
+## Package OpenBoard
+```
+cd release_scripts
+cd linux
+```
+
+### If you installed another version of Qt
+First, open build.sh and package.sh in your favorite text editor, and modify this line to point to the correct Qt path :
+```
+ QT_PATH="<path_to_your_Qt_folder>/<Qt_version>/gcc_64"
+```
+
+### Execute the scripts
+
+Launch the build
+```
+sudo ./build.sh
+```
+
+Finally, launch the packaging
+```
+sudo ./package.sh
+```
+
+Now, you should see your OpenBoard package in `<path_to_openboard>/Openboard/install/linux>`
+
+That's all ! Well done !
+
+
+--------------------------------
+## Install another version of Qt
+#### Install Qt
+If you want to install another version of Qt, go to Qt downloads page and follow the instructions to download the opensource version of Qt
+
+- https://www.qt.io/download-open-source
+- at the bottom of the page, click on the "Download the Qt Online Installer" button
+- on the next page, Qt chose automatically the version corresponding to your current OS, so be sure it is the version you want to download (for this example, "Qt Online Installer for Linux (64-bit)")
+- click on the "Download" button
+
+You need to add the right to your user to execute this file : 
+```
+#for this example, I had to execute the followings commands
+cd
+cd Downloads
+chmod u+x qt-unified-linux-x64-3.1.1-online.run
+# launch the installer (and follow the instructions) by executing this command :
+./qt-unified-linux-x64-3.1.1-online.run
+```
+
+Follow the instructions and pick the <Qt_version> you want (for example 6.3.2). You'll need : 
+* Desktop gcc 64-bit
+* Qt Multimedia
+* Qt WebEngine
+* Qt Positioning
+* Qt WebChannel
+* Qt 5 Compatibility Module (for Qt 6 only)
+* Qt Debug Information Files (recommended but not mandatory)
+
+
+**Important note** : The QtWebEngine binary provided by Qt does not come with proprietary codecs enabled, which means that you won't be able to play videos using a proprietary codec for sound or video. Some major video platforms like Vimeo and PeerTube won't work. If you want them to work, you'll have to build QtWebEngine from source. To do so, follow [this link](https://github.com/OpenBoard-org/OpenBoard/wiki/Build-Qt-WebEngine-on-Ubuntu-20.04)
+
+#### Install qtchooser
+
+```
+sudo apt install qtchooser
+```
+
+```
+#replace the <path_to_your_Qt_folder> by the correct value (for example, "/home/dev/Qt")
+#replace the <Qt_version> by the correct value (for example, "5.15.2")
+echo "<path_to_your_Qt_folder>/<Qt_version>/gcc_64/bin/" >> default.conf
+echo "<path_to_your_Qt_folder>/<Qt_version>/gcc_64/lib/" >> default.conf
+```
+
+Finally, move it to the qtchooser directory : 
+```
+sudo mv default.conf /usr/lib/x86_64-linux-gnu/qtchooser/
+```
+
+If you type `qmake -v` on a terminal and it should returns something like this :
+```
+QMake version x.y
+Using Qt version <Qt_version> in <path_to_your_Qt_lib_folder>/lib
+```
+
+When you successfully installed Qt, go back to [this section](#install-openboard-dependencies)
+


### PR DESCRIPTION
I'm running a laptop on a recent pre-release nightly build of Noble Numbat (as well as a day-to-day machine running non-LTS 23.10 Mantic).

I picked up OpenBoard a couple of weeks back as a medium for some notes I was preparing for myself, thought I'd build it from source, and given the support situation with Qt5, and KDE5, I decided to build against Qt6 rather than follow the instructions dating back a couple of LTS's for building against Qt5.15.X.

I found the build went through fairly easily once I'd worked out the correct dependencies to bring in with apt.  The only change to the original source in the code repository I needed related to the libquazip library for which the recommendation seems to be that Qt6 builds should depend on a different major version with different install path conventions:
[https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1019507].

Apart from that, I felt the 