### PR TITLE
fix: boxing in singlescreen mode

### DIFF
--- a/src/core/UBDisplayManager.h
+++ b/src/core/UBDisplayManager.h
@@ -84,12 +84,12 @@ class UBDisplayManager : public QObject
 
         bool hasDisplay()
         {
-            return mScreensByRole.value(ScreenRole::Display);
+            return mUseMultiScreen && mScreensByRole.value(ScreenRole::Display);
         }
 
         bool hasPrevious()
         {
-            return mScreensByRole.value(ScreenRole::Previous1);
+            return mUseMultiScreen && mScreensByRole.value(ScreenRole::Previous1);
         }
 
         bool useMultiScreen()


### PR DESCRIPTION
When

- more than one monitor is connected,
- no monitor or more than one monitor is configured in the preferences,
- and single monitor mode was selected in the OpenBoard menu,

then the control display was still boxed as if the display screen (projector) was used.

This PR fixes the values returned by `hasDisplay()` and `hasPrevious()` in the `UBDisplayManager` to include the value of the multi-monitor flag.

Related issues:

- #887
- #943

Note: This is not the same problem as addressed by #901. In that PR it is about scaling of control and display view in multi-monitor mode. This PR fixes a problem in single-monitor mode.