### PR TITLE
chore: remove cmake files related to OpenSankore import

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -19,8 +19,6 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBIdleTimer.h
     UBMimeData.cpp
     UBMimeData.h
-    UBOpenSankoreImporter.cpp
-    UBOpenSankoreImporter.h
     UBPersistenceManager.cpp
     UBPersistenceManager.h
     UBPersistenceWorker.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -49,8 +49,6 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBMessagesDialog.h
     UBMousePressFilter.cpp
     UBMousePressFilter.h
-    UBOpenSankoreImporterWidget.cpp
-    UBOpenSankoreImporterWidget.h
     UBPageNavigationWidget.cpp
     UBPageNavigationWidget.h
     UBPropertyPalette.cpp


### PR DESCRIPTION
- source files have been removed
- remove UBOpenSankoreImporter from core/CMakeLists.txt
- remove UBOpenSankoreImporterWidget from gui/CMakeLists.txt