### PR TITLE
refactor(UBPersistenceManager): Make createDocumentProxyStructure static

### DIFF
--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -178,11 +178,7 @@ void UBPersistenceManager::createDocumentProxiesStructure(const QFileInfoList &c
     QObject::connect(&futureWatcher, &QFutureWatcher<void>::progressValueChanged,  &mProgress, &QProgressDialog::setValue);
 
     // Start the computation.
-    std::function<std::shared_ptr<UBDocumentProxy> (QFileInfo contentInfo)> createDocumentProxyLambda = [=](QFileInfo contentInfo) {
-        return createDocumentProxyStructure(contentInfo);
-    };
-
-    QFuture<std::shared_ptr<UBDocumentProxy>> proxiesFuture = QtConcurrent::mapped(contentInfoList, createDocumentProxyLambda);
+    QFuture<std::shared_ptr<UBDocumentProxy>> proxiesFuture = QtConcurrent::mapped(contentInfoList, &UBPersistenceManager::createDocumentProxyStructure);
     futureWatcher.setFuture(proxiesFuture);
 
     // Display the dialog and start the event loop.
@@ -258,7 +254,7 @@ void UBPersistenceManager::createDocumentProxiesStructure(bool interactive)
     }
 }
 
-std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocumentProxyStructure(QFileInfo& contentInfo)
+std::shared_ptr<UBDocumentProxy> UBPersistenceManager::createDocumentProxyStructure(const QFileInfo& contentInfo)
 {
     QString fullPath = contentInfo.absoluteFilePath();
 

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -133,7 +133,7 @@ class UBPersistenceManager : public QObject
 
         void createDocumentProxiesStructure(bool interactive = false);
         void createDocumentProxiesStructure(const QFileInfoList &contentInfoList, bool interactive = false);
-        std::shared_ptr<UBDocumentProxy> createDocumentProxyStructure(QFileInfo &contentInfo);
+        static std::shared_ptr<UBDocumentProxy> createDocumentProxyStructure(const QFileInfo &contentInfo);
         QDialog::DialogCode processInteractiveReplacementDialog(std::shared_ptr<UBDocumentProxy> pProxy, bool multipleFiles = false);
 
         QStringList documentSubDirectories()
@@ -167,7 +167,7 @@ class UBPersistenceManager : public QObject
         void documentSceneDeleted(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int pIndex);
 
 private:
-        int sceneCount(const std::shared_ptr<UBDocumentProxy> pDocumentProxy);
+        static int sceneCount(const std::shared_ptr<UBDocumentProxy> pDocumentProxy);
         static QStringList getSceneFileNames(const QString& folder);
         void renamePage(std::shared_ptr<UBDocumentProxy> pDocumentProxy,
                         const int sourceIndex, const int targetIndex);


### PR DESCRIPTION
The method `createDocumentProxyStructure` doesn't depend on the object, so can be made static. QtConcurrent::mapped requires the argument of the method to be const, since it creates a new list for the mapping.

The lambda function marks its arguments as const by default. Since the method is now static, the lambda can be replaced with a direct reference.

The removal of the lambda resolves warning 3 of #1046.