### PR TITLE
Remove MD5 hashing from UBFileSystemUtils

### DIFF
--- a/src/frameworks/UBFileSystemUtils.cpp
+++ b/src/frameworks/UBFileSystemUtils.cpp
@@ -41,7 +41,6 @@ THIRD_PARTY_WARNINGS_DISABLE
 #else
     #include "quazipfile.h"
 #endif
-#include <openssl/md5.h>
 THIRD_PARTY_WARNINGS_ENABLE
 
 #include "core/memcheck.h"
@@ -838,37 +837,6 @@ bool UBFileSystemUtils::expandZipToDir(const QFile& pZipFile, const QDir& pTarge
     }
 
     return true;
-}
-
-
-QString UBFileSystemUtils::md5InHex(const QByteArray &pByteArray)
-{
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
-    MD5_Update(&ctx, pByteArray.data(), pByteArray.size());
-
-    unsigned char result[16];
-    MD5_Final(result, &ctx);
-
-    return QString(QByteArray((char *)result, 16).toHex());
-}
-
-QString UBFileSystemUtils::md5(const QByteArray &pByteArray)
-{
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
-    MD5_Update(&ctx, pByteArray.data(), pByteArray.size());
-
-    unsigned char result[16];
-    MD5_Final(result, &ctx);
-    QString s;
-
-    for(int i = 0; i < 16; i++)
-    {
-        s += QChar(result[i]);
-    }
-
-    return s;
 }
 
 QString UBFileSystemUtils::readTextFile(QString path)

--- a/src/frameworks/UBFileSystemUtils.h
+++ b/src/frameworks/UBFileSystemUtils.h
@@ -108,9 +108,6 @@ class UBFileSystemUtils : public QObject
 
         static bool expandZipToDir(const QFile& pZipFile, const QDir& pTargetDir);
 
-        static QString md5InHex(const QByteArray &pByteArray);
-        static QString md5(const QByteArray &pByteArray);
-
         static QString nextAvailableFileName(const QString& filename, const QString& inter = QString(""));
 
         static QString readTextFile(QString path);


### PR DESCRIPTION
The functions `MD5_Init`, `MD5_Update`, `MD5_Final` are deprecated in OpenSSL 3.0. This leads to warnings during compilation.

~~Use `EVP_Q_digest` instead.~~
**Edit:** Since the utility functions `md5` and `md5InHex` are not used anywhere, just remove them.