### PR TITLE
Fix qt and c++ warnings

### DIFF
--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -631,7 +631,7 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parsePageset(const QStringList &page
 
     QDomElement svgPagesetElement = mDocumentToWrite->createElementNS(svgIWBNS,":"+ tIWBPageSet);
 
-    for (const auto &value : qAsConst(pageList)) {
+    for (const auto &value : std::as_const(pageList)) {
         svgPagesetElement.appendChild(value);
     }
 
@@ -680,7 +680,7 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parseSvgPageSection(const QDomElemen
     // to do:
     // there we must to sort elements (take elements from list and assign parent ordered like in parseSVGGGroup)
     // we returns just element because we don't care about layer.
-    for (const auto &value : qAsConst(svgElements)) {
+    for (const auto &value : std::as_const(svgElements)) {
         svgElementPart.appendChild(value);
     }
  
@@ -1612,7 +1612,7 @@ bool UBCFFAdaptor::UBToCFFConverter::parseSVGGGroup(const QDomElement &element, 
     std::sort(layers.begin(), layers.end());
     int layer = layers.at(0);
 
-    for (const auto &value : qAsConst(svgElements)) {
+    for (const auto &value : std::as_const(svgElements)) {
         svgElementPart.appendChild(value);
     }
 

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -551,14 +551,22 @@ std::shared_ptr<UBGraphicsScene> UBSvgSubsetAdaptor::UBSvgSubsetReader::loadScen
 
                 if (!ubFillOnDarkBackground.isNull())
                 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+                    mGroupDarkBackgroundColor = QColor::fromString(ubFillOnDarkBackground.toString());
+#else
                     mGroupDarkBackgroundColor.setNamedColor(ubFillOnDarkBackground.toString());
+#endif
                 }
 
                 auto ubFillOnLightBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-light-background");
 
                 if (!ubFillOnLightBackground.isNull())
                 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+                    mGroupLightBackgroundColor = QColor::fromString(ubFillOnLightBackground.toString());
+#else
                     mGroupLightBackgroundColor.setNamedColor(ubFillOnLightBackground.toString());
+#endif
                 }
 
                 auto ubUuid = mXmlReader.attributes().value(mNamespaceUri, "uuid");
@@ -1785,7 +1793,11 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromPol
     QColor brushColor = pDefaultColor;
 
     if (!svgFill.isNull())
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        brushColor = QColor::fromString(svgFill.toString());
+#else
         brushColor.setNamedColor(svgFill.toString());
+#endif
 
     auto svgFillOpacity = mXmlReader.attributes().value("fill-opacity");
     qreal opacity = 1.0;
@@ -1802,8 +1814,12 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromPol
 
     if (!ubFillOnDarkBackground.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(ubFillOnDarkBackground.toString());
+#else
         QColor color;
         color.setNamedColor(ubFillOnDarkBackground.toString());
+#endif
         if (!color.isValid())
             color = Qt::white;
 
@@ -1821,8 +1837,12 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromPol
 
     if (!ubFillOnLightBackground.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(ubFillOnLightBackground.toString());
+#else
         QColor color;
         color.setNamedColor(ubFillOnLightBackground.toString());
+#endif
         if (!color.isValid())
             color = Qt::black;
         color.setAlphaF(opacity);
@@ -1891,7 +1911,11 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromLin
 
     if (!svgStroke.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        brushColor = QColor::fromString(svgStroke.toString());
+#else
         brushColor.setNamedColor(svgStroke.toString());
+#endif
 
     }
 
@@ -1910,8 +1934,12 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromLin
 
     if (!ubFillOnDarkBackground.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(ubFillOnDarkBackground.toString());
+#else
         QColor color;
         color.setNamedColor(ubFillOnDarkBackground.toString());
+#endif
         if (!color.isValid())
             color = Qt::white;
 
@@ -1929,8 +1957,12 @@ UBGraphicsPolygonItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItemFromLin
 
     if (!ubFillOnLightBackground.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(ubFillOnLightBackground.toString());
+#else
         QColor color;
         color.setNamedColor(ubFillOnLightBackground.toString());
+#endif
         if (!color.isValid())
             color = Qt::black;
         color.setAlphaF(opacity);
@@ -1962,7 +1994,11 @@ QList<UBGraphicsPolygonItem*> UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItem
     auto svgStroke = mXmlReader.attributes().value("stroke");
     if (!svgStroke.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        brushColor = QColor::fromString(svgStroke.toString());
+#else
         brushColor.setNamedColor(svgStroke.toString());
+#endif
     }
 
     qreal opacity = 1.0;
@@ -1988,7 +2024,11 @@ QList<UBGraphicsPolygonItem*> UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItem
     auto ubFillOnDarkBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-dark-background");
     if (!ubFillOnDarkBackground.isNull())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        colorOnDarkBackground = QColor::fromString(ubFillOnDarkBackground.toString());
+#else
         colorOnDarkBackground.setNamedColor(ubFillOnDarkBackground.toString());
+#endif
     }
 
     if (!colorOnDarkBackground.isValid())
@@ -2001,8 +2041,11 @@ QList<UBGraphicsPolygonItem*> UBSvgSubsetAdaptor::UBSvgSubsetReader::polygonItem
     auto ubFillOnLightBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-light-background");
     if (!ubFillOnLightBackground.isNull())
     {
-        QColor colorOnLightBackground;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        colorOnLightBackground = QColor::fromString(ubFillOnLightBackground.toString());
+#else
         colorOnLightBackground.setNamedColor(ubFillOnLightBackground.toString());
+#endif
     }
 
     if (!colorOnLightBackground.isValid())
@@ -2764,16 +2807,24 @@ UBGraphicsTextItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::textItemFromSvg()
     auto ubFillOnLightBackground = mXmlReader.attributes().value(mNamespaceUri, "fill-on-light-background");
 
     if (!ubFillOnDarkBackground.isNull()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(ubFillOnDarkBackground.toString());
+#else
         QColor color;
         color.setNamedColor(ubFillOnDarkBackground.toString());
+#endif
         if (!color.isValid())
             color = Qt::white;
         textItem->setColorOnDarkBackground(color);
     }
 
     if (!ubFillOnLightBackground.isNull()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(ubFillOnLightBackground.toString());
+#else
         QColor color;
         color.setNamedColor(ubFillOnLightBackground.toString());
+#endif
         if (!color.isValid())
             color = Qt::black;
         textItem->setColorOnLightBackground(color);
@@ -2874,8 +2925,12 @@ UBGraphicsTextItem* UBSvgSubsetAdaptor::UBSvgSubsetReader::textItemFromSvg()
 
                 auto fill = mXmlReader.attributes().value("color");
                 if (!fill.isNull()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+                    QColor textColor = QColor::fromString(fill.toString());
+#else
                     QColor textColor;
                     textColor.setNamedColor(fill.toString());
+#endif
                     textItem->setDefaultTextColor(textColor);
                 }
 

--- a/src/adaptors/UBWidgetUpgradeAdaptor.cpp
+++ b/src/adaptors/UBWidgetUpgradeAdaptor.cpp
@@ -187,7 +187,7 @@ void UBWidgetUpgradeAdaptor::fillLibraryWidgets()
     widgetPaths << UBPersistenceManager::persistenceManager()->allWidgets(UBSettings::settings()->applicationInteractivesDirectory());
     widgetPaths << UBPersistenceManager::persistenceManager()->allWidgets(UBSettings::settings()->userInteractiveDirectory());
 
-    for (const QString& wigetPath : qAsConst(widgetPaths)) {
+    for (const QString& wigetPath : std::as_const(widgetPaths)) {
         Widget widget(wigetPath);
 
         if (widget.valid())

--- a/src/api/UBWidgetUniboardAPI.cpp
+++ b/src/api/UBWidgetUniboardAPI.cpp
@@ -165,8 +165,12 @@ void UBWidgetUniboardAPI::setPenColor(const QString& penColor)
     }
     else
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor svgColor = QColor::fromString(penColor);
+#else
         QColor svgColor;
         svgColor.setNamedColor(penColor);
+#endif
         if (svgColor.isValid())
         {
             UBApplication::boardController->setPenColorOnDarkBackground(svgColor);
@@ -194,8 +198,12 @@ void UBWidgetUniboardAPI::setMarkerColor(const QString& penColor)
     }
     else
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor svgColor = QColor::fromString(penColor);
+#else
         QColor svgColor;
         svgColor.setNamedColor(penColor);
+#endif
         if (svgColor.isValid())
         {
             UBApplication::boardController->setMarkerColorOnDarkBackground(svgColor);

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -405,7 +405,11 @@ void UBBoardPaletteManager::connectPalettes()
 {
     connect(UBApplication::mainWindow->actionStylus, SIGNAL(toggled(bool)), this, SLOT(toggleStylusPalette(bool)));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, UBApplication::mainWindow->actionZoomIn->associatedObjects())
+#else
     foreach(QWidget *widget, UBApplication::mainWindow->actionZoomIn->associatedWidgets())
+#endif
     {
         QAbstractButton *button = qobject_cast<QAbstractButton*>(widget);
         if (button)
@@ -415,7 +419,11 @@ void UBBoardPaletteManager::connectPalettes()
         }
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, UBApplication::mainWindow->actionZoomOut->associatedObjects())
+#else
     foreach(QWidget *widget, UBApplication::mainWindow->actionZoomOut->associatedWidgets())
+#endif
     {
         QAbstractButton *button = qobject_cast<QAbstractButton*>(widget);
         if (button)
@@ -425,7 +433,11 @@ void UBBoardPaletteManager::connectPalettes()
         }
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, UBApplication::mainWindow->actionHand->associatedObjects())
+#else
     foreach(QWidget *widget, UBApplication::mainWindow->actionHand->associatedWidgets())
+#endif
     {
         QAbstractButton *button = qobject_cast<QAbstractButton*>(widget);
         if (button)
@@ -458,7 +470,11 @@ void UBBoardPaletteManager::connectPalettes()
     connect(UBApplication::mainWindow->actionEraseBackground,SIGNAL(triggered()),mErasePalette,SLOT(close()));
     connect(mErasePalette, SIGNAL(closed()), this, SLOT(erasePaletteClosed()));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, UBApplication::mainWindow->actionErase->associatedObjects())
+#else
     foreach(QWidget *widget, UBApplication::mainWindow->actionErase->associatedWidgets())
+#endif
     {
         QAbstractButton *button = qobject_cast<QAbstractButton*>(widget);
         if (button)
@@ -473,7 +489,11 @@ void UBBoardPaletteManager::connectPalettes()
     connect(UBApplication::mainWindow->actionImportPage, SIGNAL(triggered()), mPagePalette, SLOT(close()));
     connect(mPagePalette, SIGNAL(closed()), this, SLOT(pagePaletteClosed()));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, UBApplication::mainWindow->actionPages->associatedObjects())
+#else
     foreach(QWidget *widget, UBApplication::mainWindow->actionPages->associatedWidgets())
+#endif
     {
         QAbstractButton *button = qobject_cast<QAbstractButton*>(widget);
         if (button)

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -821,7 +821,13 @@ void UBBoardView::handleItemMousePress(QMouseEvent *event)
 
         if (itemShouldReceiveSuspendedMousePressEvent(getMovingItem()))
         {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+            suspendedMousePressEvent = new QMouseEvent(event->type(), event->position(), event->globalPosition(), event->button(), event->buttons(), event->modifiers());
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            suspendedMousePressEvent = new QMouseEvent(event->type(), event->position(), event->button(), event->buttons(), event->modifiers());
+#else
             suspendedMousePressEvent = new QMouseEvent(event->type(), event->pos(), event->button(), event->buttons(), event->modifiers());
+#endif
         }
     }
 }

--- a/src/board/UBFeaturesController.cpp
+++ b/src/board/UBFeaturesController.cpp
@@ -441,7 +441,7 @@ void UBFeaturesController::scanFS()
     }
 
     QSet<QUrl> favoriteDocumentsToRemove;
-    for (auto&& favoriteElement : qAsConst(*favoriteSet))
+    for (auto&& favoriteElement : std::as_const(*favoriteSet))
     {
         if (favoriteElement.fileName().endsWith(".rdf"))
         {
@@ -462,7 +462,7 @@ void UBFeaturesController::scanFS()
         }
     }
 
-    for (auto&& favoriteDocumentToRemove : qAsConst(favoriteDocumentsToRemove))
+    for (auto&& favoriteDocumentToRemove : std::as_const(favoriteDocumentsToRemove))
     {
         removeFromFavorite(favoriteDocumentToRemove);
     }
@@ -529,7 +529,7 @@ bool UBFeaturesController::isInFavoriteList(QUrl url)
 
 bool UBFeaturesController::isDocumentInFavoriteList(QString documentFolderName)
 {
-    for(auto&& url : qAsConst(*favoriteSet))
+    for(auto&& url : std::as_const(*favoriteSet))
     {
         QString localFile = url.toLocalFile();
         if (localFile.endsWith(".rdf"))
@@ -546,7 +546,7 @@ bool UBFeaturesController::isDocumentInFavoriteList(QString documentFolderName)
 
 bool UBFeaturesController::isInRecentlyOpenDocuments(QString documentFolderName)
 {
-    for(auto&& url : qAsConst(recentlyOpenDocuments))
+    for(auto&& url : std::as_const(recentlyOpenDocuments))
     {
         QString localFile = url.toLocalFile();
         if (localFile.endsWith(".rdf"))

--- a/src/board/UBFeaturesController.cpp
+++ b/src/board/UBFeaturesController.cpp
@@ -241,7 +241,7 @@ QString UBFeature::getNameFromVirtualPath(const QString &pVirtPath)
     QString result;
     int slashPos = pVirtPath.lastIndexOf("/");
     if (slashPos != -1) {
-        result = pVirtPath.right(pVirtPath.count() - slashPos - 1);
+        result = pVirtPath.right(pVirtPath.length() - slashPos - 1);
     } else {
         qDebug() << "UBFeature: incorrect virtual path parameter specified";
     }
@@ -611,10 +611,10 @@ QString UBFeaturesController::uniqNameForFeature(const UBFeature &feature, const
             if (!parentVirtualPath.endsWith("/")) {
                 parentVirtualPath.append("/");
             }
-            //Cut virtual path prevfix
+            //Cut virtual path prefix
             int i = curResultName.indexOf(feature.getFullVirtualPath());
             if (i != -1) {
-                curResultName = curResultName.right(curFeature.getFullVirtualPath().count() - i - parentVirtualPath.count());
+                curResultName = curResultName.right(curFeature.getFullVirtualPath().length() - i - parentVirtualPath.length());
             }
             //if directory has children, emptying the name;
             i = curResultName.indexOf("/");
@@ -869,7 +869,7 @@ QString UBFeaturesController::categoryNameForVirtualPath(const QString &str)
     QString result;
     int ind = str.lastIndexOf("/");
     if (ind != -1) {
-        result = str.right(str.count() - ind - 1);
+        result = str.right(str.length() - ind - 1);
     }
     return result;
 }

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -546,7 +546,11 @@ void UBApplication::setDisabled(bool disable)
 
 void UBApplication::decorateActionMenu(QAction* action)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject* menuWidget,  action->associatedObjects())
+#else
     foreach(QWidget* menuWidget,  action->associatedWidgets())
+#endif
     {
         QToolButton *tb = qobject_cast<QToolButton*>(menuWidget);
 

--- a/src/core/UBDisplayManager.cpp
+++ b/src/core/UBDisplayManager.cpp
@@ -448,7 +448,7 @@ void UBDisplayManager::blackout()
 
     UBPlatformUtils::fadeDisplayOut();
 
-    for (UBBlackoutWidget* blackoutWidget : qAsConst(mBlackoutWidgets))
+    for (UBBlackoutWidget* blackoutWidget : std::as_const(mBlackoutWidgets))
     {
         UBPlatformUtils::showFullScreen(blackoutWidget);
     }

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -205,7 +205,7 @@ void UBPersistenceManager::createDocumentProxiesStructure(const QFileInfoList &c
 
     QList<std::shared_ptr<UBDocumentProxy>> proxies = futureWatcher.future().results();
 
-    for (auto&& proxy : qAsConst(proxies))
+    for (auto&& proxy : std::as_const(proxies))
     {
         if (proxy)
         {

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -877,7 +877,7 @@ void UBScreenListLineEdit::onTextChanged(const QString &input)
 {
     const QStringList screenList = UBStringUtils::trimmed(input.split(','));
 
-    for (QPushButton* button : qAsConst(mScreenLabels))
+    for (QPushButton* button : std::as_const(mScreenLabels))
     {
         button->setDisabled(screenList.contains(button->property("screenIndex").toString()));
     }
@@ -887,7 +887,7 @@ void UBScreenListLineEdit::onTextChanged(const QString &input)
         // create and attach a new QCompleter
         QStringList model;
 
-        for (QPushButton* button : qAsConst(mScreenLabels))
+        for (QPushButton* button : std::as_const(mScreenLabels))
         {
             if (button->isEnabled())
             {

--- a/src/core/UBSetting.cpp
+++ b/src/core/UBSetting.cpp
@@ -108,8 +108,12 @@ UBColorListSetting::UBColorListSetting(UBSettings* owner, const QString& pDomain
 
     foreach(QString s, get().toStringList())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(s);
+#else
         QColor color;
         color.setNamedColor(s);
+#endif
         if (mAlpha>=0)
             color.setAlphaF(mAlpha);
         mColors.append(color);
@@ -130,8 +134,12 @@ QVariant UBColorListSetting::reset()
 
     foreach(QString s, get().toStringList())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QColor color = QColor::fromString(s);
+#else
         QColor color;
         color.setNamedColor(s);
+#endif
         if (mAlpha>=0)
             color.setAlphaF(mAlpha);
 

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -320,7 +320,7 @@ QString UBDocumentTreeNode::dirPathInHierarchy()
     }
 
     if (result.endsWith("/")) {
-        result.truncate(result.count() - 1);
+        result.truncate(result.length() - 1);
     }
 
     return result;
@@ -1116,7 +1116,7 @@ QString UBDocumentTreeModel::virtualDirForIndex(const QModelIndex &pIndex) const
     }
 
     if (result.endsWith("/")) {
-        result.truncate(result.count() - 1);
+        result.truncate(result.length() - 1);
     }
 
     return result;

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -2189,7 +2189,11 @@ void UBDocumentController::setupViews()
         connect(mAddFileToDocumentAction, SIGNAL(triggered(bool)), this, SLOT(addFileToDocument()));
         connect(mAddImagesAction, SIGNAL(triggered(bool)), this, SLOT(addImages()));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        foreach (QObject* menuWidget,  mMainWindow->actionDocumentAdd->associatedObjects())
+#else
         foreach (QWidget* menuWidget,  mMainWindow->actionDocumentAdd->associatedWidgets())
+#endif
         {
             QToolButton *tb = qobject_cast<QToolButton*>(menuWidget);
 
@@ -2221,7 +2225,11 @@ void UBDocumentController::setupViews()
             adaptor->setAssociatedAction(currentExportAction);
         }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        foreach (QObject* menuWidget,  mMainWindow->actionExport->associatedObjects())
+#else
         foreach (QWidget* menuWidget,  mMainWindow->actionExport->associatedWidgets())
+#endif
         {
             QToolButton *tb = qobject_cast<QToolButton*>(menuWidget);
 

--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -201,7 +201,7 @@ void UBBoardThumbnailsView::updateExposure()
     QRect viewportRect(QPoint(0, 0), viewport()->size());
     QRectF visibleSceneRect = mapToScene(viewportRect).boundingRect();
 
-    for (UBDraggableLivePixmapItem* thumbnail : qAsConst(mThumbnails))
+    for (UBDraggableLivePixmapItem* thumbnail : std::as_const(mThumbnails))
     {
         thumbnail->setExposed(visibleSceneRect.intersects(thumbnail->sceneBoundingRect()));
     }

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -780,19 +780,37 @@ void UBTabDockPalette::tabletEvent(QTabletEvent *event)
 {
     if (event->type() == QEvent::TabletPress)
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QMouseEvent mouseEvent(QEvent::MouseButtonPress, event->position(), event->globalPosition(), event->button(), event->buttons(), event->modifiers());
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QMouseEvent mouseEvent(QEvent::MouseButtonPress, event->position(), event->button(), event->buttons(), event->modifiers());
+#else
         QMouseEvent mouseEvent(QEvent::MouseButtonPress, event->posF(), event->button(), event->buttons(), event->modifiers());
+#endif
         mousePressEvent(&mouseEvent);
         event->accept();
     }
     else if (event->type() == QEvent::TabletMove)
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QMouseEvent mouseEvent(QEvent::MouseMove, event->position(), event->globalPosition(), event->button(), event->buttons(), event->modifiers());
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QMouseEvent mouseEvent(QEvent::MouseMove, event->position(), event->button(), event->buttons(), event->modifiers());
+#else
         QMouseEvent mouseEvent(QEvent::MouseMove, event->posF(), event->button(), event->buttons(), event->modifiers());
+#endif
         mouseMoveEvent(&mouseEvent);
         event->accept();
     }
     else if (event->type() == QEvent::TabletRelease)
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 4, 0))
+        QMouseEvent mouseEvent(QEvent::MouseButtonRelease, event->position(), event->globalPosition(), event->button(), event->buttons(), event->modifiers());
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QMouseEvent mouseEvent(QEvent::MouseButtonRelease, event->position(), event->button(), event->buttons(), event->modifiers());
+#else
         QMouseEvent mouseEvent(QEvent::MouseButtonRelease, event->posF(), event->button(), event->buttons(), event->modifiers());
+#endif
         mouseReleaseEvent(&mouseEvent);
         event->accept();
     }

--- a/src/gui/UBMousePressFilter.cpp
+++ b/src/gui/UBMousePressFilter.cpp
@@ -64,11 +64,13 @@ bool UBMousePressFilter::eventFilter(QObject *obj, QEvent *event)
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
             QPointF globalPosition = mouseEvent->globalPosition();
+            QPointF position = mouseEvent->position();
 #else
             QPointF globalPosition = mouseEvent->globalPos();
+            QPointF position = mouseEvent->pos();
 #endif
             mPendingEvent = new QMouseEvent(QEvent::MouseButtonDblClick,
-                mouseEvent->pos(), globalPosition,
+                position, globalPosition,
                 mouseEvent->button(), mouseEvent->buttons(),
                 mouseEvent->modifiers());
 

--- a/src/gui/UBToolbarButtonGroup.cpp
+++ b/src/gui/UBToolbarButtonGroup.cpp
@@ -118,7 +118,11 @@ void UBToolbarButtonGroup::setIcon(const QIcon &icon, int index)
 {
     Q_ASSERT(index < mActions.size());
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, mActions.at(index)->associatedObjects())
+#else
     foreach(QWidget *widget, mActions.at(index)->associatedWidgets())
+#endif
     {
         QToolButton *button = qobject_cast<QToolButton*>(widget);
         if (button)
@@ -138,7 +142,11 @@ void UBToolbarButtonGroup::setColor(const QColor &color, int index)
 
 void UBToolbarButtonGroup::selected(QAction *action)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject *widget, action->associatedObjects())
+#else
     foreach(QWidget *widget, action->associatedWidgets())
+#endif
     {
         QToolButton *button = qobject_cast<QToolButton*>(widget);
         if (button)

--- a/src/pdf-merger/Object.cpp
+++ b/src/pdf-merger/Object.cpp
@@ -280,7 +280,7 @@ void Object::serialize(std::ofstream & out, std::map< unsigned int, std::pair<un
 
    serialize(out, stream);
    stream.clear();
-   stream.reserve();
+   stream.shrink_to_fit();
 
    //call serialize of each child
    Children::iterator it;

--- a/src/pdf-merger/Parser.cpp
+++ b/src/pdf-merger/Parser.cpp
@@ -113,7 +113,7 @@ void Parser::_clearParser()
 {
    _root = 0;
    _fileContent.clear();
-   _fileContent.reserve();
+   _fileContent.shrink_to_fit();
    _objects.clear();
 }
 

--- a/src/pdf-merger/Utils.cpp
+++ b/src/pdf-merger/Utils.cpp
@@ -45,7 +45,7 @@ using namespace merge_lib;
 int Utils::stringToInt(const std::string & str) //throw ConvertException
 {
    //skip zeros
-   unsigned int lastZero = 0;str.find_last_of("0");
+   unsigned int lastZero = 0;
    while(str[lastZero++] == '0')
    {
       if(lastZero == str.size())

--- a/src/podcast/UBPodcastRecordingPalette.cpp
+++ b/src/podcast/UBPodcastRecordingPalette.cpp
@@ -59,7 +59,11 @@ UBPodcastRecordingPalette::UBPodcastRecordingPalette(QWidget *parent)
 
     addAction(UBApplication::mainWindow->actionPodcastConfig);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    foreach(QObject* menuWidget,  UBApplication::mainWindow->actionPodcastConfig->associatedObjects())
+#else
     foreach(QWidget* menuWidget,  UBApplication::mainWindow->actionPodcastConfig->associatedWidgets())
+#endif
     {
         QToolButton *tb = qobject_cast<QToolButton*>(menuWidget);
 

--- a/src/web/UBEmbedParser.cpp
+++ b/src/web/UBEmbedParser.cpp
@@ -107,7 +107,7 @@ void UBEmbedParser::parse(const QString& html)
 
     QList<QString> oembedUrls;
 
-    for (QString result : qAsConst(results))
+    for (QString result : std::as_const(results))
     {
         // replace entities
         result = result.trimmed().replace("&lt;", "<").replace("&gt;", ">").replace("\\&quot;", "\"").replace("\\", "");

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -298,7 +298,11 @@ void UBWebController::webBrowserInstance()
             connect(mHistoryBackMenu, SIGNAL(triggered(QAction *)), this, SLOT(openActionUrl(QAction *)));
 
             // setup history drop down menus
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            for (QObject* menuWidget : mMainWindow->actionWebBack->associatedObjects())
+#else
             for (QWidget* menuWidget : mMainWindow->actionWebBack->associatedWidgets())
+#endif
             {
                 QToolButton *tb = qobject_cast<QToolButton*>(menuWidget);
 
@@ -313,7 +317,11 @@ void UBWebController::webBrowserInstance()
             connect(mHistoryForwardMenu, SIGNAL(aboutToShow()), this, SLOT(aboutToShowForwardMenu()));
             connect(mHistoryForwardMenu, SIGNAL(triggered(QAction *)), this, SLOT(openActionUrl(QAction *)));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            for (QObject* menuWidget : mMainWindow->actionWebForward->associatedObjects())
+#else
             for (QWidget* menuWidget : mMainWindow->actionWebForward->associatedWidgets())
+#endif
             {
                 QToolButton *tb = qobject_cast<QToolButton*>(menuWidget);
 


### PR DESCRIPTION
Similar warnings are grouped into commits. If there are questions or suggestions, you may comment below, so we can discuss them. The solutions are based on the compiler recommendations.

Where changes cannot be made cross-compatible, they are version gated (mostly concerns Qt 6 vs Qt 5).  Some warnings remain that are a bit more involved (mainly around FFmpeg and OpenSSL/MD5).

Run on Arch Linux with Qt 6.7.1 and C++20 on GCC 14.1.1.