### PR TITLE
fix: export axes to PDF

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -776,7 +776,6 @@ std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScen
                 if (axes)
                 {
                     mScene->addItem(axes);
-                    mScene->registerTool(axes);
                 }
 
             }

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2214,7 +2214,6 @@ void UBGraphicsScene::addRuler(QPointF center)
 void UBGraphicsScene::addAxes(QPointF center)
 {
     UBGraphicsAxes* axes = new UBGraphicsAxes(); // mem : owned and destroyed by the scene
-    mTools << axes;
 
     axes->setData(UBGraphicsItemData::ItemLayerType, QVariant(UBItemLayerType::Tool));
 


### PR DESCRIPTION
When exporting a document containing axes to PDF, the axes are not exported. They are currently treated as a tool like the ruler or compass, which do not belong to the page content. However he axes are different. They are an integral part of the page content and should be exported.

This PR avoids registering axes as a tool when creating them and when loading a document page containing axes.

This PR is related to #924. It only addresses the axes tool, where it is evident that it is part of the page content. For other tools like ruler, protractor or triangle it can still be discussed whether they should be part of the PDF export.