### PR TITLE
Fix Dice widget and add automatic update

### DIFF
--- a/resources/library/interactivities/Dice.wgt/config.xml
+++ b/resources/library/interactivities/Dice.wgt/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns="http://www.w3.org/ns/widgets" 
     xmlns:ub="http://uniboard.mnemis.com/widgets"
         id="http://www.openboard.org/widget/interactivity/dice"
-        version="2.0"
+        version="2.1"
         width="760"
         height="610"
         ub:resizable="false">     

--- a/resources/library/interactivities/Dice.wgt/css/ubw-main.css
+++ b/resources/library/interactivities/Dice.wgt/css/ubw-main.css
@@ -45,10 +45,10 @@ html, body {
 
 .theme-slate #ubwidget > .wrapper, .theme-pad #ubwidget > .wrapper {
 	position: absolute;
-	top: -49px;
+	/* top: -49px;
 	bottom: -5px;
 	left: -5px;
-	right: -5px;
+	right: -5px; */
 	overflow: hidden;
 }
 

--- a/resources/library/interactivities/Dice.wgt/js/lib/ubw-main.js
+++ b/resources/library/interactivities/Dice.wgt/js/lib/ubw-main.js
@@ -16,17 +16,26 @@ function log(object) {
 	console.log(object);
 }
 
-function initAfterI18nMessagesLoaded(reload, templates, callbacks) {
+async function initAfterI18nMessagesLoaded(reload, templates, callbacks) {
 	document.title = fr.njin.i18n.document.title;
 	
 	var ubwidget = $("#ubwidget");
+
+	function createDelegate() {
+		if (window.sankore.async) {
+			return Object.create(SankoreAsyncDelegate);
+		}
+		else {
+			return window.sankore || Object.create(ParametersDelegate);
+		}
+	}
 	
 	var parameters = Object.create(Parameters,{
 		container: {
 			value: ubwidget
 		},
 		delegate: {
-			value: window.sankore || Object.create(ParametersDelegate)
+			value: createDelegate()
 		}
 	});
 	
@@ -41,6 +50,20 @@ function initAfterI18nMessagesLoaded(reload, templates, callbacks) {
 			value: reload
 		}
 	});
+
+	async function fillParameters() {
+		var keys = await window.sankore.async.preferenceKeys();
+		for (var i = 0; i < keys.length; i++) {
+			var key = keys[i];
+			var value = await window.sankore.async.preference(key);
+			log("Init parameter value ["+value+"] for key : ["+key+"]");
+			app.parameters.delegate[key] = value;
+		}
+	}
+
+	if (window.sankore.async) {
+			await fillParameters();
+	}
 
 	app.init();
 	app.onEdit = false;
@@ -157,6 +180,25 @@ var ParametersDelegate = (function(){
 	return self;
 })();
 
+var SankoreAsyncDelegate = (function(){
+    var self = Object.create({}, {
+        preference: {
+            value: function(key) {
+                // return cached value
+                return this[key];
+            }
+        },
+        setPreference: {
+            value: function(key, value) {
+                // store in cache and application
+                this[key] = value
+                window.sankore.setPreference(key, value);
+            }
+        }
+    });
+    return self;
+})();
+
 var App = (function() {
     var self = Object.create({}, {
 		container: {
@@ -233,7 +275,7 @@ var App = (function() {
 								    }
 								    return doc;
 								}
-								var file = stringToXML(e.dataTransfer.getData("text/plain"));
+								var file = stringToXML(e.dataTransfer.getData("text/plain") || window.sankore.dropData);
 								callback({
 			                        src: $(file).find("path:eq(0)").text()
 								});


### PR DESCRIPTION
When updating the interactivity widgets to the new OpenBoard API, the `Dice` widget was forgotten. This PR fixes this in two commits:

- The first commit extends the `UBWidgetUpgradeAdaptor`. It was initially written to upgrade widgets which have been using the old API to updated versions using the new API. The extension added now can also update a widget already using the new API to a new version.
- The second commit applies all the changes necessary for `uwb-main` based widgets.

The automatic version update makes sure that widgets on already existing documents get automatically updated. The update is performed if

- The widget existing in the document has a valid ID and version number.
- The widget existing in the document does not use the old API. Using the old API takes us to the already implemented "upgrade" path where an widget is upgraded without version number comparison.
- The library contains a widget with the same id as the document widget.
- The library widget and the document widget have the same major version number. Different major version numbers might indicate incompatible widgets, where an automatic update could break things.
- The library widget has however a newer version number taking into account minor or micro version.

This PR fixes #1020.