### PR TITLE
refactor(UBMainWindow): Use | to combine keys

### DIFF
--- a/src/gui/UBMainWindow.cpp
+++ b/src/gui/UBMainWindow.cpp
@@ -67,14 +67,14 @@ UBMainWindow::UBMainWindow(QWidget *parent, Qt::WindowFlags flags)
     setCentralWidget(centralWidget);
 
 #ifdef Q_OS_OSX
-    actionPreferences->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Comma));
-    actionQuit->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
+    actionPreferences->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Comma));
+    actionQuit->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q));
 #elif defined(Q_OS_WIN)
-    actionPreferences->setShortcut(QKeySequence(Qt::ALT + Qt::Key_Return));
+    actionPreferences->setShortcut(QKeySequence(Qt::ALT | Qt::Key_Return));
     // this code, because it unusable, system key combination can`t be triggered, even we add it manually
-    actionQuit->setShortcut(QKeySequence(Qt::ALT + Qt::Key_F4));
+    actionQuit->setShortcut(QKeySequence(Qt::ALT | Qt::Key_F4));
 #else
-    actionQuit->setShortcut(QKeySequence(Qt::ALT + Qt::Key_F4));
+    actionQuit->setShortcut(QKeySequence(Qt::ALT | Qt::Key_F4));
 #endif
 }
 


### PR DESCRIPTION
Addition between enums is deprecated, and in Qt6 support for the + operator between modifiers and keys gets deprecated. Instead, the | operator is provided.

The | operator is supported in both Qt5 and Qt6.

Resolves warning 4 in #1046 