### PR TITLE
fix: disconnect with nullptr receiver

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -1586,7 +1586,11 @@ std::shared_ptr<UBGraphicsScene> UBBoardController::setActiveDocumentScene(std::
 
         updateSystemScaleFactor();
 
-        disconnect(UBApplication::undoStack.data(), SIGNAL(indexChanged(int)), mControlView->scene().get(), SLOT(updateSelectionFrameWrapper(int)));
+        if (mControlView->scene())
+        {
+            disconnect(UBApplication::undoStack.data(), SIGNAL(indexChanged(int)), mControlView->scene().get(), SLOT(updateSelectionFrameWrapper(int)));
+        }
+
         mControlView->setScene(mActiveScene.get());
         connect(UBApplication::undoStack.data(), SIGNAL(indexChanged(int)), mControlView->scene().get(), SLOT(updateSelectionFrameWrapper(int)));
 


### PR DESCRIPTION
When starting OpenBoard, there was the following warning:

```
QObject::disconnect: Unexpected nullptr parameter
```

This PR fixes this.

- fix regression introduced with 3e76f16
- check receiver before disconnecting signal
- only disconnect when receiver is not-null