### PR TITLE
Feat: snap to grid

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -1,5 +1,4 @@
 [App]
-AngleTolerance=4
 HideCheckForSoftwareUpdate=false
 HideSwapDisplayScreens=true
 EnableAutomaticSoftwareUpdates=true
@@ -12,6 +11,7 @@ LastSessionPageIndex=0
 PageCacheSize=20
 PreferredLanguage=fr_CH
 ProductWebAddress=http://www.openboard.ch
+RotationAngleStep=5.
 RunInWindow=false
 SoftwareUpdateURL=http://www.openboard.ch/update.json
 StartMode=

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -299,21 +299,34 @@ void UBBoardController::setBoxing(QRect displayRect)
     }
 }
 
-void UBBoardController::setCursorFromAngle(QString angle)
+void UBBoardController::setCursorFromAngle(QString angle, const QPoint offset)
 {
         QWidget *controlViewport = controlView()->viewport();
 
         QSize cursorSize(45,30);
+        QSize bitmapSize = cursorSize;
+        int hotX = -1;
+        int hotY = -1;
 
-        QImage mask_img(cursorSize, QImage::Format_Mono);
+        if (!offset.isNull())
+        {
+            bitmapSize.setWidth(std::max(bitmapSize.width(), 2 * std::abs(offset.x())));
+            bitmapSize.setHeight(std::max(bitmapSize.height(), 2 * std::abs(offset.y())));
+            hotX = bitmapSize.width() / 2 - offset.x();
+            hotY = bitmapSize.height() / 2 - offset.y();
+        }
+
+        QSize origin = (bitmapSize - cursorSize) / 2;
+
+        QImage mask_img(bitmapSize, QImage::Format_Mono);
         mask_img.fill(0xff);
         QPainter mask_ptr(&mask_img);
         mask_ptr.setBrush( QBrush( QColor(0, 0, 0) ) );
-        mask_ptr.drawRoundedRect(0,0, cursorSize.width()-1, cursorSize.height()-1, 6, 6);
+        mask_ptr.drawRoundedRect(origin.width(), origin.height(), cursorSize.width()-1, cursorSize.height()-1, 6, 6);
         QBitmap bmpMask = QBitmap::fromImage(mask_img);
 
 
-        QPixmap pixCursor(cursorSize);
+        QPixmap pixCursor(bitmapSize);
         pixCursor.fill(QColor(Qt::white));
 
         QPainter painter(&pixCursor);
@@ -321,13 +334,13 @@ void UBBoardController::setCursorFromAngle(QString angle)
         painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
         painter.setBrush(QBrush(Qt::white));
         painter.setPen(QPen(QColor(Qt::black)));
-        painter.drawRoundedRect(1,1,cursorSize.width()-2,cursorSize.height()-2,6,6);
+        painter.drawRoundedRect(origin.width() + 1, origin.height() + 1,cursorSize.width()-2,cursorSize.height()-2,6,6);
         painter.setFont(QFont("Arial", 10));
-        painter.drawText(1,1,cursorSize.width(),cursorSize.height(), Qt::AlignCenter, angle.append(QChar(176)));
+        painter.drawText(origin.width() + 1, origin.height() + 1,cursorSize.width(),cursorSize.height(), Qt::AlignCenter, angle.append(QChar(176)));
         painter.end();
 
         pixCursor.setMask(bmpMask);
-        controlViewport->setCursor(QCursor(pixCursor));
+        controlViewport->setCursor(QCursor(pixCursor, hotX, hotY));
 }
 
 

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -165,7 +165,7 @@ class UBBoardController : public UBDocumentContainer
         void persistCurrentScene(bool isAnAutomaticBackup = false, bool forceImmediateSave = false);
         void showNewVersionAvailable(bool automatic, const UBVersion &installedVersion, const UBSoftwareUpdate &softwareUpdate);
         void setBoxing(QRect displayRect);
-        void setCursorFromAngle(QString angle);
+        void setCursorFromAngle(QString angle, const QPoint offset = {});
         void setToolbarTexts();
         static QUrl expandWidgetToTempDir(const QByteArray& pZipedData, const QString& pExtension = QString("wgt"));
 

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -391,13 +391,13 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
     switch (event->type ()) {
     case QEvent::TabletPress: {
         mTabletStylusIsPressed = true;
-        scene()->inputDevicePress (scenePos, pressure);
+        scene()->inputDevicePress (scenePos, pressure, event->modifiers());
 
         break;
     }
     case QEvent::TabletMove: {
         if (mTabletStylusIsPressed)
-            scene ()->inputDeviceMove (scenePos, pressure);
+            scene ()->inputDeviceMove (scenePos, pressure, event->modifiers());
 
         acceptEvent = false; // rerouted to mouse move
 
@@ -409,7 +409,7 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
         scene ()->setToolCursor (currentTool);
         setToolCursor (currentTool);
 
-        scene ()->inputDeviceRelease ();
+        scene ()->inputDeviceRelease (currentTool, event->modifiers());
 
         mPendingStylusReleaseEvent = false;
 
@@ -1146,7 +1146,7 @@ void UBBoardView::mousePressEvent (QMouseEvent *event)
                     connect(&mLongPressTimer, SIGNAL(timeout()), this, SLOT(longPressEvent()));
                     mLongPressTimer.start();
                 }
-                scene()->inputDevicePress(mapToScene(UBGeometryUtils::pointConstrainedInRect(event->pos(), rect())));
+                scene()->inputDevicePress(mapToScene(UBGeometryUtils::pointConstrainedInRect(event->pos(), rect())), 1., event->modifiers());
             }
             event->accept ();
         }
@@ -1311,7 +1311,7 @@ void UBBoardView::mouseMoveEvent (QMouseEvent *event)
 
     default:
         if (!mTabletStylusIsPressed && scene()) {
-            scene()->inputDeviceMove(mapToScene(UBGeometryUtils::pointConstrainedInRect(event->pos(), rect())) , mMouseButtonIsPressed);
+            scene()->inputDeviceMove(mapToScene(UBGeometryUtils::pointConstrainedInRect(event->pos(), rect())) , mMouseButtonIsPressed, event->modifiers());
         }
         event->accept ();
     }
@@ -1333,7 +1333,7 @@ void UBBoardView::mouseReleaseEvent (QMouseEvent *event)
     setToolCursor (currentTool);
     // first/ propagate device release to the scene
     if (scene())
-        scene()->inputDeviceRelease();
+        scene()->inputDeviceRelease(currentTool, event->modifiers());
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QPointF eventPosition = event->position();

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1052,7 +1052,7 @@ void UBBoardView::mousePressEvent (QMouseEvent *event)
         return;
     }
 
-    setMultiselection(event->modifiers() & (Qt::ControlModifier | Qt::ShiftModifier));
+    setMultiselection(event->modifiers() & Qt::ControlModifier);
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     QPointF eventPosition = event->position();

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -693,9 +693,9 @@ bool UBBoardView::itemShouldBeMoved(QGraphicsItem *item)
     case UBGraphicsMediaItem::Type:
     case UBGraphicsVideoItem::Type:
     case UBGraphicsAudioItem::Type:
+    case UBGraphicsStrokesGroup::Type:
         return true;
 
-    case UBGraphicsStrokesGroup::Type:
     case UBGraphicsTextItem::Type:
         if (currentTool == UBStylusTool::Play)
             return true;

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -53,6 +53,7 @@
 #include "gui/UBToolWidget.h"
 #include "gui/UBResources.h"
 #include "gui/UBMainWindow.h"
+#include "gui/UBSnapIndicator.h"
 #include "gui/UBThumbnailWidget.h"
 
 #include "board/UBBoardController.h"
@@ -850,11 +851,18 @@ void UBBoardView::handleItemMouseMove(QMouseEvent *event)
         if (event->modifiers().testFlag(Qt::ShiftModifier))
         {
             QRectF rect = UBGraphicsScene::itemRect(movingItem);
-            auto offset = scene()->snap({rect.topLeft(), rect.topRight(), rect.bottomLeft(), rect.bottomRight()});
+            Qt::Corner corner;
+            auto offset = scene()->snap(rect, &corner);
             newPos += offset;
             movingItem->setPos(newPos);
 
             mLastPressedMousePos = scenePos + offset;
+
+            // display snap indicator
+            if (!offset.isNull())
+            {
+                updateSnapIndicator(corner);
+            }
         }
         else
         {
@@ -938,6 +946,17 @@ void UBBoardView::moveRubberedItems(QPointF movingVector)
 void UBBoardView::setMultiselection(bool enable)
 {
     mMultipleSelectionIsEnabled = enable;
+}
+
+void UBBoardView::updateSnapIndicator(Qt::Corner corner)
+{
+    if (!mSnapIndicator)
+    {
+        mSnapIndicator = new UBSnapIndicator(this);
+        mSnapIndicator->resize(60, 60);
+    }
+
+    mSnapIndicator->appear(corner);
 }
 
 void UBBoardView::setBoxing(const QMargins& margins)

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -842,9 +842,25 @@ void UBBoardView::handleItemMouseMove(QMouseEvent *event)
     if (getMovingItem() && itemShouldBeMoved(getMovingItem()) && (mMouseButtonIsPressed || mTabletStylusIsPressed))
     {
         QPointF scenePos = mapToScene(event->pos());
-        QPointF newPos = getMovingItem()->pos() + scenePos - mLastPressedMousePos;
-        getMovingItem()->setPos(newPos);
-        mLastPressedMousePos = scenePos;
+        auto movingItem = getMovingItem();
+        QPointF newPos = movingItem->pos() + scenePos - mLastPressedMousePos;
+        movingItem->setPos(newPos);
+
+        // snap to grid
+        if (event->modifiers().testFlag(Qt::ShiftModifier))
+        {
+            QRectF rect = UBGraphicsScene::itemRect(movingItem);
+            auto offset = scene()->snap({rect.topLeft(), rect.topRight(), rect.bottomLeft(), rect.bottomRight()});
+            newPos += offset;
+            movingItem->setPos(newPos);
+
+            mLastPressedMousePos = scenePos + offset;
+        }
+        else
+        {
+            mLastPressedMousePos = scenePos;
+        }
+
         mWidgetMoved = true;
         event->accept();
     }

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -42,6 +42,7 @@ class UBBoardController;
 class UBGraphicsScene;
 class UBGraphicsWidgetItem;
 class UBRubberBand;
+class UBSnapIndicator;
 
 class UBBoardView : public QGraphicsView
 {
@@ -66,6 +67,7 @@ public:
     bool isMultipleSelectionEnabled() { return mMultipleSelectionIsEnabled; }
 
     void setBoxing(const QMargins& margins);
+    void updateSnapIndicator(Qt::Corner corner);
 
     // work around for handling tablet events on MAC OS with Qt 4.8.0 and above
 #if defined(Q_OS_OSX)
@@ -208,6 +210,7 @@ private:
     bool mRubberBandInPlayMode;
 
     QMargins mMargins{};
+    UBSnapIndicator* mSnapIndicator{nullptr};
 
     static bool hasSelectedParents(QGraphicsItem * item);
 

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -468,7 +468,7 @@ void UBSettings::init()
     KeyboardLocale = new UBSetting(this, "Board", "StartupKeyboardLocale", 0);
     swapControlAndDisplayScreens = new UBSetting(this, "App", "SwapControlAndDisplayScreens", false);
 
-    angleTolerance = new UBSetting(this, "App", "AngleTolerance", 4);
+    rotationAngleStep = new UBSetting(this, "App", "RotationAngleStep", 5.);
     historyLimit = new UBSetting(this, "Web", "HistoryLimit", 15);
 
     libIconSize = new UBSetting(this, "Library", "LibIconSize", defaultLibraryIconSize);

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -417,7 +417,7 @@ class UBSettings : public QObject
         UBSetting* KeyboardLocale;
         UBSetting* swapControlAndDisplayScreens;
 
-        UBSetting* angleTolerance;
+        UBSetting* rotationAngleStep;
         UBSetting* historyLimit;
 
         UBSetting* libIconSize;

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -589,10 +589,17 @@ void UBGraphicsDelegateFrame::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 
             if (ubscene)
             {
-                QPointF snapVector = ubscene->snap({movedBounds.topLeft(), movedBounds.topRight(), movedBounds.bottomLeft(), movedBounds.bottomRight()});
+                Qt::Corner corner;
+                QPointF snapVector = ubscene->snap(movedBounds, &corner);
                 moveX += snapVector.x();
                 moveY += snapVector.y();
                 move.setP2(move.p2() + snapVector);
+
+                // display snap indicator
+                if (!snapVector.isNull())
+                {
+                    UBApplication::boardController->controlView()->updateSnapIndicator(corner);
+                }
             }
         }
 

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -576,6 +576,23 @@ void UBGraphicsDelegateFrame::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     }
     else if (moving())
     {
+        if (event->modifiers().testFlag(Qt::ShiftModifier))
+        {
+            // snap to grid
+            QPointF moved = event->scenePos() - mStartingPoint;
+            QRectF movedBounds = mStartingBounds.translated(moved);
+
+            UBGraphicsScene* ubscene = dynamic_cast<UBGraphicsScene*>(scene());
+
+            if (ubscene)
+            {
+                QPointF snapVector = ubscene->snap({movedBounds.topLeft(), movedBounds.topRight(), movedBounds.bottomLeft(), movedBounds.bottomRight()});
+                moveX += snapVector.x();
+                moveY += snapVector.y();
+                move.setP2(move.p2() + snapVector);
+            }
+        }
+
         mTranslateX = move.dx();
         mTranslateY = move.dy();
         moveLinkedItems(move);

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -547,24 +547,27 @@ void UBGraphicsDelegateFrame::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         QLineF currentLine(sceneBoundingRect().center(), event->scenePos());
         mAngle += startLine.angleTo(currentLine);
 
-        if ((int)mAngle % 45 >= 45 - mAngleTolerance || (int)mAngle % 45 <= mAngleTolerance)
+        if (event->modifiers().testFlag(Qt::ShiftModifier))
         {
-            mAngle = qRound(mAngle / 45) * 45;
-            mAngleOffset += startLine.angleTo(currentLine);
-            if ((int)mAngleOffset % 360 > mAngleTolerance && (int)mAngleOffset % 360 < 360 - mAngleTolerance)
+            if ((int)mAngle % 45 >= 45 - mAngleTolerance || (int)mAngle % 45 <= mAngleTolerance)
             {
-                mAngle += mAngleOffset;
-                mAngleOffset = 0;
+                mAngle = qRound(mAngle / 45) * 45;
+                mAngleOffset += startLine.angleTo(currentLine);
+                if ((int)mAngleOffset % 360 > mAngleTolerance && (int)mAngleOffset % 360 < 360 - mAngleTolerance)
+                {
+                    mAngle += mAngleOffset;
+                    mAngleOffset = 0;
+                }
             }
-        }
-        else if ((int)mAngle % 30 >= 30 - mAngleTolerance || (int)mAngle % 30 <= mAngleTolerance)
-        {
-            mAngle = qRound(mAngle / 30) * 30;
-            mAngleOffset += startLine.angleTo(currentLine);
-            if ((int)mAngleOffset % 360 > mAngleTolerance && (int)mAngleOffset % 360 < 360 - mAngleTolerance)
+            else if ((int)mAngle % 30 >= 30 - mAngleTolerance || (int)mAngle % 30 <= mAngleTolerance)
             {
-                mAngle += mAngleOffset;
-                mAngleOffset = 0;
+                mAngle = qRound(mAngle / 30) * 30;
+                mAngleOffset += startLine.angleTo(currentLine);
+                if ((int)mAngleOffset % 360 > mAngleTolerance && (int)mAngleOffset % 360 < 360 - mAngleTolerance)
+                {
+                    mAngle += mAngleOffset;
+                    mAngleOffset = 0;
+                }
             }
         }
 

--- a/src/domain/UBGraphicsDelegateFrame.h
+++ b/src/domain/UBGraphicsDelegateFrame.h
@@ -105,6 +105,7 @@ class UBGraphicsDelegateFrame: public QGraphicsRectItem, public QObject
         bool mRespectRatio;
 
         qreal mAngle;
+        qreal mRotatedAngle;
         qreal mAngleOffset;
         qreal mTotalScaleX;
         qreal mTotalScaleY;
@@ -114,7 +115,7 @@ class UBGraphicsDelegateFrame: public QGraphicsRectItem, public QObject
         qreal mTranslateY;
         qreal mTotalTranslateX;
         qreal mTotalTranslateY;
-        qreal mAngleTolerance;
+        qreal mRotationAngleStep;
         QRect mAngleRect;
 
         QPointF mStartingPoint;

--- a/src/domain/UBGraphicsDelegateFrame.h
+++ b/src/domain/UBGraphicsDelegateFrame.h
@@ -94,6 +94,7 @@ class UBGraphicsDelegateFrame: public QGraphicsRectItem, public QObject
         enum FrameTool {None, Move, Rotate, ResizeBottomRight, ResizeTop, ResizeRight, ResizeBottom, ResizeLeft};
         FrameTool toolFromPos (QPointF pos);
         void refreshGeometry();
+        QPointF snapVector(QPointF scenePos) const;
 
         FrameTool mCurrentTool;
         UBGraphicsItemDelegate* mDelegate;
@@ -117,6 +118,7 @@ class UBGraphicsDelegateFrame: public QGraphicsRectItem, public QObject
         QRect mAngleRect;
 
         QPointF mStartingPoint;
+        QRectF mStartingBounds;
         QTransform mInitialTransform;
         QSizeF mOriginalSize;
         QPointF mFixedPoint;

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2509,30 +2509,27 @@ QPointF UBGraphicsScene::snap(const QPointF& point, double* force, std::optional
     double snapForce{0};
     double gridSize = backgroundGridSize();
 
-    // determine closest grid point
-    if (mPageBackground != UBPageBackground::plain)
+    if (mIntermediateLines)
     {
-        if (mIntermediateLines)
-        {
-            gridSize /= 2.;
-        }
-
-        // y axis
-        double floorY = std::floor(point.y () / gridSize) * gridSize;
-        snapPoint.setY(point.y() - floorY < gridSize / 2. ? floorY : floorY + gridSize);
-
-        if (mPageBackground == UBPageBackground::crossed)
-        {
-            // x axis
-            double floorX = std::floor(point.x () / gridSize) * gridSize;
-            snapPoint.setX(point.x() - floorX < gridSize / 2. ? floorX : floorX + gridSize);
-        }
-
-        // force is a number between 0 and 1 based on the manhattan distance of the snap point
-        // from the original point
-        double relativeDist = (snapPoint - point).manhattanLength() / gridSize;
-        snapForce = std::max(1. - relativeDist, 0.);
+        gridSize /= 2.;
     }
+
+    // y axis
+    double floorY = std::floor(point.y () / gridSize) * gridSize;
+    snapPoint.setY(point.y() - floorY < gridSize / 2. ? floorY : floorY + gridSize);
+
+    // for blank background, use same snapping as for grid
+    if (mPageBackground == UBPageBackground::crossed || mPageBackground == UBPageBackground::plain)
+    {
+        // x axis
+        double floorX = std::floor(point.x () / gridSize) * gridSize;
+        snapPoint.setX(point.x() - floorX < gridSize / 2. ? floorX : floorX + gridSize);
+    }
+
+    // force is a number between 0 and 1 based on the manhattan distance of the snap point
+    // from the original point
+    double relativeDist = (snapPoint - point).manhattanLength() / gridSize;
+    snapForce = std::max(1. - relativeDist, 0.);
 
     if (proposedPoint)
     {

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -248,6 +248,11 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
         void addCache();
         UBGraphicsCache* graphicsCache();
 
+        QPointF snap(const QPointF& point, double* force = nullptr, std::optional<QPointF> proposedPoint = {}) const;
+        QPointF snap(const std::vector<QPointF>& corners, int* snapIndex = nullptr) const;
+        QPointF snap(const QRectF& rect, Qt::Corner* corner = nullptr) const;
+        static QRectF itemRect(const QGraphicsItem* item);
+
         class SceneViewState
         {
             public:

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -138,9 +138,9 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
         void clearContent(clearCase pCase = clearItemsAndAnnotations);
         void saveWidgetSnapshots();
 
-        bool inputDevicePress(const QPointF& scenePos, const qreal& pressure = 1.0);
-        bool inputDeviceMove(const QPointF& scenePos, const qreal& pressure = 1.0);
-        bool inputDeviceRelease(int tool = -1);
+        bool inputDevicePress(const QPointF& scenePos, const qreal& pressure = 1.0, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
+        bool inputDeviceMove(const QPointF& scenePos, const qreal& pressure = 1.0, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
+        bool inputDeviceRelease(int tool = -1, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 
         void leaveEvent (QEvent* event);
 

--- a/src/domain/UBSelectionFrame.h
+++ b/src/domain/UBSelectionFrame.h
@@ -102,7 +102,8 @@ private:
     QRectF mStartingBounds;
     QPointF mLastMovedPos;
     QPointF mLastTranslateOffset;
-    qreal mRotationAngle;
+    qreal mCursorRotationAngle;
+    qreal mItemRotationAngle;
 
     bool mIsLocked;
 

--- a/src/domain/UBSelectionFrame.h
+++ b/src/domain/UBSelectionFrame.h
@@ -99,6 +99,7 @@ private:
     QBrush mLocalBrush;
 
     QPointF mPressedPos;
+    QRectF mStartingBounds;
     QPointF mLastMovedPos;
     QPointF mLastTranslateOffset;
     qreal mRotationAngle;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -61,6 +61,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBRubberBand.h
     UBScreenMirror.cpp
     UBScreenMirror.h
+    UBSnapIndicator.cpp
+    UBSnapIndicator.h
     UBSpinningWheel.cpp
     UBSpinningWheel.h
     UBStartupHintsPalette.cpp

--- a/src/gui/UBSnapIndicator.cpp
+++ b/src/gui/UBSnapIndicator.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015-2024 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "UBSnapIndicator.h"
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPropertyAnimation>
+
+UBSnapIndicator::UBSnapIndicator(QWidget* parent)
+    : QLabel(parent)
+{
+    mAnimation = new QPropertyAnimation(this, "alpha", this);
+    mAnimation->setStartValue(0xff);
+    mAnimation->setEndValue(0);
+    mAnimation->setDuration(1000);
+
+    connect(mAnimation, &QPropertyAnimation::finished, this, &QWidget::hide);
+}
+
+void UBSnapIndicator::appear(Qt::Corner corner)
+{
+    if (corner != mCorner)
+    {
+        mAnimation->stop();
+        mCorner = corner;
+        show();
+        const auto cursorPos = parentWidget()->mapFromGlobal(QCursor::pos());
+        move(cursorPos - QPoint(width() / 2, height() / 2));
+        mAnimation->start();
+    }
+}
+
+int UBSnapIndicator::alpha() const
+{
+    return mAlpha;
+}
+
+void UBSnapIndicator::setAlpha(int opacity)
+{
+    mAlpha = opacity;
+    update();
+}
+
+void UBSnapIndicator::setColor(const QColor& color)
+{
+    mColor = color;
+}
+
+void UBSnapIndicator::paintEvent(QPaintEvent* event)
+{
+    QPainter painter(this);
+    QRect area = rect() - QMargins(2, 2, 2, 2);
+
+    QPen pen;
+    QColor penColor{mColor};
+    penColor.setAlpha(mAlpha);
+    pen.setColor(penColor);
+    pen.setWidth(3);
+
+    painter.setPen(pen);
+
+    QPoint p1;
+    QPoint p2;
+    QPoint p3;
+    int dist = rect().width() / 3;
+
+    switch (mCorner)
+    {
+    case Qt::TopLeftCorner:
+        p2 = area.topLeft();
+        p1 = p2 + QPoint{0, dist};
+        p3 = p2 + QPoint(dist, 0);
+        break;
+
+    case Qt::TopRightCorner:
+        p2 = area.topRight();
+        p1 = p2 + QPoint{0, dist};
+        p3 = p2 + QPoint(-dist, 0);
+        break;
+
+    case Qt::BottomLeftCorner:
+        p2 = area.bottomLeft();
+        p1 = p2 + QPoint{0, -dist};
+        p3 = p2 + QPoint(dist, 0);
+        break;
+
+    case Qt::BottomRightCorner:
+        p2 = area.bottomRight();
+        p1 = p2 + QPoint{0, -dist};
+        p3 = p2 + QPoint(-dist, 0);
+        break;
+
+    default:
+        break;
+    }
+
+    QPolygon polygon;
+    polygon << p1 << p2 << p3 << p1;
+
+    QPainterPath path;
+    path.addPolygon(polygon);
+
+    painter.drawPolygon(polygon);
+    painter.fillPath(path, penColor);
+
+    const int radius = rect().width() / 3;
+    const QPoint center = rect().center();
+    QRect circle = QRect(center, center) + QMargins(radius, radius, radius, radius);
+    painter.drawArc(circle, 0, 360 * 16);
+}

--- a/src/gui/UBSnapIndicator.h
+++ b/src/gui/UBSnapIndicator.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015-2024 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <QLabel>
+
+// forward
+class QPropertyAnimation;
+
+class UBSnapIndicator : public QLabel
+{
+    Q_OBJECT
+    Q_PROPERTY(int alpha READ alpha WRITE setAlpha)
+
+public:
+    UBSnapIndicator(QWidget* parent);
+
+    void appear(Qt::Corner corner);
+
+    int alpha() const;
+    void setAlpha(int opacity);
+
+    void setColor(const QColor& color);
+
+protected:
+    virtual void paintEvent(QPaintEvent* event) override;
+
+private:
+    Qt::Corner mCorner{Qt::TopLeftCorner};
+    int mAlpha;
+    QColor mColor{0x62a7e0};
+    QPropertyAnimation* mAnimation;
+};
+

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -40,7 +40,8 @@ HEADERS += src/gui/UBThumbnailView.h \
     src/gui/UBFeaturesActionBar.h \
     src/gui/UBMessagesDialog.h \
     src/gui/UBBackgroundPalette.h \
-    src/gui/UBBoardThumbnailsView.h
+    src/gui/UBBoardThumbnailsView.h \
+    src/gui/UBSnapIndicator.h
 SOURCES += src/gui/UBThumbnailView.cpp \
     $$PWD/UBStartupHintsPalette.cpp \
     src/gui/UBFloatingPalette.cpp \
@@ -83,7 +84,8 @@ SOURCES += src/gui/UBThumbnailView.cpp \
     src/gui/UBFeaturesActionBar.cpp \
     src/gui/UBMessagesDialog.cpp \
     src/gui/UBBackgroundPalette.cpp \
-    src/gui/UBBoardThumbnailsView.cpp
+    src/gui/UBBoardThumbnailsView.cpp \
+    src/gui/UBSnapIndicator.cpp
 win32:SOURCES += src/gui/UBKeyboardPalette_win.cpp
 macx:OBJECTIVE_SOURCES += src/gui/UBKeyboardPalette_mac.mm
 linux-g++:SOURCES += src/gui/UBKeyboardPalette_linux.cpp

--- a/src/tools/UBGraphicsAxes.cpp
+++ b/src/tools/UBGraphicsAxes.cpp
@@ -33,7 +33,6 @@
 #include "domain/UBGraphicsScene.h"
 #include "frameworks/UBGeometryUtils.h"
 #include "core/UBApplication.h"
-#include "gui/UBResources.h"
 #include "board/UBBoardController.h" // TODO UB 4.x clean that dependency
 #include "board/UBDrawingController.h"
 
@@ -352,6 +351,12 @@ void UBGraphicsAxes::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     if (!mResizing)
     {
         QGraphicsItem::mouseMoveEvent(event);
+
+        // snap to grid
+        if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+            QPointF snapVector = scene()->snap(pos());
+            setPos(pos() + snapVector);
+        }
     }
     else
     {
@@ -411,15 +416,6 @@ void UBGraphicsAxes::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     }
     else
     {
-        // snap to grid
-        if (true) {
-            QPointF delta = pos();
-            qreal gridSize = scene()->backgroundGridSize();
-            qreal deltaX = delta.x() - round(delta.x() / gridSize) * gridSize;
-            qreal deltaY = delta.y() - round(delta.y() / gridSize) * gridSize;
-            setPos(pos() - QPointF(deltaX, deltaY));
-        }
-
         QGraphicsItem::mouseReleaseEvent(event);
     }
 

--- a/src/tools/UBGraphicsCompass.h
+++ b/src/tools/UBGraphicsCompass.h
@@ -125,6 +125,8 @@ class UBGraphicsCompass: public QObject, public QGraphicsRectItem, public UBItem
         QGraphicsSvgItem* mMoveToolSvgItem;
         qreal mAntiScaleRatio;
         bool mDrewCenterCross;
+        qreal mCursorRotationAngle;
+        qreal mItemRotationAngle;
 
         // Constants
         static const int                      sNeedleLength = 12;

--- a/src/tools/UBGraphicsProtractor.cpp
+++ b/src/tools/UBGraphicsProtractor.cpp
@@ -267,6 +267,15 @@ void UBGraphicsProtractor::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 
     case Move :
         QGraphicsEllipseItem::mouseMoveEvent(event);
+
+        // snap to grid
+        if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+            // snap rotation center to grid
+            QPointF rotCenter = mapToScene(rotationCenter());
+            QPointF snapVector = scene()->snap(rotCenter);
+            setPos(pos() + snapVector);
+        }
+
         break;
 
     default :
@@ -299,6 +308,9 @@ void UBGraphicsProtractor::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     case Resize:
         update();
         break;
+
+    case Move:
+        Q_FALLTHROUGH();
 
     default :
         QGraphicsEllipseItem::mouseReleaseEvent(event);
@@ -701,6 +713,5 @@ void UBGraphicsProtractor::rotateAroundCenter(qreal angle)
 
 QPointF UBGraphicsProtractor::rotationCenter() const
 {
-    return QPointF(rect().x(), rect().y());
-
+    return QPointF{0., 0.};
 }

--- a/src/tools/UBGraphicsProtractor.h
+++ b/src/tools/UBGraphicsProtractor.h
@@ -114,6 +114,8 @@ class UBGraphicsProtractor : public UBAbstractDrawRuler, public QGraphicsEllipse
         qreal   mSpan;
         qreal   mStartAngle;
         qreal   mScaleFactor;
+        qreal   mCursorRotationAngle;
+        qreal   mItemRotationAngle;
 
         QGraphicsSvgItem* mResetSvgItem;
         QGraphicsSvgItem* mResizeSvgItem;

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -47,6 +47,8 @@ UBGraphicsRuler::UBGraphicsRuler()
     : QGraphicsRectItem()
     , mResizing(false)
     , mRotating(false)
+    , mCursorRotationAngle(0)
+    , mItemRotationAngle(0)
 {
     setRect(sDefaultRect);
 
@@ -402,6 +404,10 @@ void UBGraphicsRuler::mousePressEvent(QGraphicsSceneMouseEvent *event)
     else if (rotateButtonRect().contains(event->pos()))
     {
         mRotating = true;
+        mCursorRotationAngle = 0;
+        QPointF topLeft = sceneTransform().map(boundingRect().topLeft());
+        QPointF topRight = sceneTransform().map(boundingRect().topRight());
+        mItemRotationAngle = QLineF(topLeft, topRight).angle();
         event->accept();
     }
     else
@@ -446,13 +452,24 @@ void UBGraphicsRuler::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         {
             QLineF currentLine(rotationCenter(), event->pos());
             QLineF lastLine(rotationCenter(), event->lastPos());
-            rotateAroundCenter(currentLine.angleTo(lastLine));
+            mCursorRotationAngle = std::fmod(mCursorRotationAngle + lastLine.angleTo(currentLine), 360.);
+            qreal newAngle = mItemRotationAngle + mCursorRotationAngle;
 
-            //display current angle
+            if (event->modifiers().testFlag(Qt::ShiftModifier))
+            {
+                qreal step = UBSettings::settings()->rotationAngleStep->get().toReal();
+                newAngle = qRound(newAngle / step) * step;
+            }
+
+            newAngle = std::fmod(newAngle, 360.);
+
             QPointF topLeft = sceneTransform().map(boundingRect().topLeft());
             QPointF topRight = sceneTransform().map(boundingRect().topRight());
-            QLineF topLine(topLeft, topRight);
-            UBApplication::boardController->setCursorFromAngle(QString::number(topLine.angle(), 'f', 1));
+            qreal currentAngle = QLineF(topLeft, topRight).angle();
+            rotateAroundCenter(currentAngle - newAngle);
+
+            //display current angle
+            UBApplication::boardController->setCursorFromAngle(QString::number(newAngle, 'f', 1));
         }
 
         event->accept();

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -420,6 +420,14 @@ void UBGraphicsRuler::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     if (!mResizing && !mRotating)
     {
         QGraphicsItem::mouseMoveEvent(event);
+
+        // snap to grid
+        if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+            // snap rotation center to grid
+            QPointF rotCenter = mapToScene(rotationCenter());
+            QPointF snapVector = scene()->snap(rotCenter);
+            setPos(pos() + snapVector);
+        }
     }
     else
     {

--- a/src/tools/UBGraphicsRuler.h
+++ b/src/tools/UBGraphicsRuler.h
@@ -80,6 +80,8 @@ class UBGraphicsRuler : public UBAbstractDrawRuler, public QGraphicsRectItem, pu
 
         bool mResizing;
         bool mRotating;
+        qreal mCursorRotationAngle;
+        qreal mItemRotationAngle;
 
 
         // Helpers

--- a/src/tools/UBGraphicsTriangle.cpp
+++ b/src/tools/UBGraphicsTriangle.cpp
@@ -555,7 +555,7 @@ void UBGraphicsTriangle::rotateAroundCenter(QTransform& transform, QPointF cente
 }
 
 
-QPointF    UBGraphicsTriangle::rotationCenter() const
+QPointF UBGraphicsTriangle::rotationCenter() const
 {
     return B1;
 }
@@ -807,6 +807,14 @@ void UBGraphicsTriangle::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     if (!mResizing1 && !mResizing2 && !mRotating)
     {
         QGraphicsItem::mouseMoveEvent(event);
+
+        // snap to grid
+        if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+            // snap rotation center to grid
+            QPointF rotCenter = mapToScene(rotationCenter());
+            QPointF snapVector = scene()->snap(rotCenter);
+            setPos(pos() + snapVector);
+        }
     }
     else
     {

--- a/src/tools/UBGraphicsTriangle.cpp
+++ b/src/tools/UBGraphicsTriangle.cpp
@@ -49,6 +49,8 @@ UBGraphicsTriangle::UBGraphicsTriangle()
     , mResizing1(false)
     , mResizing2(false)
     , mRotating(false)
+    , mCursorRotationAngle(0)
+    , mItemRotationAngle(0)
     , mShouldPaintInnerTriangle(true)
 
 {
@@ -787,6 +789,10 @@ void UBGraphicsTriangle::mousePressEvent(QGraphicsSceneMouseEvent *event)
     if(rotateRect().contains(event->pos()))
     {
         mRotating = true;
+        mCursorRotationAngle = 0;
+        QPointF topLeft = sceneTransform().map(boundingRect().topLeft());
+        QPointF topRight = sceneTransform().map(boundingRect().topRight());
+        mItemRotationAngle = QLineF(topLeft, topRight).angle();
         event->accept();
     }
     else
@@ -873,13 +879,24 @@ void UBGraphicsTriangle::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         {
             QLineF currentLine(rotationCenter(), event->pos());
             QLineF lastLine(rotationCenter(), event->lastPos());
-            rotateAroundCenter(currentLine.angleTo(lastLine));
+            mCursorRotationAngle = std::fmod(mCursorRotationAngle + lastLine.angleTo(currentLine), 360.);
+            qreal newAngle = mItemRotationAngle + mCursorRotationAngle;
 
-            //display current angle
+            if (event->modifiers().testFlag(Qt::ShiftModifier))
+            {
+                qreal step = UBSettings::settings()->rotationAngleStep->get().toReal();
+                newAngle = qRound(newAngle / step) * step;
+            }
+
+            newAngle = std::fmod(newAngle, 360.);
+
             QPointF topLeft = sceneTransform().map(boundingRect().topLeft());
             QPointF topRight = sceneTransform().map(boundingRect().topRight());
-            QLineF topLine(topLeft, topRight);
-            UBApplication::boardController->setCursorFromAngle(QString::number(topLine.angle(), 'f', 1));
+            qreal currentAngle = QLineF(topLeft, topRight).angle();
+            rotateAroundCenter(currentAngle - newAngle);
+
+            //display current angle
+            UBApplication::boardController->setCursorFromAngle(QString::number(newAngle, 'f', 1));
         }
 
         //-----------------------------------------------//

--- a/src/tools/UBGraphicsTriangle.h
+++ b/src/tools/UBGraphicsTriangle.h
@@ -166,6 +166,8 @@ class UBGraphicsTriangle : public UBAbstractDrawRuler, public QGraphicsPolygonIt
         bool mResizing1;
         bool mResizing2;
         bool mRotating;
+        qreal mCursorRotationAngle;
+        qreal mItemRotationAngle;
 
         QRect lastRect;
 


### PR DESCRIPTION
This pull request adds a snap-to-grid function when drawing lines and moving tools or objects and resizing objects. In detail it provides the following functions:

- The `Shift` key is no longer used for multi-selection. Instead now only the `Ctrl` key works for that. Before, both keys were used for multi-selection.
- The `Shift` key is now used to activate snap-to-grid. The snap function is only active while this key is pressed. If `Shift` is not pressed, all draw, move and resize operations do not snap.
- This also means that the current 0°/45°/90° snap when drawing lines is no longer active when `Shift` is not pressed. This was requested by several people who wanted to draw "near horizontal" lines.

With the `Shift` key pressed, some points snap to the grid as follows:

- If the background is blank, then no snapping occurs.
- If the background is lined, then points snap to the closest line.
- If the background is crossed, points snap to the closest crossing.
- If intermediate lines are on, they also act as snap points.
- Additionally when drawing a line, the 0°/45°/90° snap is activated.

The individual tools and objects behave as follows when the `Shift` key is pressed and the tool or object is **moved**:

- The center of the **Axes** tool snaps.
- The Zero point of the upper scale on the **Ruler** snaps.
- The Zero point of the **Protractor** snaps.
- The Zero point of the **Triangle** snaps.
- The needle of the **compass** snaps.
- For **Objects**, all four corner points are snappy.

The individual tools and objects behave as follows when the `Shift` key is pressed and the tool or object is **resized**:

- When the **compass** is resized (radius is adjusted) and `Shift` is pressed, then the radius snaps so that the circle goes through the closest grid point.
- No snap when **Axes**, **Ruler**, **Protractor** or **Triangle** are resized.
- When **Objects** are resized, the resized side snaps to the grid.
- No snap for **Objects** if the lower right corner is resized. Here keeping the aspect ratio is more important.

When an object is in a rotated state, then the corners of the bounding rectangle of the rotated object define the points to snap.

For a **Line**, the snap points are not determined by the outline of the line, but by the actual line start and end points inside the outline. This works however only if the line is moved or resized in the same session where it was created. After a document was serialized and loaded again, the line property is lost and the line is handled like any other arbitrary drawing.

The implementation of the snap function is as follows:

- In `UBGraphicsScene`, functions are added to compute the snap vector, i.e. the amount by which we should move an object so that it snaps.
- Separate commits use these functions for the tools (Axes, Ruler, Protractor, Triangle and Compass).
- For drawing a line, the keyboard modifier is forwarded from the `UBBoardView` to the `UBGraphicsScene` and the snap functions are used.
- Moving objects using the Hand tool is handled in the `UBBoardView`.
- Moving and resizing objects with the pointer tool and using the Delegate frame is handled in the `UBGraphicsDelegateFrame`.

When at some later time the flexible background definitions are implemented (PR #888), then only the single `UBGraphicsScene::snap()` function must be adapted. All the other logic is not affected.

This PR is related to the following issues:

- #871 
- #1007 
