### PR TITLE
Perf lazy loading

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -344,6 +344,13 @@ std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::loadScene(std::shared_ptr<U
     return reader.loadScene(proxy);
 }
 
+std::shared_ptr<UBSvgSubsetAdaptor::UBSvgReaderContext> UBSvgSubsetAdaptor::prepareLoadingScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex)
+{
+    const auto fileContent = loadSceneAsText(proxy, pageIndex);
+    auto context = std::make_shared<UBSvgReaderContext>(proxy, fileContent);
+    return context;
+}
+
 UBSvgSubsetAdaptor::UBSvgSubsetReader::UBSvgSubsetReader(std::shared_ptr<UBDocumentProxy> pProxy, const QByteArray& pXmlData)
     : mXmlReader(pXmlData)
     , mProxy(pProxy)
@@ -356,652 +363,679 @@ UBSvgSubsetAdaptor::UBSvgSubsetReader::UBSvgSubsetReader(std::shared_ptr<UBDocum
 
 std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScene(std::shared_ptr<UBDocumentProxy> proxy)
 {
-    qDebug() << "loadScene() : starting reading...";
     QElapsedTimer time;
     time.start();
+
+    start();
+
+    while (!mXmlReader.atEnd())
+    {
+        processElement();
+    }
+
+    qDebug() << "spent milliseconds: " << time.elapsed();
+    return scene();
+}
+
+void UBSvgSubsetAdaptor::UBSvgSubsetReader::start()
+{
+    qDebug() << "loadScene() : starting reading...";
     mScene = nullptr;
     UBGraphicsWidgetItem *currentWidget = 0;
     //bool pageDpiSpecified = true;
     saveSceneAfterLoading = false;
 
     mFileVersion = 40100; // default to 4.1.0
+}
 
-    UBGraphicsStrokesGroup* strokesGroup = 0;
-    UBGraphicsStroke* currentStroke = 0;
+bool UBSvgSubsetAdaptor::UBSvgSubsetReader::isFinished()
+{
+    return mXmlReader.atEnd();
+}
 
-    while (!mXmlReader.atEnd())
+void UBSvgSubsetAdaptor::UBSvgSubsetReader::processElement()
+{
+    mXmlReader.readNext();
+    if (mXmlReader.isStartElement())
     {
-        mXmlReader.readNext();
-        if (mXmlReader.isStartElement())
+        QString name = mXmlReader.name().toString();
+
+        if (name == "svg")
         {
-            QString name = mXmlReader.name().toString();
-
-            if (name == "svg")
+            if (!mScene)
             {
-                if (!mScene)
+                mScene = std::make_shared<UBGraphicsScene>(mProxy, false);
+                mScene->setModified(false);
+            }
+
+            // introduced in UB 4.2
+
+            auto svgUbVersion = mXmlReader.attributes().value(UBSettings::uniboardDocumentNamespaceUri, "version");
+
+            if (!svgUbVersion.isNull())
+            {
+                QString ubVersion = svgUbVersion.toString();
+
+                //may look like : 4 or 4.1 or 4.2 or 4.2.1, etc
+
+                QStringList parts = ubVersion.split(".");
+
+                if (parts.length() > 0)
                 {
-                    mScene = std::make_shared<UBGraphicsScene>(mProxy, false);
-                    mScene->setModified(false);
+                    mFileVersion = parts.at(0).toInt() * 10000;
                 }
 
-                // introduced in UB 4.2
-
-                auto svgUbVersion = mXmlReader.attributes().value(UBSettings::uniboardDocumentNamespaceUri, "version");
-
-                if (!svgUbVersion.isNull())
+                if (parts.length() > 1)
                 {
-                    QString ubVersion = svgUbVersion.toString();
-
-                    //may look like : 4 or 4.1 or 4.2 or 4.2.1, etc
-
-                    QStringList parts = ubVersion.split(".");
-
-                    if (parts.length() > 0)
-                    {
-                        mFileVersion = parts.at(0).toInt() * 10000;
-                    }
-
-                    if (parts.length() > 1)
-                    {
-                        mFileVersion += parts.at(1).toInt() * 100;
-                    }
-
-                    if (parts.length() > 2)
-                    {
-                        mFileVersion += parts.at(2).toInt();
-                    }
+                    mFileVersion += parts.at(1).toInt() * 100;
                 }
 
-                mNamespaceUri = uniboardDocumentNamespaceUriFromVersion(mFileVersion);
-
-                auto svgSceneUuid = mXmlReader.attributes().value(mNamespaceUri, "uuid");
-
-                if (!svgSceneUuid.isNull())
-                    mScene->setUuid(QUuid(svgSceneUuid.toString()));
-
-                // introduced in UB 4.0
-
-                auto svgViewBox = mXmlReader.attributes().value("viewBox");
-
-
-                if (!svgViewBox.isNull())
+                if (parts.length() > 2)
                 {
-                    QStringList ts = svgViewBox.toString().split(QLatin1Char(' '), UB::SplitBehavior::SkipEmptyParts);
-
-                    QRectF sceneRect;
-                    if (ts.size() >= 4)
-                    {
-                        sceneRect.setX(ts.at(0).toFloat());
-                        sceneRect.setY(ts.at(1).toFloat());
-                        sceneRect.setWidth(ts.at(2).toFloat());
-                        sceneRect.setHeight(ts.at(3).toFloat());
-
-                        mScene->setSceneRect(sceneRect);
-                    }
-                    else
-                    {
-                        qWarning() << "cannot make sense of 'viewBox' value " << svgViewBox.toString();
-                    }
-                }
-
-                auto pageDpi = mXmlReader.attributes().value("pageDpi");
-
-                if (!pageDpi.isNull())
-                    proxy->setPageDpi(pageDpi.toInt());
-
-                else if (proxy->pageDpi() == 0) {
-                    proxy->setPageDpi(UBApplication::displayManager->logicalDpi(ScreenRole::Control));
-                    //pageDpiSpecified = false;
-                }
-
-                bool darkBackground = false;
-                bool crossedBackground = false;
-                bool ruledBackground = false;
-
-                auto ubDarkBackground = mXmlReader.attributes().value(mNamespaceUri, "dark-background");
-
-                if (!ubDarkBackground.isNull())
-                    darkBackground = (ubDarkBackground.toString() == xmlTrue);
-
-                auto ubCrossedBackground = mXmlReader.attributes().value(mNamespaceUri, "crossed-background");
-
-                if (!ubCrossedBackground.isNull())
-                    crossedBackground = (ubCrossedBackground.toString() == xmlTrue);
-
-                auto ubGridSize = mXmlReader.attributes().value(mNamespaceUri, "grid-size");
-
-                if (!ubGridSize.isNull()) {
-                    int gridSize = ubGridSize.toInt();
-
-                    mScene->setBackgroundGridSize(gridSize);
-                }
-
-                if (crossedBackground) {
-
-                    auto ubIntermediateLines = mXmlReader.attributes().value(mNamespaceUri, "intermediate-lines");
-
-                    if (!ubIntermediateLines.isNull()) {
-                        bool intermediateLines = ubIntermediateLines.toInt();
-
-                        mScene->setIntermediateLines(intermediateLines);
-                    }
-                }
-
-                auto ubRuledBackground = mXmlReader.attributes().value(mNamespaceUri, "ruled-background");
-
-                if (!ubRuledBackground.isNull())
-                    ruledBackground = (ubRuledBackground.toString() == xmlTrue);
-
-                if (ruledBackground && !crossedBackground) { // if for some reason both are true, the background will be a grid
-
-                    auto ubIntermediateLines = mXmlReader.attributes().value(mNamespaceUri, "intermediate-lines");
-
-                    if (!ubIntermediateLines.isNull()) {
-                        bool intermediateLines = ubIntermediateLines.toInt();
-
-                        mScene->setIntermediateLines(intermediateLines);
-                    }
-                }
-
-                UBPageBackground bg;
-                if (crossedBackground)
-                    bg = UBPageBackground::crossed;
-                else if (ruledBackground)
-                    bg = UBPageBackground::ruled;
-                else
-                    bg = UBPageBackground::plain;
-
-                mScene->setBackground(darkBackground, bg);
-
-                auto pageNominalSize = mXmlReader.attributes().value(mNamespaceUri, "nominal-size");
-                if (!pageNominalSize.isNull())
-                {
-                    QStringList ts = pageNominalSize.toString().split(QLatin1Char('x'), UB::SplitBehavior::SkipEmptyParts);
-
-                    QSize sceneSize;
-                    if (ts.size() >= 2)
-                    {
-                        sceneSize.setWidth(ts.at(0).toInt());
-                        sceneSize.setHeight(ts.at(1).toInt());
-
-                        mScene->setNominalSize(sceneSize);
-                    }
-                    else
-                    {
-                        qWarning() << "cannot make sense of 'nominal-size' value " << pageNominalSize.toString();
-                    }
-
+                    mFileVersion += parts.at(2).toInt();
                 }
             }
-            else if (name == "g")
+
+            mNamespaceUri = uniboardDocumentNamespaceUriFromVersion(mFileVersion);
+
+            auto svgSceneUuid = mXmlReader.attributes().value(mNamespaceUri, "uuid");
+
+            if (!svgSceneUuid.isNull())
+                mScene->setUuid(QUuid(svgSceneUuid.toString()));
+
+            // introduced in UB 4.0
+
+            auto svgViewBox = mXmlReader.attributes().value("viewBox");
+
+
+            if (!svgViewBox.isNull())
             {
-                strokesGroup = new UBGraphicsStrokesGroup();
-                graphicsItemFromSvg(strokesGroup);
+                QStringList ts = svgViewBox.toString().split(QLatin1Char(' '), UB::SplitBehavior::SkipEmptyParts);
 
-                bool hasZValue;
-                qreal zValue = normalizedZValue(&hasZValue);
-
-                if (hasZValue)
+                QRectF sceneRect;
+                if (ts.size() >= 4)
                 {
-                    mGroupZIndex = zValue;
-                    mGroupHasInfo = true;
+                    sceneRect.setX(ts.at(0).toFloat());
+                    sceneRect.setY(ts.at(1).toFloat());
+                    sceneRect.setWidth(ts.at(2).toFloat());
+                    sceneRect.setHeight(ts.at(3).toFloat());
+
+                    mScene->setSceneRect(sceneRect);
+                }
+                else
+                {
+                    qWarning() << "cannot make sense of 'viewBox' value " << svgViewBox.toString();
+                }
+            }
+
+            auto pageDpi = mXmlReader.attributes().value("pageDpi");
+
+            if (!pageDpi.isNull())
+                mProxy->setPageDpi(pageDpi.toInt());
+
+            else if (mProxy->pageDpi() == 0) {
+                mProxy->setPageDpi(UBApplication::displayManager->logicalDpi(ScreenRole::Control));
+                //pageDpiSpecified = false;
+            }
+
+            bool darkBackground = false;
+            bool crossedBackground = false;
+            bool ruledBackground = false;
+
+            auto ubDarkBackground = mXmlReader.attributes().value(mNamespaceUri, "dark-background");
+
+            if (!ubDarkBackground.isNull())
+                darkBackground = (ubDarkBackground.toString() == xmlTrue);
+
+            auto ubCrossedBackground = mXmlReader.attributes().value(mNamespaceUri, "crossed-background");
+
+            if (!ubCrossedBackground.isNull())
+                crossedBackground = (ubCrossedBackground.toString() == xmlTrue);
+
+            auto ubGridSize = mXmlReader.attributes().value(mNamespaceUri, "grid-size");
+
+            if (!ubGridSize.isNull()) {
+                int gridSize = ubGridSize.toInt();
+
+                mScene->setBackgroundGridSize(gridSize);
+            }
+
+            if (crossedBackground) {
+
+                auto ubIntermediateLines = mXmlReader.attributes().value(mNamespaceUri, "intermediate-lines");
+
+                if (!ubIntermediateLines.isNull()) {
+                    bool intermediateLines = ubIntermediateLines.toInt();
+
+                    mScene->setIntermediateLines(intermediateLines);
+                }
+            }
+
+            auto ubRuledBackground = mXmlReader.attributes().value(mNamespaceUri, "ruled-background");
+
+            if (!ubRuledBackground.isNull())
+                ruledBackground = (ubRuledBackground.toString() == xmlTrue);
+
+            if (ruledBackground && !crossedBackground) { // if for some reason both are true, the background will be a grid
+
+                auto ubIntermediateLines = mXmlReader.attributes().value(mNamespaceUri, "intermediate-lines");
+
+                if (!ubIntermediateLines.isNull()) {
+                    bool intermediateLines = ubIntermediateLines.toInt();
+
+                    mScene->setIntermediateLines(intermediateLines);
+                }
+            }
+
+            UBPageBackground bg;
+            if (crossedBackground)
+                bg = UBPageBackground::crossed;
+            else if (ruledBackground)
+                bg = UBPageBackground::ruled;
+            else
+                bg = UBPageBackground::plain;
+
+            mScene->setBackground(darkBackground, bg);
+
+            auto pageNominalSize = mXmlReader.attributes().value(mNamespaceUri, "nominal-size");
+            if (!pageNominalSize.isNull())
+            {
+                QStringList ts = pageNominalSize.toString().split(QLatin1Char('x'), UB::SplitBehavior::SkipEmptyParts);
+
+                QSize sceneSize;
+                if (ts.size() >= 2)
+                {
+                    sceneSize.setWidth(ts.at(0).toInt());
+                    sceneSize.setHeight(ts.at(1).toInt());
+
+                    mScene->setNominalSize(sceneSize);
+                }
+                else
+                {
+                    qWarning() << "cannot make sense of 'nominal-size' value " << pageNominalSize.toString();
                 }
 
-                auto ubFillOnDarkBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-dark-background");
+            }
+        }
+        else if (name == "g")
+        {
+            strokesGroup = new UBGraphicsStrokesGroup();
+            graphicsItemFromSvg(strokesGroup);
 
-                if (!ubFillOnDarkBackground.isNull())
-                {
+            bool hasZValue;
+            qreal zValue = normalizedZValue(&hasZValue);
+
+            if (hasZValue)
+            {
+                mGroupZIndex = zValue;
+                mGroupHasInfo = true;
+            }
+
+            auto ubFillOnDarkBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-dark-background");
+
+            if (!ubFillOnDarkBackground.isNull())
+            {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
                     mGroupDarkBackgroundColor = QColor::fromString(ubFillOnDarkBackground.toString());
 #else
-                    mGroupDarkBackgroundColor.setNamedColor(ubFillOnDarkBackground.toString());
+                mGroupDarkBackgroundColor.setNamedColor(ubFillOnDarkBackground.toString());
 #endif
-                }
+            }
 
-                auto ubFillOnLightBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-light-background");
+            auto ubFillOnLightBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-light-background");
 
-                if (!ubFillOnLightBackground.isNull())
-                {
+            if (!ubFillOnLightBackground.isNull())
+            {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
                     mGroupLightBackgroundColor = QColor::fromString(ubFillOnLightBackground.toString());
 #else
-                    mGroupLightBackgroundColor.setNamedColor(ubFillOnLightBackground.toString());
+                mGroupLightBackgroundColor.setNamedColor(ubFillOnLightBackground.toString());
 #endif
+            }
+
+            auto ubUuid = mXmlReader.attributes().value(mNamespaceUri, "uuid");
+
+            if (!ubUuid.isNull())
+                strokesGroup->setUuid(QUuid(ubUuid.toString()));
+            else
+                strokesGroup->setUuid(QUuid::createUuid());
+
+            QString uuid_stripped = strokesGroup->uuid().toString().replace("}","").replace("{","");
+
+            if (!mStrokesList.contains(uuid_stripped))
+                mStrokesList.insert(uuid_stripped, strokesGroup);
+        }
+        else if (name == "polygon" || name == "line")
+        {
+            UBGraphicsPolygonItem* polygonItem = 0;
+
+            QString parentId = mXmlReader.attributes().value(mNamespaceUri, "parent").toString();
+
+            if (name == "polygon")
+                polygonItem = polygonItemFromPolygonSvg(mScene->isDarkBackground() ? Qt::white : Qt::black);
+            else if (name == "line")
+                polygonItem = polygonItemFromLineSvg(mScene->isDarkBackground() ? Qt::white : Qt::black);
+
+            if(parentId.isEmpty() && strokesGroup)
+                parentId = strokesGroup->uuid().toString();
+
+            if(parentId.isEmpty())
+                parentId = QUuid::createUuid().toString();
+
+            if (polygonItem)
+            {
+                polygonItem->setData(UBGraphicsItemData::ItemLayerType, QVariant(UBItemLayerType::Graphic));
+
+                UBGraphicsStrokesGroup* group;
+                if(!mStrokesList.contains(parentId)){
+                    group = new UBGraphicsStrokesGroup();
+                    mStrokesList.insert(parentId,group);
+                    group->setTransform(polygonItem->transform());
+                    UBGraphicsItem::assignZValue(group, polygonItem->zValue());
                 }
-
-                auto ubUuid = mXmlReader.attributes().value(mNamespaceUri, "uuid");
-
-                if (!ubUuid.isNull())
-                    strokesGroup->setUuid(QUuid(ubUuid.toString()));
                 else
-                    strokesGroup->setUuid(QUuid::createUuid());
+                    group = mStrokesList.value(parentId);
 
-                QString uuid_stripped = strokesGroup->uuid().toString().replace("}","").replace("{","");
+                if (!currentStroke)
+                    currentStroke = new UBGraphicsStroke();
 
-                if (!mStrokesList.contains(uuid_stripped))
-                    mStrokesList.insert(uuid_stripped, strokesGroup);
+                if(polygonItem->transform().isIdentity())
+                    polygonItem->setTransform(group->transform());
+
+                group->addToGroup(polygonItem);
+                polygonItem->setStrokesGroup(group);
+                polygonItem->setStroke(currentStroke);
+
+                polygonItem->show();
+                group->addToGroup(polygonItem);
             }
-            else if (name == "polygon" || name == "line")
+        }
+        else if (name == "polyline")
+        {
+            QList<UBGraphicsPolygonItem*> polygonItems = polygonItemsFromPolylineSvg(mScene->isDarkBackground() ? Qt::white : Qt::black);
+
+            QString parentId = mXmlReader.attributes().value(mNamespaceUri, "parent").toString();
+
+            if(parentId.isEmpty() && strokesGroup)
+                parentId = strokesGroup->uuid().toString();
+
+            if(parentId.isEmpty())
+                parentId = QUuid::createUuid().toString();
+
+            foreach(UBGraphicsPolygonItem* polygonItem, polygonItems)
             {
-                UBGraphicsPolygonItem* polygonItem = 0;
+                polygonItem->setData(UBGraphicsItemData::ItemLayerType, QVariant(UBItemLayerType::Graphic));
 
-                QString parentId = mXmlReader.attributes().value(mNamespaceUri, "parent").toString();
+                UBGraphicsStrokesGroup* group;
 
-                if (name == "polygon")
-                    polygonItem = polygonItemFromPolygonSvg(mScene->isDarkBackground() ? Qt::white : Qt::black);
-                else if (name == "line")
-                    polygonItem = polygonItemFromLineSvg(mScene->isDarkBackground() ? Qt::white : Qt::black);
-
-                if(parentId.isEmpty() && strokesGroup)
-                    parentId = strokesGroup->uuid().toString();
-
-                if(parentId.isEmpty())
-                    parentId = QUuid::createUuid().toString();
-
-                if (polygonItem)
-                {
-                    polygonItem->setData(UBGraphicsItemData::ItemLayerType, QVariant(UBItemLayerType::Graphic));
-
-                    UBGraphicsStrokesGroup* group;
-                    if(!mStrokesList.contains(parentId)){
-                        group = new UBGraphicsStrokesGroup();
-                        mStrokesList.insert(parentId,group);
-                        group->setTransform(polygonItem->transform());
-                        UBGraphicsItem::assignZValue(group, polygonItem->zValue());
-                    }
-                    else
-                        group = mStrokesList.value(parentId);
-
-                    if (!currentStroke)
-                        currentStroke = new UBGraphicsStroke();
-
-                    if(polygonItem->transform().isIdentity())
-                        polygonItem->setTransform(group->transform());
-
-                    group->addToGroup(polygonItem);
-                    polygonItem->setStrokesGroup(group);
-                    polygonItem->setStroke(currentStroke);
-
-                    polygonItem->show();
-                    group->addToGroup(polygonItem);
+                if(!mStrokesList.contains(parentId)){
+                    group = new UBGraphicsStrokesGroup();
+                    mStrokesList.insert(parentId,group);
+                    group->setTransform(polygonItem->transform());
+                    UBGraphicsItem::assignZValue(group, polygonItem->zValue());
                 }
+                else
+                    group = mStrokesList.value(parentId);
+
+                if (!currentStroke)
+                    currentStroke = new UBGraphicsStroke();
+
+                if(polygonItem->transform().isIdentity())
+                    polygonItem->setTransform(group->transform());
+
+                group->addToGroup(polygonItem);
+                polygonItem->setStrokesGroup(group);
+                polygonItem->setStroke(currentStroke);
+
+                polygonItem->show();
+                group->addToGroup(polygonItem);
             }
-            else if (name == "polyline")
+
+        }
+        else if (name == "image")
+        {
+            auto imageHref = mXmlReader.attributes().value(nsXLink, "href");
+
+            if (!imageHref.isNull())
             {
-                QList<UBGraphicsPolygonItem*> polygonItems = polygonItemsFromPolylineSvg(mScene->isDarkBackground() ? Qt::white : Qt::black);
+                QString href = imageHref.toString();
 
-                QString parentId = mXmlReader.attributes().value(mNamespaceUri, "parent").toString();
+                auto ubBackground = mXmlReader.attributes().value(mNamespaceUri, "background");
 
-                if(parentId.isEmpty() && strokesGroup)
-                    parentId = strokesGroup->uuid().toString();
+                bool isBackground = (!ubBackground.isNull() && ubBackground.toString() == xmlTrue);
 
-                if(parentId.isEmpty())
-                    parentId = QUuid::createUuid().toString();
-
-                foreach(UBGraphicsPolygonItem* polygonItem, polygonItems)
+                if (href.endsWith(".svg"))
                 {
-                    polygonItem->setData(UBGraphicsItemData::ItemLayerType, QVariant(UBItemLayerType::Graphic));
-
-                    UBGraphicsStrokesGroup* group;
-
-                    if(!mStrokesList.contains(parentId)){
-                        group = new UBGraphicsStrokesGroup();
-                        mStrokesList.insert(parentId,group);
-                        group->setTransform(polygonItem->transform());
-                        UBGraphicsItem::assignZValue(group, polygonItem->zValue());
-                    }
-                    else
-                        group = mStrokesList.value(parentId);
-
-                    if (!currentStroke)
-                        currentStroke = new UBGraphicsStroke();
-
-                    if(polygonItem->transform().isIdentity())
-                        polygonItem->setTransform(group->transform());
-
-                    group->addToGroup(polygonItem);
-                    polygonItem->setStrokesGroup(group);
-                    polygonItem->setStroke(currentStroke);
-
-                    polygonItem->show();
-                    group->addToGroup(polygonItem);
-                }
-
-            }
-            else if (name == "image")
-            {
-                auto imageHref = mXmlReader.attributes().value(nsXLink, "href");
-
-                if (!imageHref.isNull())
-                {
-                    QString href = imageHref.toString();
-
-                    auto ubBackground = mXmlReader.attributes().value(mNamespaceUri, "background");
-
-                    bool isBackground = (!ubBackground.isNull() && ubBackground.toString() == xmlTrue);
-
-                    if (href.endsWith(".svg"))
+                    UBGraphicsSvgItem* svgItem = svgItemFromSvg();
+                    if (svgItem)
                     {
-                        UBGraphicsSvgItem* svgItem = svgItemFromSvg();
-                        if (svgItem)
-                        {
-                            svgItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-                            svgItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+                        svgItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+                        svgItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-                            mScene->addItem(svgItem);
+                        mScene->addItem(svgItem);
 
-                            if (isBackground)
-                                mScene->setAsBackgroundObject(svgItem);
+                        if (isBackground)
+                            mScene->setAsBackgroundObject(svgItem);
 
-                            svgItem->show();
-                        }
+                        svgItem->show();
                     }
-                    else
+                }
+                else
+                {
+                    UBGraphicsPixmapItem* pixmapItem = pixmapItemFromSvg();
+                    if (pixmapItem)
                     {
-                        UBGraphicsPixmapItem* pixmapItem = pixmapItemFromSvg();
-                        if (pixmapItem)
-                        {
-                            pixmapItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-                            pixmapItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+                        pixmapItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+                        pixmapItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-                            mScene->addItem(pixmapItem);
+                        mScene->addItem(pixmapItem);
 
-                            if (isBackground)
-                                mScene->setAsBackgroundObject(pixmapItem);
+                        if (isBackground)
+                            mScene->setAsBackgroundObject(pixmapItem);
 
-                            pixmapItem->show();
-                        }
+                        pixmapItem->show();
                     }
                 }
             }
-            else if (name == "audio")
+        }
+        else if (name == "audio")
+        {
+            UBGraphicsMediaItem* audioItem = audioItemFromSvg();
+            if (audioItem)
             {
-                UBGraphicsMediaItem* audioItem = audioItemFromSvg();
-                if (audioItem)
+                audioItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+                audioItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+
+                mScene->addItem(audioItem);
+
+                audioItem->show();
+
+                audioItem->play();
+                audioItem->pause();
+            }
+        }
+        else if (name == "video")
+        {
+            UBGraphicsMediaItem* videoItem = videoItemFromSvg();
+            if (videoItem)
+            {
+
+                videoItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+                videoItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+
+                mScene->addItem(videoItem);
+
+                videoItem->show();
+            }
+        }
+        else if (name == "text")//This is for backward compatibility with proto text field prior to version 4.3
+        {
+            UBGraphicsTextItem* textItem = textItemFromSvg();
+            if (textItem)
+            {
+                textItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+                textItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+
+                mScene->addItem(textItem);
+
+                textItem->show();
+            }
+        }
+        else if (name == "curtain")
+        {
+            UBGraphicsCurtainItem* mask = curtainItemFromSvg();
+            if (mask)
+            {
+                mScene->addItem(mask);
+                mScene->registerTool(mask);
+            }
+        }
+        else if (name == "ruler")
+        {
+
+            UBGraphicsRuler *ruler = rulerFromSvg();
+            if (ruler)
+            {
+                mScene->addItem(ruler);
+                mScene->registerTool(ruler);
+            }
+
+        }
+        else if (name == "axes")
+        {
+
+            UBGraphicsAxes *axes = axesFromSvg();
+            if (axes)
+            {
+                mScene->addItem(axes);
+            }
+
+        }
+        else if (name == "compass")
+        {
+            UBGraphicsCompass *compass = compassFromSvg();
+            if (compass)
+            {
+                mScene->addItem(compass);
+                mScene->registerTool(compass);
+            }
+        }
+        else if (name == "protractor")
+        {
+            UBGraphicsProtractor *protractor = protractorFromSvg();
+            if (protractor)
+            {
+                mScene->addItem(protractor);
+                mScene->registerTool(protractor);
+            }
+        }
+        else if (name == "triangle")
+        {
+            UBGraphicsTriangle *triangle = triangleFromSvg();
+            if (triangle)
+            {
+                mScene->addItem(triangle);
+                mScene->registerTool(triangle);
+            }
+        }
+        else if (name == "cache")
+        {
+            UBGraphicsCache* cache = cacheFromSvg();
+            if(cache)
+            {
+                mScene->addItem(cache);
+                mScene->registerTool(cache);
+                UBApplication::boardController->notifyCache(true);
+            }
+        }
+        else if (name == "foreignObject")
+        {
+            QString href = mXmlReader.attributes().value(nsXLink, "href").toString();
+            QString src = mXmlReader.attributes().value(mNamespaceUri, "src").toString();
+            QString type = mXmlReader.attributes().value(mNamespaceUri, "type").toString();
+            bool isBackground = mXmlReader.attributes().value(mNamespaceUri, "background").toString() == xmlTrue;
+
+            qreal foreignObjectWidth = mXmlReader.attributes().value("width").toString().toFloat();
+            qreal foreignObjectHeight = mXmlReader.attributes().value("height").toString().toFloat();
+
+            if (href.contains(".pdf"))
+            {
+                UBGraphicsPDFItem* pdfItem = pdfItemFromPDF();
+                if (pdfItem)
                 {
-                    audioItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-                    audioItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+                    qreal currentDpi = UBApplication::displayManager->logicalDpi(ScreenRole::Control);
+                    // qDebug() << "currentDpi = " << currentDpi;
+                    qreal pdfScale = qreal(mProxy->pageDpi())/currentDpi;
+                    // qDebug() << "pdfScale " << pdfScale;
 
-                    mScene->addItem(audioItem);
+                    // If the PDF is in the background, it occupies the whole page; so we can simply
+                    // use that information to calculate its scale.
+                    if (isBackground) {
+                        qreal pageWidth = mScene->nominalSize().width();
+                        qreal pageHeight = mScene->nominalSize().height();
 
-                    audioItem->show();
+                        qreal scaleX = pageWidth / pdfItem->sceneBoundingRect().width();
+                        qreal scaleY = pageHeight / pdfItem->sceneBoundingRect().height();
 
-                    audioItem->play();
-                    audioItem->pause();
+                        pdfScale = (scaleX+scaleY)/2.;
+                    }
+
+                    pdfItem->setScale(pdfScale);
+                    pdfItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+                    pdfItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+
+                    mScene->addItem(pdfItem);
+
+                    if (isBackground)
+                        mScene->setAsBackgroundObject(pdfItem);
+
+                    pdfItem->show();
+
+                    currentWidget = 0;
                 }
             }
-            else if (name == "video")
+            else if (src.contains(".wdgt")) // NOTE @letsfindaway obsolete
             {
-                UBGraphicsMediaItem* videoItem = videoItemFromSvg();
-                if (videoItem)
+                UBGraphicsAppleWidgetItem* appleWidgetItem = graphicsAppleWidgetFromSvg();
+                if (appleWidgetItem)
                 {
+                    appleWidgetItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-                    videoItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-                    videoItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+                    appleWidgetItem->resize(foreignObjectWidth, foreignObjectHeight);
 
-                    mScene->addItem(videoItem);
+                    mScene->addItem(appleWidgetItem);
 
-                    videoItem->show();
+                    appleWidgetItem->show();
+
+                    currentWidget = appleWidgetItem;
                 }
             }
-            else if (name == "text")//This is for backward compatibility with proto text field prior to version 4.3
+            else if (src.contains(".wgt"))
+            {
+                UBGraphicsW3CWidgetItem* w3cWidgetItem = graphicsW3CWidgetFromSvg();
+
+                if (w3cWidgetItem)
+                {
+                    // check compatibility
+                    QUuid uuid(mXmlReader.attributes().value(mNamespaceUri, "uuid").toString());
+
+                    if (!mProxy->isWidgetCompatible(uuid))
+                    {
+                        // show a substitute image and freeze the widget
+                        QPixmap pixmap(w3cWidgetItem->size().toSize());
+                        pixmap.fill(Qt::lightGray);
+                        QPainter painter(&pixmap);
+                        QFont font = painter.font();
+                        font.setPixelSize(16);
+                        painter.setFont(font);
+                        const QRectF rectangle(QPointF(0, 0), w3cWidgetItem->size());
+
+                        std::string incompatibleWidgetMessage = QString("Incompatible widget (%1).").arg(w3cWidgetItem->metadatas().name).toStdString();
+                        painter.drawText(rectangle, Qt::AlignCenter, QObject::tr(incompatibleWidgetMessage.c_str()));
+                        w3cWidgetItem->setSnapshot(pixmap, true);
+
+                        // disable user interactions
+                        w3cWidgetItem->setFreezable(false);
+                        w3cWidgetItem->setCanBeTool(false);
+                    }
+
+                    w3cWidgetItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+
+                    w3cWidgetItem->resize(foreignObjectWidth, foreignObjectHeight);
+
+                    mScene->addItem(w3cWidgetItem);
+
+                    w3cWidgetItem->show();
+
+                    currentWidget = w3cWidgetItem;
+                }
+            }
+            else if (type == "text")
             {
                 UBGraphicsTextItem* textItem = textItemFromSvg();
+
                 if (textItem)
                 {
                     textItem->setFlag(QGraphicsItem::ItemIsMovable, true);
                     textItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+                    textItem->activateTextEditor(false);
 
                     mScene->addItem(textItem);
 
                     textItem->show();
                 }
             }
-            else if (name == "curtain")
-            {
-                UBGraphicsCurtainItem* mask = curtainItemFromSvg();
-                if (mask)
-                {
-                    mScene->addItem(mask);
-                    mScene->registerTool(mask);
-                }
-            }
-            else if (name == "ruler")
-            {
-
-                UBGraphicsRuler *ruler = rulerFromSvg();
-                if (ruler)
-                {
-                    mScene->addItem(ruler);
-                    mScene->registerTool(ruler);
-                }
-
-            }
-            else if (name == "axes")
-            {
-
-                UBGraphicsAxes *axes = axesFromSvg();
-                if (axes)
-                {
-                    mScene->addItem(axes);
-                }
-
-            }
-            else if (name == "compass")
-            {
-                UBGraphicsCompass *compass = compassFromSvg();
-                if (compass)
-                {
-                    mScene->addItem(compass);
-                    mScene->registerTool(compass);
-                }
-            }
-            else if (name == "protractor")
-            {
-                UBGraphicsProtractor *protractor = protractorFromSvg();
-                if (protractor)
-                {
-                    mScene->addItem(protractor);
-                    mScene->registerTool(protractor);
-                }
-            }
-            else if (name == "triangle")
-            {
-                UBGraphicsTriangle *triangle = triangleFromSvg();
-                if (triangle)
-                {
-                    mScene->addItem(triangle);
-                    mScene->registerTool(triangle);
-                }
-            }
-            else if (name == "cache")
-            {
-                UBGraphicsCache* cache = cacheFromSvg();
-                if(cache)
-                {
-                    mScene->addItem(cache);
-                    mScene->registerTool(cache);
-                    UBApplication::boardController->notifyCache(true);
-                }
-            }
-            else if (name == "foreignObject")
-            {
-                QString href = mXmlReader.attributes().value(nsXLink, "href").toString();
-                QString src = mXmlReader.attributes().value(mNamespaceUri, "src").toString();
-                QString type = mXmlReader.attributes().value(mNamespaceUri, "type").toString();
-                bool isBackground = mXmlReader.attributes().value(mNamespaceUri, "background").toString() == xmlTrue;
-
-                qreal foreignObjectWidth = mXmlReader.attributes().value("width").toString().toFloat();
-                qreal foreignObjectHeight = mXmlReader.attributes().value("height").toString().toFloat();
-
-                if (href.contains(".pdf"))
-                {
-                    UBGraphicsPDFItem* pdfItem = pdfItemFromPDF();
-                    if (pdfItem)
-                    {
-                        qreal currentDpi = UBApplication::displayManager->logicalDpi(ScreenRole::Control);
-                        // qDebug() << "currentDpi = " << currentDpi;
-                        qreal pdfScale = qreal(proxy->pageDpi())/currentDpi;
-                        // qDebug() << "pdfScale " << pdfScale;
-
-                        // If the PDF is in the background, it occupies the whole page; so we can simply
-                        // use that information to calculate its scale.
-                        if (isBackground) {
-                            qreal pageWidth = mScene->nominalSize().width();
-                            qreal pageHeight = mScene->nominalSize().height();
-
-                            qreal scaleX = pageWidth / pdfItem->sceneBoundingRect().width();
-                            qreal scaleY = pageHeight / pdfItem->sceneBoundingRect().height();
-
-                            pdfScale = (scaleX+scaleY)/2.;
-                        }
-
-                        pdfItem->setScale(pdfScale);
-                        pdfItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-                        pdfItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-
-                        mScene->addItem(pdfItem);
-
-                        if (isBackground)
-                            mScene->setAsBackgroundObject(pdfItem);
-
-                        pdfItem->show();
-
-                        currentWidget = 0;
-                    }
-                }
-                else if (src.contains(".wdgt")) // NOTE @letsfindaway obsolete
-                {
-                    UBGraphicsAppleWidgetItem* appleWidgetItem = graphicsAppleWidgetFromSvg();
-                    if (appleWidgetItem)
-                    {
-                        appleWidgetItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-
-                        appleWidgetItem->resize(foreignObjectWidth, foreignObjectHeight);
-
-                        mScene->addItem(appleWidgetItem);
-
-                        appleWidgetItem->show();
-
-                        currentWidget = appleWidgetItem;
-                    }
-                }
-                else if (src.contains(".wgt"))
-                {
-                    UBGraphicsW3CWidgetItem* w3cWidgetItem = graphicsW3CWidgetFromSvg();
-
-                    if (w3cWidgetItem)
-                    {
-                        // check compatibility
-                        QUuid uuid(mXmlReader.attributes().value(mNamespaceUri, "uuid").toString());
-
-                        if (!proxy->isWidgetCompatible(uuid))
-                        {
-                            // show a substitute image and freeze the widget
-                            QPixmap pixmap(w3cWidgetItem->size().toSize());
-                            pixmap.fill(Qt::lightGray);
-                            QPainter painter(&pixmap);
-                            QFont font = painter.font();
-                            font.setPixelSize(16);
-                            painter.setFont(font);
-                            const QRectF rectangle(QPointF(0, 0), w3cWidgetItem->size());
-
-                            std::string incompatibleWidgetMessage = QString("Incompatible widget (%1).").arg(w3cWidgetItem->metadatas().name).toStdString();
-                            painter.drawText(rectangle, Qt::AlignCenter, QObject::tr(incompatibleWidgetMessage.c_str()));
-                            w3cWidgetItem->setSnapshot(pixmap, true);
-
-                            // disable user interactions
-                            w3cWidgetItem->setFreezable(false);
-                            w3cWidgetItem->setCanBeTool(false);
-                        }
-
-                        w3cWidgetItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-
-                        w3cWidgetItem->resize(foreignObjectWidth, foreignObjectHeight);
-
-                        mScene->addItem(w3cWidgetItem);
-
-                        w3cWidgetItem->show();
-
-                        currentWidget = w3cWidgetItem;
-                    }
-                }
-                else if (type == "text")
-                {
-                    UBGraphicsTextItem* textItem = textItemFromSvg();
-
-                    if (textItem)
-                    {
-                        textItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-                        textItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-                        textItem->activateTextEditor(false);
-
-                        mScene->addItem(textItem);
-
-                        textItem->show();
-                    }
-                }
-                else
-                {
-                    qWarning() << "Ignoring unknown foreignObject:" << href;
-                }
-            }
-            else if (currentWidget && (name == "preference"))
-            {
-                QString key = mXmlReader.attributes().value("key").toString();
-                QString value = mXmlReader.attributes().value("value").toString();
-
-                currentWidget->setPreference(key, value);
-            }
-            else if (currentWidget && (name == "datastoreEntry"))
-            {
-                QString key = mXmlReader.attributes().value("key").toString();
-                QString value = mXmlReader.attributes().value("value").toString();
-
-                currentWidget->setDatastoreEntry(key, value);
-            } else if (name == tGroups) {
-                //considering groups section at the end of the document
-                readGroupRoot();
-            }
             else
             {
-                // NOOP
+                qWarning() << "Ignoring unknown foreignObject:" << href;
             }
         }
-        else if (mXmlReader.isEndElement())
+        else if (currentWidget && (name == "preference"))
         {
-            if (mXmlReader.name().toString() == "g")
-            {
-                mGroupHasInfo = false;
-                mGroupDarkBackgroundColor = QColor();
-                mGroupLightBackgroundColor = QColor();
-                strokesGroup = NULL;
-                currentStroke = NULL;
-            }
+            QString key = mXmlReader.attributes().value("key").toString();
+            QString value = mXmlReader.attributes().value("value").toString();
+
+            currentWidget->setPreference(key, value);
+        }
+        else if (currentWidget && (name == "datastoreEntry"))
+        {
+            QString key = mXmlReader.attributes().value("key").toString();
+            QString value = mXmlReader.attributes().value("value").toString();
+
+            currentWidget->setDatastoreEntry(key, value);
+        } else if (name == tGroups) {
+            //considering groups section at the end of the document
+            readGroupRoot();
+        }
+        else
+        {
+            // NOOP
         }
     }
-
-
-    if (mXmlReader.hasError())
+    else if (mXmlReader.isEndElement())
     {
-        qWarning() << "error parsing file " << mXmlReader.errorString();
+        if (mXmlReader.name().toString() == "g")
+        {
+            mGroupHasInfo = false;
+            mGroupDarkBackgroundColor = QColor();
+            mGroupLightBackgroundColor = QColor();
+            strokesGroup = NULL;
+            currentStroke = NULL;
+        }
     }
 
-    qDebug() << "Number of detected strokes: " << mStrokesList.count();
+    if (mXmlReader.atEnd())
+    {
+        mMustFinalize = true;
+    }
+}
 
-    if (mScene) {
-        QHashIterator<QString, UBGraphicsStrokesGroup*> iterator(mStrokesList);
-        while (iterator.hasNext()) {
-            iterator.next();
-            mScene->addItem(iterator.value());
+std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgSubsetReader::scene()
+{
+    if (mMustFinalize)
+    {
+        if (mXmlReader.hasError())
+        {
+            qWarning() << "error parsing file " << mXmlReader.errorString();
         }
 
-        mScene->setModified(saveSceneAfterLoading);
-        mScene->enableUndoRedoStack();
+        qDebug() << "Number of detected strokes: " << mStrokesList.count();
+
+        if (mScene) {
+            QHashIterator<QString, UBGraphicsStrokesGroup*> iterator(mStrokesList);
+            while (iterator.hasNext()) {
+                iterator.next();
+                mScene->addItem(iterator.value());
+            }
+
+            mScene->setModified(saveSceneAfterLoading);
+            mScene->enableUndoRedoStack();
+            qDebug() << "loadScene() : created scene and read file";
+        }
+
+        mMustFinalize = false;
     }
 
-    qDebug() << "loadScene() : created scene and read file";
-    qDebug() << "spent milliseconds: " << time.elapsed();
     return mScene;
 }
 
@@ -3469,4 +3503,30 @@ void UBSvgSubsetAdaptor::convertSvgImagesToImages(std::shared_ptr<UBDocumentProx
             }
         }
     }
+}
+
+UBSvgSubsetAdaptor::UBSvgReaderContext::UBSvgReaderContext(std::shared_ptr<UBDocumentProxy> proxy, const QByteArray& pXmlData)
+{
+    reader = new UBSvgSubsetReader(proxy, pXmlData);
+    reader->start();
+}
+
+UBSvgSubsetAdaptor::UBSvgReaderContext::~UBSvgReaderContext()
+{
+    delete reader;
+}
+
+bool UBSvgSubsetAdaptor::UBSvgReaderContext::isFinished() const
+{
+    return reader->isFinished();
+}
+
+void UBSvgSubsetAdaptor::UBSvgReaderContext::step()
+{
+    reader->processElement();
+}
+
+std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgReaderContext::scene() const
+{
+    return reader->scene();
 }

--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -63,16 +63,30 @@ class UBGraphicsStrokesGroup;
 
 class UBSvgSubsetAdaptor
 {
+    class UBSvgSubsetReader;
     private:
 
         UBSvgSubsetAdaptor() {;}
         virtual ~UBSvgSubsetAdaptor() {;}
 
     public:
+        class UBSvgReaderContext
+        {
+        public:
+            UBSvgReaderContext(std::shared_ptr<UBDocumentProxy> proxy, const QByteArray& pXmlData);
+            ~UBSvgReaderContext();
+            bool isFinished() const;
+            void step();
+            std::shared_ptr<UBGraphicsScene> scene() const;
+
+        private:
+            UBSvgSubsetReader* reader = nullptr;
+        };
 
         static std::shared_ptr<UBGraphicsScene> loadScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
         static QByteArray loadSceneAsText(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
         static std::shared_ptr<UBGraphicsScene> loadScene(std::shared_ptr<UBDocumentProxy> proxy, const QByteArray& pArray);
+        static std::shared_ptr<UBSvgReaderContext> prepareLoadingScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
 
         static void persistScene(std::shared_ptr<UBDocumentProxy> proxy, std::shared_ptr<UBGraphicsScene> pScene, const int pageIndex);
         static void upgradeScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
@@ -116,6 +130,11 @@ class UBSvgSubsetAdaptor
                 virtual ~UBSvgSubsetReader(){}
 
                 std::shared_ptr<UBGraphicsScene> loadScene(std::shared_ptr<UBDocumentProxy> proxy);
+
+                void start();
+                bool isFinished();
+                void processElement();
+                std::shared_ptr<UBGraphicsScene> scene();
 
             private:
 
@@ -179,6 +198,11 @@ class UBSvgSubsetAdaptor
                 std::shared_ptr<UBGraphicsScene> mScene;
 
                 QHash<QString,UBGraphicsStrokesGroup*> mStrokesList;
+
+                UBGraphicsStrokesGroup* strokesGroup = nullptr;
+                UBGraphicsStroke* currentStroke = nullptr;
+                UBGraphicsWidgetItem *currentWidget = nullptr;
+                bool mMustFinalize = false;
         };
 
         class UBSvgSubsetWriter

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -115,7 +115,6 @@ UBPersistenceManager::UBPersistenceManager(QObject *pParent)
     connect(mWorker, SIGNAL(finished()), this, SLOT(onWorkerFinished()));
     connect(mWorker, SIGNAL(finished()), mWorker, SLOT(deleteLater()));
     connect(mThread, SIGNAL(finished()), mThread, SLOT(deleteLater()));
-    connect(mWorker, SIGNAL(sceneLoaded(QByteArray,std::shared_ptr<UBDocumentProxy>,int)), this, SLOT(onSceneLoaded(QByteArray,std::shared_ptr<UBDocumentProxy>,int)));
     connect(mWorker, &UBPersistenceWorker::scenePersisted, this, &UBPersistenceManager::onScenePersisted);
 
     mThread->start();
@@ -170,16 +169,6 @@ UBPersistenceManager::~UBPersistenceManager()
 void UBPersistenceManager::errorString(QString error)
 {
     qWarning() << "An error occured in the peristence thread " << error;
-}
-
-void UBPersistenceManager::onSceneLoaded(QByteArray scene, std::shared_ptr<UBDocumentProxy> proxy, int sceneIndex)
-{
-    Q_UNUSED(scene);
-    qDebug() << "scene loaded " << sceneIndex;
-    QElapsedTimer time;
-    time.start();
-    mSceneCache.insert(proxy, sceneIndex, loadDocumentScene(proxy, sceneIndex, false));
-    qDebug() << "millisecond for sceneCache " << time.elapsed();
 }
 
 void UBPersistenceManager::createDocumentProxiesStructure(const QFileInfoList &contentInfoList, bool interactive)

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -1091,37 +1091,28 @@ void UBPersistenceManager::moveSceneToIndex(std::shared_ptr<UBDocumentProxy> pro
 
 std::shared_ptr<UBGraphicsScene> UBPersistenceManager::loadDocumentScene(std::shared_ptr<UBDocumentProxy> proxy, int sceneIndex, bool cacheNeighboringScenes)
 {
-    std::shared_ptr<UBGraphicsScene> scene = nullptr;
-
-    if (mSceneCache.contains(proxy, sceneIndex))
-    {
-        return mSceneCache.value(proxy, sceneIndex);
-    }
-    else
-    {
-        scene = UBSvgSubsetAdaptor::loadScene(proxy, sceneIndex);
-        if (scene)
-        {
-            mSceneCache.insert(proxy, sceneIndex, scene);
-        }
-        else
-        {
-            qWarning() << "could not load scene for document : " << proxy->persistencePath() << ", scene index : " << sceneIndex;
-            return nullptr;
-        }
-    }
+    mSceneCache.prepareLoading(proxy, sceneIndex);
+    auto scene = mSceneCache.value(proxy, sceneIndex);
+    qDebug() << "loadDocumentScene: got result from cache";
 
     if (cacheNeighboringScenes)
     {
         if(sceneIndex + 1 < proxy->pageCount() &&  !mSceneCache.contains(proxy, sceneIndex + 1))
-            mWorker->readScene(proxy,sceneIndex+1);
+            mSceneCache.prepareLoading(proxy,sceneIndex+1);
+
+        if(sceneIndex + 2 < proxy->pageCount() &&  !mSceneCache.contains(proxy, sceneIndex + 2))
+            mSceneCache.prepareLoading(proxy,sceneIndex+2);
 
         if(sceneIndex - 1 >= 0 &&  !mSceneCache.contains(proxy, sceneIndex - 1))
-            mWorker->readScene(proxy,sceneIndex-1);
+            mSceneCache.prepareLoading(proxy,sceneIndex-1);
     }
 
-
     return scene;
+}
+
+std::shared_ptr<UBGraphicsScene> UBPersistenceManager::getDocumentScene(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int sceneIndex)
+{
+    return mSceneCache.value(pDocumentProxy, sceneIndex);
 }
 
 void UBPersistenceManager::reassignDocProxy(std::shared_ptr<UBDocumentProxy> newDocument, std::shared_ptr<UBDocumentProxy> oldDocument)

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -205,7 +205,6 @@ private:
     private slots:
         void documentRepositoryChanged(const QString& path);
         void errorString(QString error);
-        void onSceneLoaded(QByteArray,std::shared_ptr<UBDocumentProxy>,int);
         void onWorkerFinished();
         void onScenePersisted(UBGraphicsScene* scene);
 };

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -113,7 +113,7 @@ class UBPersistenceManager : public QObject
         virtual void moveSceneToIndex(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int source, int target);
 
         virtual std::shared_ptr<UBGraphicsScene> loadDocumentScene(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int sceneIndex, bool cacheNeighboringScenes = true);
-        std::shared_ptr<UBGraphicsScene> getDocumentScene(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int sceneIndex) {return mSceneCache.value(pDocumentProxy, sceneIndex);}
+        std::shared_ptr<UBGraphicsScene> getDocumentScene(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int sceneIndex);
         void reassignDocProxy(std::shared_ptr<UBDocumentProxy> newDocument, std::shared_ptr<UBDocumentProxy> oldDocument);
 
 //        QList<QPointer<UBDocumentProxy> > documentProxies;

--- a/src/core/UBPersistenceWorker.cpp
+++ b/src/core/UBPersistenceWorker.cpp
@@ -45,14 +45,6 @@ void UBPersistenceWorker::saveScene(std::shared_ptr<UBDocumentProxy> proxy, UBGr
     mSemaphore.release();
 }
 
-void UBPersistenceWorker::readScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex)
-{
-    PersistenceInformation entry = {ReadScene, proxy, 0, pageIndex};
-
-    saves.append(entry);
-    mSemaphore.release();
-}
-
 void UBPersistenceWorker::saveMetadata(std::shared_ptr<UBDocumentProxy> proxy)
 {
     PersistenceInformation entry = {WriteMetadata, proxy, NULL, 0};
@@ -76,9 +68,6 @@ void UBPersistenceWorker::process()
         if(info.action == WriteScene){
             UBSvgSubsetAdaptor::persistScene(info.proxy, info.scene->shared_from_this(), info.sceneIndex);
             emit scenePersisted(info.scene);
-        }
-        else if (info.action == ReadScene){
-            emit sceneLoaded(UBSvgSubsetAdaptor::loadSceneAsText(info.proxy,info.sceneIndex), info.proxy, info.sceneIndex);
         }
         else if (info.action == WriteMetadata) {
             UBMetadataDcSubsetAdaptor::persist(info.proxy);

--- a/src/core/UBPersistenceWorker.h
+++ b/src/core/UBPersistenceWorker.h
@@ -36,7 +36,6 @@
 
 typedef enum{
     WriteScene = 0,
-    ReadScene,
     WriteMetadata
 }ActionType;
 
@@ -54,13 +53,11 @@ public:
     explicit UBPersistenceWorker(QObject *parent = 0);
 
     void saveScene(std::shared_ptr<UBDocumentProxy> proxy, UBGraphicsScene* scene, const int pageIndex);
-    void readScene(std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
     void saveMetadata(std::shared_ptr<UBDocumentProxy> proxy);
 
 signals:
    void finished();
    void error(QString string);
-   void sceneLoaded(QByteArray text,std::shared_ptr<UBDocumentProxy> proxy, const int pageIndex);
    void scenePersisted(UBGraphicsScene* scene);
    void metadataPersisted(std::shared_ptr<UBDocumentProxy> proxy);
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -72,7 +72,7 @@ void ub_message_output(QtMsgType type, const QMessageLogContext& context, const 
 
         if (logFile.open(QIODevice::Append | QIODevice::Text)) {
             QTextStream out(&logFile);
-            out << QDateTime::currentDateTime().toString(Qt::ISODate)
+            out << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
                 << "      " << msg << "\n";
             logFile.close();
         }

--- a/src/domain/UBGraphicsItemDelegate.cpp
+++ b/src/domain/UBGraphicsItemDelegate.cpp
@@ -182,7 +182,6 @@ UBGraphicsItemDelegate::UBGraphicsItemDelegate(QGraphicsItem* pDelegated, QObjec
 #endif
 {
     setUBFlags(fls);
-    connect(UBApplication::boardController, SIGNAL(zoomChanged(qreal)), this, SLOT(onZoomChanged()));
 }
 
 void UBGraphicsItemDelegate::createControls()
@@ -270,8 +269,15 @@ bool UBGraphicsItemDelegate::controlsExist() const
 
 UBGraphicsItemDelegate::~UBGraphicsItemDelegate()
 {
-    if (UBApplication::boardController)
-        disconnect(UBApplication::boardController, SIGNAL(zoomChanged(qreal)), this, SLOT(onZoomChanged()));
+    if (mDelegated)
+    {
+        UBGraphicsScene* scene = dynamic_cast<UBGraphicsScene*>(mDelegated->scene());
+
+        if (scene)
+        {
+            disconnect(scene, &UBGraphicsScene::zoomChanged, this, &UBGraphicsItemDelegate::onZoomChanged);
+        }
+    }
     // do not release mMimeData.
     // the mMimeData is owned by QDrag since the setMimeData call as specified in the documentation
 }
@@ -473,6 +479,18 @@ QGraphicsItem *UBGraphicsItemDelegate::delegated()
     }
 
     return curDelegate;
+}
+
+void UBGraphicsItemDelegate::sceneChanged(UBGraphicsScene* scene)
+{
+    UBGraphicsScene* previousScene = dynamic_cast<UBGraphicsScene*>(mDelegated->scene());
+
+    if (previousScene)
+    {
+        disconnect(previousScene, &UBGraphicsScene::zoomChanged, this, &UBGraphicsItemDelegate::onZoomChanged);
+    }
+
+    connect(scene, &UBGraphicsScene::zoomChanged, this, &UBGraphicsItemDelegate::onZoomChanged);
 }
 
 void UBGraphicsItemDelegate::positionHandles()

--- a/src/domain/UBGraphicsItemDelegate.h
+++ b/src/domain/UBGraphicsItemDelegate.h
@@ -270,6 +270,7 @@ class UBGraphicsItemDelegate : public QObject
         void printMessage(const QString &mess) {qDebug() << mess;}
 
         QGraphicsItem* delegated();
+        void sceneChanged(UBGraphicsScene* scene);
 
         virtual void positionHandles();
         void setZOrderButtonsVisible(bool visible);

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -366,10 +366,14 @@ UBGraphicsScene::UBGraphicsScene(std::shared_ptr<UBDocumentProxy> document, bool
 //    connect(this, SIGNAL(selectionChanged()), this, SLOT(selectionChangedProcessing()));
     connect(UBApplication::undoStack.data(), SIGNAL(indexChanged(int)), this, SLOT(updateSelectionFrameWrapper(int)));
     connect(UBDrawingController::drawingController(), SIGNAL(stylusToolChanged(int,int)), this, SLOT(stylusToolChanged(int,int)));
+    connect(UBApplication::boardController, &UBBoardController::zoomChanged, this, &UBGraphicsScene::zoomChanged);
 }
 
 UBGraphicsScene::~UBGraphicsScene()
 {
+    // disconnect all consumers of this signal at once to speed-up deletion of scene
+    disconnect(this, &UBGraphicsScene::zoomChanged, nullptr, nullptr);
+
     if (mCurrentStroke && mCurrentStroke->polygons().empty()){
         delete mCurrentStroke;
         mCurrentStroke = NULL;
@@ -1974,6 +1978,13 @@ void UBGraphicsScene::addItem(QGraphicsItem* item)
     if (widget)
     {
         widget->initAPI();
+    }
+
+    UBGraphicsItem* ubitem = dynamic_cast<UBGraphicsItem*>(item);
+
+    if (ubitem)
+    {
+        ubitem->Delegate()->sceneChanged(this);
     }
 }
 

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -394,6 +394,9 @@ public slots:
 
         void controlViewportChanged();
 
+signals:
+        void zoomChanged(qreal zoomFactor);
+
     protected:
 
         UBGraphicsPolygonItem* lineToPolygonItem(const QLineF& pLine, const qreal& pWidth);

--- a/src/domain/UBGraphicsStrokesGroup.h
+++ b/src/domain/UBGraphicsStrokesGroup.h
@@ -36,9 +36,8 @@
 #include "core/UB.h"
 #include "UBItem.h"
 
-class UBGraphicsStrokesGroup : public QObject, public QGraphicsItemGroup, public UBItem, public UBGraphicsItem
+class UBGraphicsStrokesGroup : public QGraphicsItemGroup, public UBItem, public UBGraphicsItem
 {
-    Q_OBJECT
 public:
     enum colorType {
         currentColor = 0

--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -90,6 +90,8 @@ UBBoardThumbnailsView::UBBoardThumbnailsView(QWidget *parent, const char *name)
     connect(UBApplication::boardController, SIGNAL(pageSelectionChanged(int)), this, SLOT(ensureVisibleThumbnail(int)), Qt::UniqueConnection);
     connect(UBApplication::boardController, SIGNAL(centerOnThumbnailRequired(int)), this, SLOT(centerOnThumbnail(int)), Qt::UniqueConnection);
 
+    connect(UBApplication::boardController->controlView(), &UBBoardView::mouseReleased, this, &UBBoardThumbnailsView::adjustThumbnail);
+
     connect(UBApplication::boardController->controlView(), &UBBoardView::painted, this, &UBBoardThumbnailsView::updateThumbnailPixmap);
 }
 
@@ -103,6 +105,14 @@ void UBBoardThumbnailsView::moveThumbnail(int from, int to)
 void UBBoardThumbnailsView::updateThumbnails()
 {
     updateThumbnailsPos();
+}
+
+void UBBoardThumbnailsView::adjustThumbnail()
+{
+    if (mCurrentIndex >= 0 && mCurrentIndex < mThumbnails.size())
+    {
+        mThumbnails.at(mCurrentIndex)->adjustThumbnail();
+    }
 }
 
 void UBBoardThumbnailsView::removeThumbnail(int i)
@@ -120,9 +130,10 @@ void UBBoardThumbnailsView::removeThumbnail(int i)
 
 UBDraggableLivePixmapItem* UBBoardThumbnailsView::createThumbnail(std::shared_ptr<UBDocumentProxy> document, int i)
 {
-    std::shared_ptr<UBGraphicsScene> pageScene = UBPersistenceManager::persistenceManager()->loadDocumentScene(document, i);
+    std::shared_ptr<UBGraphicsScene> pageScene = UBPersistenceManager::persistenceManager()->getDocumentScene(document, i);
+    QPixmap thumbnail = UBThumbnailAdaptor::get(document, i);
 
-    return new UBDraggableLivePixmapItem(pageScene, document, i);
+    return new UBDraggableLivePixmapItem(pageScene, document, i, thumbnail);
 }
 
 void UBBoardThumbnailsView::addThumbnail(std::shared_ptr<UBDocumentProxy> document, int i)
@@ -173,7 +184,21 @@ void UBBoardThumbnailsView::centerOnThumbnail(int index)
 
 void UBBoardThumbnailsView::ensureVisibleThumbnail(int index)
 {
-    ensureVisible(mThumbnails.at(index));
+    if (mCurrentIndex >= 0 && mCurrentIndex < mThumbnails.size())
+    {
+        // detach scene from previous thumbnail
+        mThumbnails.at(mCurrentIndex)->setScene(nullptr);
+    }
+
+    mCurrentIndex = index;
+
+    if (index >= 0 && index < mThumbnails.size())
+    {
+        auto thumbnail = mThumbnails.at(index);
+        std::shared_ptr<UBGraphicsScene> pageScene = UBPersistenceManager::persistenceManager()->getDocumentScene(thumbnail->documentProxy(), index);
+        thumbnail->setScene(pageScene);
+        ensureVisible(thumbnail);
+    }
 }
 
 void UBBoardThumbnailsView::updateThumbnailsPos()

--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -139,6 +139,7 @@ void UBBoardThumbnailsView::addThumbnail(std::shared_ptr<UBDocumentProxy> docume
 {
     UBDraggableLivePixmapItem* item = createThumbnail(document, i);
     mThumbnails.insert(i, item);
+    ensureVisibleThumbnail(i);
 
     scene()->addItem(item);
     scene()->addItem(item->pageNumber());

--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -130,10 +130,9 @@ void UBBoardThumbnailsView::removeThumbnail(int i)
 
 UBDraggableLivePixmapItem* UBBoardThumbnailsView::createThumbnail(std::shared_ptr<UBDocumentProxy> document, int i)
 {
-    std::shared_ptr<UBGraphicsScene> pageScene = UBPersistenceManager::persistenceManager()->getDocumentScene(document, i);
     QPixmap thumbnail = UBThumbnailAdaptor::get(document, i);
 
-    return new UBDraggableLivePixmapItem(pageScene, document, i, thumbnail);
+    return new UBDraggableLivePixmapItem(nullptr, document, i, thumbnail);
 }
 
 void UBBoardThumbnailsView::addThumbnail(std::shared_ptr<UBDocumentProxy> document, int i)

--- a/src/gui/UBBoardThumbnailsView.h
+++ b/src/gui/UBBoardThumbnailsView.h
@@ -55,6 +55,7 @@ public slots:
     void moveThumbnail(int from, int to);
     void removeThumbnail(int i);
     void updateThumbnails();
+    void adjustThumbnail();
 
     void longPressTimeout();
     void mousePressAndHoldEvent(QPoint pos);
@@ -95,6 +96,8 @@ private:
     int mLongPressInterval;
     QTimer mLongPressTimer;
     QPoint mLastPressedMousePos;
+
+    int mCurrentIndex{-1};
 };
 
 #endif // UBBOARDTHUMBNAILSVIEW_H

--- a/src/gui/UBThumbnailWidget.cpp
+++ b/src/gui/UBThumbnailWidget.cpp
@@ -957,7 +957,12 @@ void UBDraggableThumbnailItem::paint(QPainter *painter, const QStyleOptionGraphi
     using namespace UBThumbnailUI;
 
     if (editable())
-    {        
+    {
+        // apply inverse scaling to keep constant size of buttons
+        painter->save();
+        auto scale = 1 / transform().m11();
+        painter->scale(scale, scale);
+
         if(deletable())
             draw(painter, *getIcon("close"));
         else
@@ -976,7 +981,7 @@ void UBDraggableThumbnailItem::paint(QPainter *painter, const QStyleOptionGraphi
         else
             draw(painter, *getIcon("moveDownDisabled"));
         */
-
+        painter->restore();
     }
 }
 
@@ -1061,7 +1066,7 @@ void UBDraggableThumbnailItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event
 }
 
 
-UBDraggableLivePixmapItem::UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsScene> pageScene, std::shared_ptr<UBDocumentProxy> documentProxy, int index)
+UBDraggableLivePixmapItem::UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsScene> pageScene, std::shared_ptr<UBDocumentProxy> documentProxy, int index, const QPixmap& thumbnail)
     : UBDraggableThumbnailItem(documentProxy, index)
     , mScene(pageScene)
     , mPageNumber(new UBThumbnailTextItem(index))
@@ -1069,6 +1074,7 @@ UBDraggableLivePixmapItem::UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsS
 {
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setAcceptDrops(true);
+    setTransformationMode(Qt::SmoothTransformation);
 
     mSelectionItem = new QGraphicsRectItem(sceneBoundingRect().x() - sSelectionItemMargin,
                                            sceneBoundingRect().y() - sSelectionItemMargin,
@@ -1077,44 +1083,24 @@ UBDraggableLivePixmapItem::UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsS
     mSelectionItem->setPen(QPen(UBSettings::treeViewBackgroundColor, 8));
     mSelectionItem->setZValue(-1);
 
-    connect(&updateTimer, &QTimer::timeout, this, [this](){
-        updatePixmap();
-
-        if (--updateCount <= 0)
-        {
-            updateTimer.stop();
-        }
-    });
+    setPixmap(thumbnail);
 }
 
 void UBDraggableLivePixmapItem::updatePos(qreal width, qreal height)
 {
     QSizeF newSize(width, height);
 
-    if (newSize != mSize)
+    if (newSize != mSize && mScene)
     {
         mSize = newSize;
-        QPixmap pixmap = QPixmap(mSize.toSize());
-        pixmap.fill(Qt::white);
-        setPixmap(pixmap);
-        updatePixmap();
-
-        QRectF sceneRect(QPointF(0, 0), mScene->sceneSize());
-        sceneRect.translate(-sceneRect.center());
-        QSizeF sceneSize = mSize.scaled(sceneRect.size(), Qt::KeepAspectRatioByExpanding);
-        QSizeF expand = (sceneSize - sceneRect.size()) / 2;
-        QMarginsF margins(expand.width(), expand.height(), expand.width(), expand.height());
-
-        mTransform = QTransform();
-        mTransform.scale(mSize.width() / sceneSize.width(), mSize.height() / sceneSize.height());
-        mTransform.translate(sceneSize.width() / 2, sceneSize.height() / 2);
+        createPixmap(newSize);
     }
 
     QFontMetrics fm(mPageNumber->font());
     int labelSpacing = UBSettings::thumbnailSpacing + fm.height();
 
-    int w = boundingRect().width();
-    int h = boundingRect().height();
+    int w = pixmap().width();
+    int h = pixmap().height();
 
     qreal scaledWidth = width / w;
     qreal scaledHeight = height / h;
@@ -1127,8 +1113,9 @@ void UBDraggableLivePixmapItem::updatePos(qreal width, qreal height)
     setTransform(transform);
     setFlag(QGraphicsItem::ItemIsSelectable, true);
 
-    // even spacing, all thumbnails have the same size
-    QPointF position(2*sSelectionItemMargin, 2*sSelectionItemMargin + sceneIndex() * (height + labelSpacing) + (height - h * scaledFactor) / 2);
+    // even spacing, all thumbnails have the same height
+    QPointF position(2 * sSelectionItemMargin + (width - w * scaledFactor) / 2,
+                     2 * sSelectionItemMargin + sceneIndex() * (height + labelSpacing) + (height - h * scaledFactor) / 2);
 
     setPos(position);
 
@@ -1164,14 +1151,6 @@ void UBDraggableLivePixmapItem::setExposed(bool exposed)
         if (exposed)
         {
             updatePixmap();
-
-            // start a burst of updates to follow PDF loading or similar
-            updateCount = 10;
-            updateTimer.start(300);
-        }
-        else
-        {
-            updateTimer.stop();
         }
     }
 }
@@ -1183,7 +1162,7 @@ bool UBDraggableLivePixmapItem::isExposed()
 
 void UBDraggableLivePixmapItem::updatePixmap(const QRectF &region)
 {
-    if (mSize.isValid() && mExposed)
+    if (mScene && mSize.isValid() && mExposed)
     {
         QPixmap pixmap = this->pixmap();
         QRectF pixmapRect;
@@ -1193,7 +1172,7 @@ void UBDraggableLivePixmapItem::updatePixmap(const QRectF &region)
         if (region.isNull() || affectsWholeScene)
         {
             // full update if region unknown or play/selector tool active, which may affect whole scene
-            pixmapRect = QRectF(QPoint(0, 0), mSize);
+            pixmapRect = pixmap.rect();
         }
         else
         {
@@ -1207,7 +1186,7 @@ void UBDraggableLivePixmapItem::updatePixmap(const QRectF &region)
             pixmapRect = mTransform.mapRect(region);        // translate to pixmap coordinates
             pixmapRect += QMarginsF(1, 1, 1, 1);            // add a margin
             pixmapRect = pixmapRect.toRect();               // cut to integer
-            pixmapRect &= QRectF(QPointF(0, 0), mSize);     // limit to pixmap area
+            pixmapRect &= pixmap.rect();                    // limit to pixmap area
         }
 
         if (pixmapRect.isValid())
@@ -1220,7 +1199,54 @@ void UBDraggableLivePixmapItem::updatePixmap(const QRectF &region)
     }
 }
 
+void UBDraggableLivePixmapItem::setScene(std::shared_ptr<UBGraphicsScene> scene)
+{
+    mScene = scene;
+}
 
+void UBDraggableLivePixmapItem::adjustThumbnail()
+{
+    // get the used area of the scene
+    mSceneRect = mScene->normalizedSceneRect();
+
+    // expand the scene rect so that it has the aspect ratio of the pixmap
+    QSizeF pSize = pixmap().size();
+    QPointF center = mSceneRect.center();
+    QSizeF sceneSize = pSize.scaled(mSceneRect.size(), Qt::KeepAspectRatioByExpanding);
+    mSceneRect.setSize(sceneSize);
+    mSceneRect.moveCenter(center);
+
+    // create a transformation from scene to pixmap coordinates
+    QRectF pixRect{{0,0}, pSize};
+    QPolygonF p1{mSceneRect};
+    QPolygonF p2{pixRect};
+
+    p1.removeLast();
+    p2.removeLast();
+
+    QTransform::quadToQuad(p1, p2, mTransform);
+
+    // re-paint the pixmap
+    updatePixmap();
+}
+
+void UBDraggableLivePixmapItem::createPixmap(const QSizeF& pixmapSize)
+{
+    if (mScene)
+    {
+        // always use a constant pixmap size
+        // NOTE this code keeps the document pixmap incl its AR
+        if (pixmap().width() != UBSettings::maxThumbnailWidth)
+        {
+            int height = UBSettings::maxThumbnailWidth * mSize.height() / mSize.width() + 0.5;
+            QPixmap pixmap = QPixmap(UBSettings::maxThumbnailWidth, height);
+            pixmap.fill(Qt::white);
+            setPixmap(pixmap);
+        }
+
+        adjustThumbnail();
+    }
+}
 
 
 UBThumbnailUI::UBThumbnailUIIcon* UBThumbnailUI::addIcon(const QString& thumbnailIcon, int pos)

--- a/src/gui/UBThumbnailWidget.h
+++ b/src/gui/UBThumbnailWidget.h
@@ -574,7 +574,7 @@ class UBDraggableLivePixmapItem : public UBDraggableThumbnailItem
 {
     Q_OBJECT
     public:
-        UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsScene> pageScene, std::shared_ptr<UBDocumentProxy> documentProxy, int index);
+        UBDraggableLivePixmapItem(std::shared_ptr<UBGraphicsScene> pageScene, std::shared_ptr<UBDocumentProxy> documentProxy, int index, const QPixmap& thumbnail);
 
         ~UBDraggableLivePixmapItem()
         {
@@ -611,17 +611,21 @@ class UBDraggableLivePixmapItem : public UBDraggableThumbnailItem
 
     public slots:
         void updatePixmap(const QRectF &region = QRectF());
+        void setScene(std::shared_ptr<UBGraphicsScene> scene);
+        void adjustThumbnail();
+
+    private:
+        void createPixmap(const QSizeF& pixmapSize);
 
     private:
         static const int sSelectionItemMargin = 5;
         QGraphicsRectItem *mSelectionItem;
         std::shared_ptr<UBGraphicsScene> mScene;
+        QRectF mSceneRect;
         UBThumbnailTextItem* mPageNumber;
         bool mExposed;
         QSizeF mSize;
         QTransform mTransform;
-        QTimer updateTimer;
-        int updateCount;
 };
 
 namespace UBThumbnailUI


### PR DESCRIPTION
This PR aims to improve performance of scene handling especially with documents with many pages, where each page has many items. This occurs when pages contain a lot of handwriting. Such scenes could be several megabytes as SVG and also occupy a lot of memory when loaded as scene.

Also loading of such pages takes considerable time. Since **all** pages of a document are currently loaded when the document is opened in order to assign the scenes to the board thumbnails, opening such heavy documents can currently take many seconds.

Currently the scene cache only grows. Scenes are never deleted from the cache. This can lead to memory exhaustion and crashing of OpenBoard.

The PR implements the following in three commits:

- The first commit addresses the long loading times when opening a document. As we have thumbnails for all pages available in the document folder, we can initially start to use these thumbnails for all pages except the current one. Only the current page thumbnail is associated with the corresponding scene and updated when the scene changes. All other thumbnails are not associated with any scene and just use the last status of the pixmap. This improves the time needed to open a document. Detaching scenes from thumbnails also avoids that releasing a scene is blocked by a pointer from the thumbnail to the scene. 
- The second commit enables predictive loading of scenes in the background. Currently there was some (unused) attempt to at least read the files on another thread in the background. We now construct scenes on the main thread, but in small steps, which are executed whenever the main thread is idle. This avoids any complexity with multi-threading. Due to the Qt internal implementation of `QGraphicsItem` data it is impossible to construct these objects on another thread, so this approach is the only possible solution. We now load the previous, next and next but one scene using this approach, which leads to a smooth page change behavior even on heavy documents. At the same time, we re-enable a cache size limit (default: 20 scenes) to limit memory usage. The already implemented LRU policy in the scene cache is re-enabled.
- The third commit removes the now obsolete code for loading scene data in a worker thread.

For me this PR fixes #918 and #921, but I would like to have more testers.