### PR TITLE
fix: Enable use of C++20 for compatibility with poppler 24.05

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ set(OPENBOARD_MIMEICON_FILE resources/linux/ch.openboard.application-ubz.svg)
 # Basic compiler settings
 # ==========================================================================
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to use - defaults to C++17")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -88,6 +88,8 @@ set(CMAKE_AUTOUIC ON)
 list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS 
     ${OPENBOARD_FORMS_DIR}
 )
+
+message(STATUS "Using C++" ${CMAKE_CXX_STANDARD})
 
 # OpenMP support
 include(FindOpenMP)


### PR DESCRIPTION
Poppler uses [`std::string::starts_with`](https://en.cppreference.com/w/cpp/string/basic_string/starts_with) since [poppler/poppler@fbb645](https://gitlab.freedesktop.org/poppler/poppler/-/commit/fbb64544e5ea25ac9b1bd25b48043d074efe9cd9). This commit (fbb645) is included in `poppler 24.05`. This change also affects the public headers of GooString, which means that all projects depending on `poppler` need to be aware of `std::string::starts_with`, even if they don't use it themselves.

`std::string::starts_with` is new with C++ 20 (see above), which means that OpenBoard must also be compiled with C++ 20. Otherwise, this error occurs:
```
/usr/include/poppler/goo/GooString.h:241:24: error: ‘starts_with’ has not been declared in ‘std::string’
  241 |     using std::string::starts_with;
      |                        ^~~~~~~~~~~
```

### Possible solutions
1. Make CMAKE_CXX_STANDARD a cache variable. This makes it easier to override for the Arch package (and in the future), while additional support burden is low. Does make the build system more complex.
2. Change CMAKE_CXX_STANDARD depending on version of `poppler`. I haven't found a way to cleanly achieve this. Might mean that devs have to test with different versions of poppler.
3. Simply bump the CMAKE_CXX_STANDARD to 20 from 17. While C++20 is considered [experimental within GCC](https://gcc.gnu.org/projects/cxx-status.html#cxx20), GCC 11 is _probably_ fine. Still means that some distributions would have to be dropped.

### Solution presented in this PR
~Solution 3 is the most straightforward fix, so this is chosen here.~
**Edit:** Changed to solution 1 since dropping support for older distros like Ubuntu 20.04 is undesirable. It's also more flexible considering that this situation already occurred with the transition to C++17.

### Conclusion
OpenBoard will eventually have to move on to C++ 20. Support for that is mostly complete in GCC, but still considered experimental. Poppler already requires it to build starting with 24.05, which afaics is only packaged with Arch Linux at this stage. Naturally, this will change in the future.

Fixes #958 

Suggestions and feedback are always welcome!\
-- Vekhir