### PR TITLE
fix: cast for UBApplication object during construction

### DIFF
--- a/src/core/UBApplication.h
+++ b/src/core/UBApplication.h
@@ -80,7 +80,7 @@ class UBApplication : public SingleApplication
 
         static UBApplication* app()
         {
-            return static_cast<UBApplication*>qApp;
+            return dynamic_cast<UBApplication*>qApp;
         }
 
         static const QString mimeTypeUniboardDocument;


### PR DESCRIPTION
- avoid to static_cast UBApplication object while constructor is still not completed
- fixes problem to determine userDirectory before ApplicationName and OrganizationName are defined

This PR fixes some strange problems we recently had with OpenBoard using the wrong user data directory. Especially it helps (or even solves?) the problems described in

- #1004 
- https://github.com/OpenBoard-org/OpenBoard/issues/951#issuecomment-2139682397