### PR TITLE
fix(intranetPodcastPublishingDialog.ui): Title string corrected

### DIFF
--- a/resources/forms/intranetPodcastPublishingDialog.ui
+++ b/resources/forms/intranetPodcastPublishingDialog.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Publish Podcast to YouTube</string>
+   <string>Publish to Intranet</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
The title for publishing to the intranet references Youtube: "Publish Podcast to YouTube". Instead use (the more generic) "Publish to Intranet".