### PR TITLE
Support FFmpeg 7.0

### DIFF
--- a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
+++ b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
@@ -520,7 +520,12 @@ bool UBFFmpegVideoEncoder::init()
         }
 
         // Buffer for resampled/converted audio
-        mAudioOutBuffer = av_audio_fifo_alloc(c->sample_fmt, c->channels, c->frame_size);
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 3, 100)
+        int nb_channels = c->channels;
+#else
+        int nb_channels = c->ch_layout.nb_channels;
+#endif
+        mAudioOutBuffer = av_audio_fifo_alloc(c->sample_fmt, nb_channels, c->frame_size);
     }
 
 
@@ -639,8 +644,13 @@ void UBFFmpegVideoEncoder::processAudio(QByteArray &data)
     uint8_t ** outSamples = nullptr;
     int outSamplesLineSize;
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 3, 100)
+    int nb_channels = codecContext->channels;
+#else
+    int nb_channels = codecContext->ch_layout.nb_channels;
+#endif
     ret = av_samples_alloc_array_and_samples(&outSamples, &outSamplesLineSize,
-                                             codecContext->channels, outSamplesCount,
+                                             nb_channels, outSamplesCount,
                                              codecContext->sample_fmt, 0);
     if (ret < 0) {
         qWarning() << "Could not allocate audio samples" << avErrorToQString(ret);

--- a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
+++ b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
@@ -746,11 +746,19 @@ void UBFFmpegVideoEncoder::finishEncoding()
     av_write_trailer(mOutputFormatContext);
     avio_close(mOutputFormatContext->pb);
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 3, 100)
     avcodec_close(mVideoCodecContext);
+#else
+    avcodec_free_context(&mVideoCodecContext);
+#endif
     sws_freeContext(mSwsContext);
 
     if (mShouldRecordAudio) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 3, 100)
         avcodec_close(mAudioCodecContext);
+#else
+        avcodec_free_context(&mAudioCodecContext);
+#endif
         swr_free(&mSwrContext);
     }
 


### PR DESCRIPTION
With FFmpeg 7.0 entering [Arch Linux extra-testing](https://archlinux.org/packages/extra-testing/x86_64/ffmpeg/), it's a good time to get support for it in OpenBoard.

This PR fixes the compilation errors and resolves related warnings.
The proposed alternatives are available since 5.1 at least, so the pragmas could be lowered to get rid of warnings in previous versions - I've elected to keep the change as small as possible, so the fix only applies to version 7.0.

I'd like to have this commit merged before Arch upgrades FFmpeg to general availability, though I don't have a timeline for when that will happen. A new release of OpenBoard is not necessary.

Fixes #1002 