### PR TITLE
Paste in the middle of current view, not in the center

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 OpenBoard is an open source cross-platform interactive white board application designed primarily for use in schools. It was originally forked from Open-Sankoré, which was itself based on Uniboard.
 
 ### Installing
-1.7.0 installers are available for Windows, OS X and Ubuntu on the [Download's page](https://github.com/OpenBoard-org/OpenBoard/wiki/Downloads).
+1.7.1 installers are available for Windows, OS X and Ubuntu on the [Download's page](https://github.com/OpenBoard-org/OpenBoard/wiki/Downloads).
 
 ### Supported platforms 
 

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2414,8 +2414,12 @@ void UBBoardController::paste()
     QClipboard *clipboard = QApplication::clipboard();
     qreal xPosition = ((qreal)QRandomGenerator::global()->bounded(RAND_MAX)/(qreal)RAND_MAX) * 400;
     qreal yPosition = ((qreal)QRandomGenerator::global()->bounded(RAND_MAX)/(qreal)RAND_MAX) * 200;
-    QPointF pos(xPosition -200 , yPosition - 100);
-    processMimeData(clipboard->mimeData(), pos);
+    QPointF randomPos(xPosition -200 , yPosition - 100);
+    QRect rect = mControlView->rect();
+    QPoint center(rect.x() + rect.width() / 2, rect.y() + rect.height() / 2);
+    QPointF viewRelativeCenter = mControlView->mapToScene(center);
+
+    processMimeData(clipboard->mimeData(), viewRelativeCenter + randomPos);
 
     QDateTime now = QDateTime::currentDateTime();
     selectedDocument()->setMetaData(UBSettings::documentUpdatedAt, UBStringUtils::toUtcIsoDateTime(now));


### PR DESCRIPTION
When for example an image is pasted into the current document, it always lands in the center of it, regardless of where the user's view is located. This might be unintuitive for some users, who would expect the newly-pasted image to pop up on their screen, regardless of which part of the document they are looking at, and not have to scroll back to the document's center. This pull request fixes this issue.