### PR TITLE
Refactor zoombehavior and xpdf minor cleanup.

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -123,14 +123,12 @@ VideosDirectory=./library/videos
 RefreshRateInFramePerSecond=2
 
 [PDF]
-enableQualityLossToIncreaseZoomPerfs=true
 ExportBackgroundGrid=false
 ExportBackgroundColor=false
 Margin=20
 PageFormat=A4
 Resolution=300
 UsePDFMerger=true
-ZoomBehavior=4
 
 [Podcast]
 AudioRecordingDevice=Default

--- a/resources/forms/preferences.ui
+++ b/resources/forms/preferences.ui
@@ -137,16 +137,6 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
-               <widget class="QCheckBox" name="enableQualityLossToIncreaseZoomPerfs">
-                <property name="text">
-                 <string>Improve zoom execution time (can slightly affect rendering quality)</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
               <item row="4" column="0">
                <widget class="QCheckBox" name="exportBackgroundColor">
                 <property name="text">

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -176,8 +176,6 @@ void UBPreferencesController::wire()
     connect(mPreferencesUI->useSystemOSKCheckBox, SIGNAL(clicked(bool)), this, SLOT(systemOSKCheckBoxToggled(bool)));
 
     // PDF preferences
-    connect(mPreferencesUI->enableQualityLossToIncreaseZoomPerfs, SIGNAL(clicked(bool)), settings->enableQualityLossToIncreaseZoomPerfs, SLOT(setBool(bool)));
-    connect(mPreferencesUI->enableQualityLossToIncreaseZoomPerfs, SIGNAL(clicked(bool)), this, SLOT(setPdfZoomBehavior(bool)));
     connect(mPreferencesUI->exportBackgroundGrid, SIGNAL(clicked(bool)), settings->exportBackgroundGrid, SLOT(setBool(bool)));
     connect(mPreferencesUI->exportBackgroundColor, SIGNAL(clicked(bool)), settings->exportBackgroundColor, SLOT(setBool(bool)));
 
@@ -317,7 +315,6 @@ void UBPreferencesController::init()
     mPreferencesUI->useSystemOSKCheckBox->setChecked(settings->useSystemOnScreenKeyboard->get().toBool());
     this->systemOSKCheckBoxToggled(mPreferencesUI->useSystemOSKCheckBox->isChecked());
 
-    mPreferencesUI->enableQualityLossToIncreaseZoomPerfs->setChecked(settings->enableQualityLossToIncreaseZoomPerfs->get().toBool());
     mPreferencesUI->exportBackgroundGrid->setChecked(settings->exportBackgroundGrid->get().toBool());
     mPreferencesUI->exportBackgroundColor->setChecked(settings->exportBackgroundColor->get().toBool());
 
@@ -395,7 +392,6 @@ void UBPreferencesController::defaultSettings()
         mPreferencesUI->showDateColumnOnAlphabeticalSort->setChecked(settings->showDateColumnOnAlphabeticalSort->reset().toBool());
         UBApplication::documentController->refreshDateColumns();
 
-        mPreferencesUI->enableQualityLossToIncreaseZoomPerfs->setChecked(settings->enableQualityLossToIncreaseZoomPerfs->reset().toBool());
         mPreferencesUI->exportBackgroundGrid->setChecked(settings->exportBackgroundGrid->reset().toBool());
         mPreferencesUI->exportBackgroundColor->setChecked(settings->exportBackgroundColor->reset().toBool());
 
@@ -698,18 +694,6 @@ void UBPreferencesController::systemOSKCheckBoxToggled(bool checked)
 {
     mPreferencesUI->keyboardPaletteKeyButtonSize->setVisible(!checked);
     mPreferencesUI->keyboardPaletteKeyButtonSize_Label->setVisible(!checked);
-}
-
-void UBPreferencesController::setPdfZoomBehavior(bool checked)
-{
-    if (checked)
-    {
-        UBSettings::settings()->pdfZoomBehavior->setInt(4);// Multithreaded, several steps, downsampled.
-    }
-    else
-    {
-        UBSettings::settings()->pdfZoomBehavior->setInt(0);//Old behavior. To remove if no issues found with the other mode
-    }
 }
 
 UBBrushPropertiesFrame::UBBrushPropertiesFrame(QFrame* owner, const QList<QColor>& lightBackgroundColors,

--- a/src/core/UBPreferencesController.h
+++ b/src/core/UBPreferencesController.h
@@ -104,7 +104,6 @@ class UBPreferencesController : public QObject
         void toolbarOrientationVertical(bool checked);
         void toolbarOrientationHorizontal(bool checked);
         void systemOSKCheckBoxToggled(bool checked);
-        void setPdfZoomBehavior(bool checked);
 
     private slots:
         void adjustScreensPreferences();

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -424,8 +424,6 @@ void UBSettings::init()
     pdfUsePDFMerger = new UBSetting(this, "PDF", "UsePDFMerger", "true");
     pdfResolution = new UBSetting(this, "PDF", "Resolution", "300");
 
-    pdfZoomBehavior = new UBSetting(this, "PDF", "ZoomBehavior", "4");
-    enableQualityLossToIncreaseZoomPerfs = new UBSetting(this, "PDF", "enableQualityLossToIncreaseZoomPerfs", true);
     exportBackgroundGrid = new UBSetting(this, "PDF", "ExportBackgroundGrid", false);
     exportBackgroundColor = new UBSetting(this, "PDF", "ExportBackgroundColor", false);
 

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -369,8 +369,6 @@ class UBSettings : public QObject
         UBSetting* pdfUsePDFMerger;
         UBSetting* pdfResolution;
 
-        UBSetting* pdfZoomBehavior;
-        UBSetting* enableQualityLossToIncreaseZoomPerfs;
         UBSetting* exportBackgroundGrid;
         UBSetting* exportBackgroundColor;
 

--- a/src/pdf/XPDFRenderer.cpp
+++ b/src/pdf/XPDFRenderer.cpp
@@ -32,9 +32,7 @@
 #include <QtGui>
 
 #include <frameworks/UBPlatformUtils.h>
-#ifndef USE_XPDF
-    #include <poppler/cpp/poppler-version.h>
-#endif
+#include <poppler/cpp/poppler-version.h>
 
 #include "core/memcheck.h"
 #include "core/UBSettings.h"
@@ -64,9 +62,7 @@ XPDFRenderer::XPDFRenderer(const QString &filename, bool importingFile)
 #endif
         globalParams->setupBaseFonts(QFile::encodeName(UBPlatformUtils::applicationResourcesDirectory() + "/" + "fonts").data());
     }
-#ifdef USE_XPDF
-    mDocument = new PDFDoc(new GString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
-#elif POPPLER_VERSION_MAJOR > 22 || (POPPLER_VERSION_MAJOR == 22 && POPPLER_VERSION_MINOR >= 3)
+#if POPPLER_VERSION_MAJOR > 22 || (POPPLER_VERSION_MAJOR == 22 && POPPLER_VERSION_MINOR >= 3)
     mDocument = new PDFDoc(std::make_unique<GooString>(filename.toLocal8Bit()));
 #else
     mDocument = new PDFDoc(new GooString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction
@@ -239,11 +235,8 @@ QImage* XPDFRenderer::createPDFImageHistorical(int pageNumber, qreal xscale, qre
             delete mSplashHistorical;
 
         mSplashHistorical = new SplashOutputDev(splashModeRGB8, 1, false, constants::paperColor);
-#ifdef USE_XPDF
-        mSplashHistorical->startDoc(mDocument->getXRef());
-#else
         mSplashHistorical->startDoc(mDocument);
-#endif
+
         int rotation = 0; // in degrees (get it from the worldTransform if we want to support rotation)
         bool useMediaBox = false;
         bool crop = true;
@@ -451,12 +444,7 @@ void XPDFRenderer::CacheThread::run()
              << "ratio" << jobData.cacheData->ratio; */
 
     jobData.cacheData->prepareNewSplash(jobData.pageNumber, constants::paperColor);
-
-#ifdef USE_XPDF
-    jobData.cacheData->splash->startDoc(jobData.document->getXRef());
-#else
     jobData.cacheData->splash->startDoc(jobData.document);
-#endif
 
     m_jobMutex.unlock();
 

--- a/src/pdf/XPDFRenderer.h
+++ b/src/pdf/XPDFRenderer.h
@@ -48,15 +48,9 @@ class PDFDoc;
 
 namespace XPDFRendererZoomFactor
 {
-    const double mode1_zoomFactor = 3.0;
-    const double mode2_zoomFactorStage1 = 2.5;
-    const double mode2_zoomFactorStage2 = 5.0;
-    const double mode2_zoomFactorStage3 = 10.0;
-    const double mode3_zoomFactorStage1 = 1.0;
-    const double mode3_zoomFactorStage2 = 3.0;
-    const double mode4_zoomFactorStart = .25;
-    const double mode4_zoomFactorStepSquare = .25;
-    const double mode4_zoomFactorIterations = 7;
+    const double zoomFactorStart = .25;
+    const double zoomFactorStepSquare = .25;
+    const double zoomFactorIterations = 7;
 }
 
 namespace XPDFThreadMaxTimeoutOnExit
@@ -154,20 +148,14 @@ class XPDFRenderer : public PDFRenderer
         CacheThread m_cacheThread;
 
         QImage &createPDFImageCached(int pageNumber, PdfZoomCacheData &cacheData);
-        QImage* createPDFImageHistorical(int pageNumber, qreal xscale, qreal yscale, const QRectF &bounds);
+        QImage* createPDFImageUncached(int pageNumber, qreal xscale, qreal yscale, const QRectF &bounds);
 
-        // Used when 'ZoomBehavior == 1, 2, 3 or 4'.
-        // =1 has only x3 zoom in cache (= loss if user zoom > 3.0).
-        // =2, has 2.5, 5 and 10 (= no loss, but a bit slower).
-        // =3, has 1.0, 2.5, 5 and 10, but downsampled instead of upsampled (= minor quality loss, a bit faster).
-        // =4, multithreaded, multiple level of zoom.
         QMap<int, QVector<PdfZoomCacheData>> m_perPagepdfZoomCache;
-        int const m_pdfZoomMode;
 
-        // Used when 'ZoomBehavior == 0' (no cache).
-        SplashBitmap* mpSplashBitmapHistorical;
-        // Used when 'ZoomBehavior == 0' (no cache).
-        SplashOutputDev* mSplashHistorical;
+        // Used when no cache allowed (e.g. rendering to a file).
+        SplashBitmap* mpSplashBitmapUncached;
+        // Used when no cache allowed (e.g. rendering to a file).
+        SplashOutputDev* mSplashUncached;
 
         PDFDoc *mDocument;
         static QAtomicInt sInstancesCount;


### PR DESCRIPTION
As ZoomBehavior 4 proven satisfactory, the modes 3 to 0 have been removed, and the code cleaned up.
Additionally, since the move to Poppler on Windows, some obsolete USE_XPDF sections have been removed.