### PR TITLE
fix: apply scene keyboard shortcuts w/o modifier only

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -208,44 +208,45 @@ void UBBoardView::keyPressEvent (QKeyEvent *event)
 
     if (!event->isAccepted ())
     {
-        switch (event->key ())
+        if (event->modifiers() == Qt::NoModifier)
         {
-        case Qt::Key_Up:
-        case Qt::Key_PageUp:
-        case Qt::Key_Left:
-        {
-            mController->previousScene ();
-            break;
-        }
+            switch (event->key ())
+            {
+            case Qt::Key_Up:
+            case Qt::Key_PageUp:
+            case Qt::Key_Left:
+            {
+                mController->previousScene ();
+                break;
+            }
 
-        case Qt::Key_Down:
-        case Qt::Key_PageDown:
-        case Qt::Key_Right:
-        case Qt::Key_Space:
-        {
-            mController->nextScene ();
-            break;
-        }
+            case Qt::Key_Down:
+            case Qt::Key_PageDown:
+            case Qt::Key_Right:
+            case Qt::Key_Space:
+            {
+                mController->nextScene ();
+                break;
+            }
 
-        case Qt::Key_Home:
-        {
-            mController->firstScene ();
-            break;
+            case Qt::Key_Home:
+            {
+                mController->firstScene ();
+                break;
+            }
+            case Qt::Key_End:
+            {
+                mController->lastScene ();
+                break;
+            }
+            case Qt::Key_Insert:
+            {
+                mController->addScene ();
+                break;
+            }
+            }
         }
-        case Qt::Key_End:
-        {
-            mController->lastScene ();
-            break;
-        }
-        case Qt::Key_Insert:
-        {
-            mController->addScene ();
-            break;
-        }
-        }
-
-
-        if (event->modifiers () & Qt::ControlModifier) // keep only ctrl/cmd keys
+        else if (event->modifiers () & Qt::ControlModifier) // keep only ctrl/cmd keys
         {
             switch (event->key ())
             {


### PR DESCRIPTION
This PR fixes a long-standing bug for keyboard shortcuts:

- The keyboard shortcuts for scene commands prev/next/first/last/add should only be active when no modifier key is pressed.
- This resolves conflicts with the same keys used together with the `Ctrl` modifier used for panning.

This bug was reported three years ago (#494) and is still not fixed.