### PR TITLE
fix: workaround foreground repaint after centerOn

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -955,7 +955,10 @@ void UBBoardController::centerRestore()
 
 void UBBoardController::centerOn(QPointF scenePoint)
 {
-    mControlView->centerOn(scenePoint);
+    // workaround: foreground not repainted after centerOn on Qt5 (fixed in Qt6)
+    QPointF offset{1, 1};
+    mControlView->centerOn(scenePoint - offset);
+    mControlView->translate(offset.x(), offset.y());
     UBApplication::applicationController->adjustDisplayView();
 }
 


### PR DESCRIPTION
- in Qt5, the foreground is not correctly redrawn after calling centerOn
- it is redrawn however with translate
- combine centerOn with a small translation to workaround this problem