### PR TITLE
Feat: improve shortcut handling

### DIFF
--- a/src/board/UBDrawingController.cpp
+++ b/src/board/UBDrawingController.cpp
@@ -156,11 +156,16 @@ void UBDrawingController::setStylusTool(int tool)
 }
 
 
-bool UBDrawingController::isDrawingTool()
+bool UBDrawingController::isDrawingTool(int tool)
 {
-    return (stylusTool() == UBStylusTool::Pen)
-            || (stylusTool() == UBStylusTool::Marker)
-            || (stylusTool() == UBStylusTool::Line);
+    if (tool < 0)
+    {
+        tool = stylusTool();
+    }
+
+    return (tool == UBStylusTool::Pen)
+            || (tool == UBStylusTool::Marker)
+            || (tool == UBStylusTool::Line);
 }
 
 

--- a/src/board/UBDrawingController.h
+++ b/src/board/UBDrawingController.h
@@ -52,7 +52,7 @@ class UBDrawingController : public QObject
         int stylusTool();
         int latestDrawingTool();
 
-        bool isDrawingTool();
+        bool isDrawingTool(int tool = -1);
 
         int currentToolWidthIndex();
         qreal currentToolWidth();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBSetting.h
     UBSettings.cpp
     UBSettings.h
+    UBShortcutManager.cpp
+    UBShortcutManager.h
     UBTextTools.cpp
     UBTextTools.h
 )

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -679,6 +679,15 @@ bool UBApplication::eventFilter(QObject *obj, QEvent *event)
 #endif
     }
 
+    else if (event->type() == QEvent::KeyRelease)
+    {
+        // intercept key release events for shortcut handler
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+        return UBShortcutManager::shortcutManager()->handleKeyReleaseEvent(keyEvent)
+                    || result;
+    }
+
     return result;
 }
 

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -45,6 +45,7 @@
 #include "UBPreferencesController.h"
 #include "UBIdleTimer.h"
 #include "UBApplicationController.h"
+#include "UBShortcutManager.h"
 
 #include "board/UBBoardController.h"
 #include "board/UBDrawingController.h"
@@ -653,14 +654,14 @@ bool UBApplication::eventFilter(QObject *obj, QEvent *event)
         }
     }
 
-    if (event->type() == QEvent::TabletLeaveProximity)
+    else if (event->type() == QEvent::TabletLeaveProximity)
     {
         if (boardController && boardController->controlView())
             boardController->controlView()->forcedTabletRelease();
     }
 
 
-    if (event->type() == QEvent::ApplicationActivate)
+    else if (event->type() == QEvent::ApplicationActivate)
     {
         boardController->controlView()->setMultiselection(false);
 

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -540,17 +540,32 @@ void UBSettings::save()
          * We save the setting to the user settings if
          * a) it is different from the (non-null) value stored in the user settings, or
          * b) it doesn't currently exist in the user settings AND has changed from the app settings
+         * An invalid value indicates removal of the setting
         */
         if (mUserSettings->contains(it.key())
                 && it.value() != mUserSettings->value(it.key()))
         {
-            mUserSettings->setValue(it.key(), it.value());
+            if (it.value().isValid())
+            {
+                mUserSettings->setValue(it.key(), it.value());
+            }
+            else
+            {
+                mUserSettings->remove(it.key());
+            }
         }
 
         else if (!mUserSettings->contains(it.key())
                  && it.value() != mAppSettings->value(it.key()))
         {
-            mUserSettings->setValue(it.key(), it.value());
+            if (it.value().isValid())
+            {
+                mUserSettings->setValue(it.key(), it.value());
+            }
+            else
+            {
+                mUserSettings->remove(it.key());
+            }
         }
 
         ++it;

--- a/src/core/UBShortcutManager.cpp
+++ b/src/core/UBShortcutManager.cpp
@@ -1,0 +1,751 @@
+/*
+ * Copyright (C) 2015-2018 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * Copyright (C) 2013 Open Education Foundation
+ *
+ * Copyright (C) 2010-2013 Groupement d'Intérêt Public pour
+ * l'Education Numérique en Afrique (GIP ENA)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "UBShortcutManager.h"
+#include "core/UBSettings.h"
+#include "frameworks/UBPlatformUtils.h"
+#include "gui/UBMainWindow.h"
+
+#include <QAction>
+#include <QDebug>
+#include <QWidget>
+
+// property names
+static const char* defaultShortcutProperty("defaultShortcut");
+static const char* descriptionProperty("description");
+static const char* mouseButtonProperty("mouseButton");
+static const char* tabletButtonProperty("tabletButton");
+
+UBShortcutManager* UBShortcutManager::sShortcutManager = nullptr;
+
+UBShortcutManager::UBShortcutManager() : mIgnoreCtrl(false)
+{
+    actionsOfGroup(QObject::tr("Common"));
+}
+
+UBShortcutManager *UBShortcutManager::shortcutManager()
+{
+    if (!sShortcutManager)
+    {
+        sShortcutManager = new UBShortcutManager;
+    }
+
+    return sShortcutManager;
+}
+
+void UBShortcutManager::addActions(const QString& group, const QList<QAction*> actions, QWidget *widget)
+{
+    // save default shortcuts for later
+    for (QAction* action : actions)
+    {
+        if (!action->isSeparator())
+        {
+            if (widget && !widget->actions().contains(action))
+            {
+                // associate actions with widget to make sure they are triggered when this widget is visible
+                widget->addAction(action);
+            }
+
+            QKeySequence shortcut = action->shortcut();
+
+            if (!shortcut.isEmpty())
+            {
+                action->setProperty(defaultShortcutProperty, shortcut.toString());
+            }
+
+            action->setProperty(descriptionProperty, action->toolTip());
+
+            QStringList settings = UBSettings::settings()->value("Shortcut/" + action->objectName()).toStringList();
+
+            if (settings.size() == 3)
+            {
+                if (!settings[0].isEmpty())
+                {
+                    action->setShortcut(settings[0]);
+                }
+
+                if (int button = settings[1].toInt())
+                {
+                    action->setProperty(mouseButtonProperty, button);
+                    mMouseActions[static_cast<Qt::MouseButton>(button)] = action;
+                }
+
+                if (int button = settings[2].toInt())
+                {
+                    action->setProperty(tabletButtonProperty, button);
+                    mTabletActions[static_cast<Qt::MouseButton>(button)] = action;
+                }
+            }
+
+            QString oldGroup = groupOfAction(action);
+
+            if (oldGroup.isEmpty()) {
+                actionsOfGroup(group) << action;
+            }
+            else
+            {
+                // remove from oldGroup, add to Common, which is always first group
+                actionsOfGroup(oldGroup).removeAll(action);
+                mActionGroups[0].second << action;
+            }
+        }
+    }
+}
+
+void UBShortcutManager::addMainActions(UBMainWindow *mainWindow)
+{
+    addActions(tr("Common"), {
+                   mainWindow->actionStylus,
+                   mainWindow->actionBoard,
+                   mainWindow->actionWeb,
+                   mainWindow->actionDocument,
+                   mainWindow->actionDesktop,
+                   mainWindow->actionLibrary,
+                   mainWindow->actionVirtualKeyboard,
+                   mainWindow->actionOpenTutorial,
+                   mainWindow->actionHideApplication,
+                   mainWindow->actionCut,
+                   mainWindow->actionCopy,
+                   mainWindow->actionPaste,
+                   mainWindow->actionQuit
+               }, mainWindow);
+
+    addActions(tr("Board"), {
+                   mainWindow->actionUndo,
+                   mainWindow->actionRedo,
+                   mainWindow->actionNewPage,
+                   mainWindow->actionDuplicatePage,
+                   mainWindow->actionImportPage,
+                   mainWindow->actionBack,
+                   mainWindow->actionForward,
+                   mainWindow->actionAdd,
+                   mainWindow->actionClearPage,
+                   mainWindow->actionEraseItems,
+                   mainWindow->actionEraseAnnotations,
+                   mainWindow->actionEraseBackground
+               }, mainWindow);
+
+    addActions(tr("Stylus Palette"),{
+                   mainWindow->actionPen,
+                   mainWindow->actionEraser,
+                   mainWindow->actionMarker,
+                   mainWindow->actionSelector,
+                   mainWindow->actionPlay,
+
+                   mainWindow->actionHand,
+                   mainWindow->actionZoomIn,
+                   mainWindow->actionZoomOut,
+
+                   mainWindow->actionPointer,
+                   mainWindow->actionLine,
+                   mainWindow->actionText,
+                   mainWindow->actionCapture
+               }, mainWindow);
+
+    if(UBPlatformUtils::hasVirtualKeyboard())
+    {
+        addActions(tr("Stylus Palette"),{ mainWindow->actionVirtualKeyboard }, mainWindow);
+    }
+
+    addActions(tr("Lines and colours"), {
+                   mainWindow->actionLineSmall,
+                   mainWindow->actionLineMedium,
+                   mainWindow->actionLineLarge,
+                   mainWindow->actionEraserSmall,
+                   mainWindow->actionEraserMedium,
+                   mainWindow->actionEraserLarge,
+                   mainWindow->actionColor0,
+                   mainWindow->actionColor1,
+                   mainWindow->actionColor2,
+                   mainWindow->actionColor3,
+                   mainWindow->actionColor4
+               }, mainWindow);
+
+    addActions(tr("Background"), {
+                   mainWindow->actionBackgrounds,
+                   mainWindow->actionPlainLightBackground,
+                   mainWindow->actionCrossedLightBackground,
+                   mainWindow->actionRuledLightBackground,
+                   mainWindow->actionPlainDarkBackground,
+                   mainWindow->actionCrossedDarkBackground,
+                   mainWindow->actionRuledDarkBackground,
+                   mainWindow->actionDefaultGridSize,
+                   mainWindow->actionDrawIntermediateGridLines
+               }, mainWindow);
+
+    addActions(tr("Podcast"), {
+                   mainWindow->actionPodcastRecord //,
+                   // mainWindow->actionPodcastPause currently not activated in UBPodcastRecordingPalette
+               }, mainWindow);
+
+    // add builtIn actions
+    QList<QAction*> actions;
+
+    QAction* action = new QAction(this);
+    action->setText(mainWindow->actionBack->text());
+    action->setToolTip(mainWindow->actionBack->toolTip());
+    action->setShortcuts( { QKeySequence(Qt::Key_Up), QKeySequence(Qt::Key_PageUp), QKeySequence(Qt::Key_Left) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(mainWindow->actionForward->text());
+    action->setToolTip(mainWindow->actionForward->toolTip());
+    action->setShortcuts( { QKeySequence(Qt::Key_Down), QKeySequence(Qt::Key_PageDown), QKeySequence(Qt::Key_Right), QKeySequence(Qt::Key_Space) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("First scene"));
+    action->setToolTip(tr("Show first scene"));
+    action->setShortcuts( { QKeySequence(Qt::Key_Home) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("Last scene"));
+    action->setToolTip(tr("Show last scene"));
+    action->setShortcuts( { QKeySequence(Qt::Key_End) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(mainWindow->actionNewPage->text());
+    action->setToolTip(mainWindow->actionNewPage->toolTip());
+    action->setShortcuts( { QKeySequence(Qt::Key_Insert) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(mainWindow->actionZoomIn->text());
+    action->setToolTip(mainWindow->actionZoomIn->toolTip());
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_Plus) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(mainWindow->actionZoomOut->text());
+    action->setToolTip(mainWindow->actionZoomOut->toolTip());
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_Minus) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("Zoom reset"));
+    action->setToolTip(tr("Reset zoom factor"));
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_0) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("Scroll left"));
+    action->setToolTip(tr("Scroll page left"));
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_Left) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("Scroll right"));
+    action->setToolTip(tr("Scroll page right"));
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_Right) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("Scroll up"));
+    action->setToolTip(tr("Scroll page up"));
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_Up) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    action = new QAction(this);
+    action->setText(tr("Scroll down"));
+    action->setToolTip(tr("Scroll page down"));
+    action->setShortcuts( { QKeySequence(Qt::CTRL | Qt::Key_Down) } );
+    action->setProperty("builtIn", true);
+    actions << action;
+
+    addActions(tr("Built-in (not editable)"), actions);
+
+    // load ignoreCtrl setting
+    ignoreCtrl(UBSettings::settings()->value("Shortcut/IgnoreCtrl").toBool());
+}
+
+bool UBShortcutManager::handleMouseEvent(QMouseEvent *event)
+{
+    if (mMouseActions.contains(event->button()))
+    {
+        QAction* action = mMouseActions[event->button()];
+
+        if (!action->isCheckable() || !action->actionGroup() || !action->isChecked())
+        {
+            action->trigger();
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+bool UBShortcutManager::handleTabletEvent(QTabletEvent *event)
+{
+    if (mTabletActions.contains(event->button()))
+    {
+        QAction* action = mTabletActions[event->button()];
+
+        if (!action->isCheckable() || !action->actionGroup() || !action->isChecked())
+        {
+            action->trigger();
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+int UBShortcutManager::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+
+    int rows = 0;
+
+    for (auto& actionGroup : mActionGroups)
+    {
+        ++rows;
+        rows += actionGroup.second.size();
+    }
+
+    return rows;
+}
+
+int UBShortcutManager::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return 5;
+}
+
+QVariant UBShortcutManager::data(const QModelIndex &index, int role) const
+{
+    QString group;
+    QAction* action = getAction(index, &group);
+
+    switch (role)
+    {
+    case Qt::DisplayRole:
+    case Qt::ToolTipRole:
+        switch (index.column())
+        {
+        case 0:
+            return action ? action->text() : group;
+
+        case 1:
+            return action ? action->property(descriptionProperty) : "";
+
+        case 2:
+        {
+            if (!action)
+            {
+                return "";
+            }
+
+            QStringList result;
+
+            for (const QKeySequence& shortcut : action->shortcuts())
+            {
+                result << shortcut.toString();
+            }
+
+            return result.join(", ");
+        }
+
+        case 3:
+            return action ? buttonName(static_cast<Qt::MouseButton>(action->property(mouseButtonProperty).toInt())) : QVariant();
+
+        case 4:
+            return action ? buttonName(static_cast<Qt::MouseButton>(action->property(tabletButtonProperty).toInt())) : QVariant();
+        }
+        break;
+
+    case Qt::FontRole:
+    {
+        QFont groupFont;
+        groupFont.setBold(true);
+        groupFont.setItalic(true);
+
+        QFont disabledFont;
+        disabledFont.setItalic(true);
+
+        return action ? (action->property("builtIn").toBool() ? disabledFont : QVariant()) : groupFont;
+    }
+
+    case UBShortcutManager::ActionRole:
+        return action && !action->property("builtIn").toBool();
+
+    case UBShortcutManager::GroupHeaderRole:
+        return !action;
+
+    case UBShortcutManager::PrimaryShortcutRole:
+        return (index.column() == 2 && action) ? action->shortcut().toString() : QVariant();
+
+    case Qt::DecorationRole:
+    case Qt::EditRole:
+    case Qt::StatusTipRole:
+    case Qt::WhatsThisRole:
+    case Qt::SizeHintRole:
+    case Qt::TextAlignmentRole:
+    case Qt::BackgroundRole:
+    case Qt::ForegroundRole:
+    case Qt::CheckStateRole:
+    case Qt::InitialSortOrderRole:
+        return QVariant();
+    }
+
+    return QVariant();
+}
+
+QVariant UBShortcutManager::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Orientation::Horizontal && role == Qt::DisplayRole)
+    {
+        switch (section)
+        {
+        case 0:
+            return tr("Command");
+
+        case 1:
+            return tr("Description");
+
+        case 2:
+            return tr("Key Sequence");
+
+        case 3:
+            return tr("Mouse Button");
+
+        case 4:
+            return tr("Tablet Button");
+        }
+    }
+
+    return QVariant();
+}
+
+bool UBShortcutManager::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    Q_UNUSED(role)
+
+    if (!index.isValid())
+    {
+        return false;
+    }
+
+    QAction* action = getAction(index);
+
+    switch (index.column())
+    {
+    case 2:
+    {
+        QKeySequence keySequence(value.toString());
+
+        action->setShortcut(keySequence);
+        updateSettings(action);
+        emit dataChanged(index, index);
+        return true;
+    }
+
+    case 3:
+        action->setProperty(mouseButtonProperty, value);
+        mMouseActions[static_cast<Qt::MouseButton>(value.toInt())] = action;
+        updateSettings(action);
+        emit dataChanged(index, index);
+        return true;
+
+    case 4:
+        action->setProperty(tabletButtonProperty, value);
+        mTabletActions[static_cast<Qt::MouseButton>(value.toInt())] = action;
+        updateSettings(action);
+        emit dataChanged(index, index);
+        return true;
+    }
+
+    return false;
+}
+
+bool UBShortcutManager::resetData(const QModelIndex &index)
+{
+    QAction* action = getAction(index);
+
+    if (action)
+    {
+        QKeySequence shortcut(action->property(defaultShortcutProperty).toString());
+        action->setShortcut(shortcut);
+        mMouseActions.remove(static_cast<Qt::MouseButton>(action->property(mouseButtonProperty).toInt()));
+        mTabletActions.remove(static_cast<Qt::MouseButton>(action->property(tabletButtonProperty).toInt()));
+        action->setProperty(mouseButtonProperty, QVariant());
+        action->setProperty(tabletButtonProperty, QVariant());
+        updateSettings(action);
+        emit dataChanged(index.siblingAtColumn(2), index.siblingAtColumn(4));
+        return true;
+    }
+
+    return false;
+}
+
+bool UBShortcutManager::checkData(const QModelIndex &index, const QVariant &value) const
+{
+    int col = index.column();
+
+    if (col < 2)
+    {
+        return true;
+    }
+
+    for (int row = 0; row < rowCount(); ++row)
+    {
+        if (data(index.siblingAtRow(row)).toString().split(", ").contains(value.toString()))
+        {
+            // duplicate value
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool UBShortcutManager::hasCtrlConflicts(const QKeySequence &additionalShortcut) const
+{
+    QSet<QKeySequence> shortcuts;
+    QSet<QKeySequence> ctrlShortcuts;
+
+    for (int row = 1; row < rowCount(); ++row)
+    {
+        QAction* action = getAction(index(row, 0));
+
+        if (!action)
+        {
+            continue;
+        }
+
+        if (action->property("builtIn").toBool())
+        {
+            for (const QKeySequence& shortcut : action->shortcuts())
+            {
+                shortcuts << shortcut;
+            }
+        }
+        else
+        {
+            shortcuts << action->shortcut();
+            ctrlShortcuts << QKeySequence(action->shortcut()[0] ^ Qt::CTRL);
+        }
+
+    }
+
+    if (!additionalShortcut.isEmpty())
+    {
+        shortcuts << additionalShortcut;
+        ctrlShortcuts << QKeySequence(additionalShortcut[0] ^ Qt::CTRL);
+    }
+
+    return shortcuts.intersects(ctrlShortcuts);
+}
+
+QString UBShortcutManager::buttonName(Qt::MouseButton button)
+{
+    switch (button)
+    {
+    case Qt::LeftButton: return tr("Left", "MouseButton");
+    case Qt::RightButton: return tr("Right", "MouseButton");
+    case Qt::MiddleButton: return tr("Middle", "MouseButton");
+    case Qt::BackButton: return tr("Back", "MouseButton");
+    case Qt::ForwardButton: return tr("Forward", "MouseButton");
+    case Qt::TaskButton: return tr("Task", "MouseButton");
+    case Qt::ExtraButton4: return tr("Extra", "MouseButton") + "4";
+    case Qt::ExtraButton5: return tr("Extra", "MouseButton") + "5";
+    case Qt::ExtraButton6: return tr("Extra", "MouseButton") + "6";
+    case Qt::ExtraButton7: return tr("Extra", "MouseButton") + "7";
+    case Qt::ExtraButton8: return tr("Extra", "MouseButton") + "8";
+    case Qt::ExtraButton9: return tr("Extra", "MouseButton") + "9";
+    case Qt::ExtraButton10: return tr("Extra", "MouseButton") + "10";
+    case Qt::ExtraButton11: return tr("Extra", "MouseButton") + "11";
+    case Qt::ExtraButton12: return tr("Extra", "MouseButton") + "12";
+    case Qt::ExtraButton13: return tr("Extra", "MouseButton") + "13";
+    case Qt::ExtraButton14: return tr("Extra", "MouseButton") + "14";
+    case Qt::ExtraButton15: return tr("Extra", "MouseButton") + "15";
+    case Qt::ExtraButton16: return tr("Extra", "MouseButton") + "16";
+    case Qt::ExtraButton17: return tr("Extra", "MouseButton") + "17";
+    case Qt::ExtraButton18: return tr("Extra", "MouseButton") + "18";
+    case Qt::ExtraButton19: return tr("Extra", "MouseButton") + "19";
+    case Qt::ExtraButton20: return tr("Extra", "MouseButton") + "20";
+    case Qt::ExtraButton21: return tr("Extra", "MouseButton") + "21";
+    case Qt::ExtraButton22: return tr("Extra", "MouseButton") + "22";
+    case Qt::ExtraButton23: return tr("Extra", "MouseButton") + "23";
+    case Qt::ExtraButton24: return tr("Extra", "MouseButton") + "24";
+    default: return "";
+    }
+}
+
+Qt::MouseButton UBShortcutManager::buttonIndex(QString button)
+{
+    for (unsigned int index = Qt::LeftButton; index < Qt::AllButtons; index <<= 1)
+    {
+        Qt::MouseButton but = static_cast<Qt::MouseButton>(index);
+
+        if (button == buttonName(but))
+        {
+            return but;
+        }
+    }
+
+    return Qt::NoButton;
+}
+
+void UBShortcutManager::ignoreCtrl(bool ignore)
+{
+    if (ignore == mIgnoreCtrl) {
+        return;
+    }
+
+    mIgnoreCtrl = ignore;
+
+    for (auto& actionGroup : mActionGroups)
+    {
+        for (QAction* action : actionGroup.second)
+        {
+            if (!action->property("builtIn").toBool())
+            {
+                QList<QKeySequence> shortcuts = action->shortcuts();
+
+                if (ignore && !shortcuts.empty() && shortcuts[0][0] & Qt::CTRL) {
+                    QKeySequence noCtrl(shortcuts[0][0] ^ Qt::CTRL);
+                    shortcuts << noCtrl;
+                    action->setShortcuts(shortcuts);
+                }
+                else if (!ignore && shortcuts.size() > 1)
+                {
+                    action->setShortcuts( { shortcuts[0] } );
+                }
+            }
+        }
+    }
+
+    UBSettings::settings()->setValue("Shortcut/IgnoreCtrl", ignore);
+    emit dataChanged(index(0, 2), index(rowCount(), 2));
+}
+
+QString UBShortcutManager::groupOfAction(const QAction *action) const
+{
+    for (auto& actionGroup : mActionGroups)
+    {
+        for (QAction* actionInGroup : actionGroup.second)
+        {
+            if (action == actionInGroup)
+            {
+                return actionGroup.first;
+            }
+        }
+    }
+
+    return QString();
+}
+
+QList<QAction *> &UBShortcutManager::actionsOfGroup(const QString &group)
+{
+    for (auto& actionGroup : mActionGroups)
+    {
+        if (actionGroup.first == group) {
+            return actionGroup.second;
+        }
+    }
+
+    QPair<QString,QList<QAction*>> actionGroup;
+    actionGroup.first = group;
+    mActionGroups << actionGroup;
+
+    return mActionGroups.last().second;
+}
+
+QAction *UBShortcutManager::getAction(const QModelIndex &index, QString *group) const
+{
+    int row = index.row();
+
+    for (auto& actionGroup : mActionGroups)
+    {
+        if (row == 0)
+        {
+            if (group)
+            {
+                *group = actionGroup.first;
+            }
+
+            return nullptr;
+        }
+
+        if (row <= actionGroup.second.size())
+        {
+            if (group)
+            {
+                *group = actionGroup.first;
+            }
+
+            return actionGroup.second[row - 1];
+        }
+
+        --row;
+        row -= actionGroup.second.size();
+    }
+
+    if (group)
+    {
+        group->clear();
+    }
+
+    return nullptr;
+}
+
+void UBShortcutManager::updateSettings(const QAction *action) const
+{
+    QString key = "Shortcut/" + action->objectName();
+    QString keySequence = action->shortcut().toString();
+    QString defaultSequence = action->property(defaultShortcutProperty).toString();
+    int mouseButton = action->property(mouseButtonProperty).toInt();
+    int tabletButton = action->property(tabletButtonProperty).toInt();
+
+    if (keySequence == defaultSequence && mouseButton == 0 && tabletButton == 0)
+    {
+        // back to default, delete settings
+        UBSettings::settings()->setValue(key, QVariant());
+    }
+    else
+    {
+        QStringList list;
+        list << keySequence;
+        list << QString("%1").arg(mouseButton);
+        list << QString("%1").arg(tabletButton);
+        UBSettings::settings()->setValue(key, list);
+    }
+}

--- a/src/core/UBShortcutManager.cpp
+++ b/src/core/UBShortcutManager.cpp
@@ -294,6 +294,20 @@ void UBShortcutManager::addMainActions(UBMainWindow *mainWindow)
     ignoreCtrl(UBSettings::settings()->value("Shortcut/IgnoreCtrl").toBool());
 }
 
+void UBShortcutManager::addActionGroup(QActionGroup *actionGroup)
+{
+    mActionGroupHistoryMap[actionGroup] = new UBActionGroupHistory(actionGroup);
+}
+
+void UBShortcutManager::removeActionGroup(QActionGroup *actionGroup)
+{
+    if (mActionGroupHistoryMap.contains(actionGroup))
+    {
+        delete mActionGroupHistoryMap[actionGroup];
+        mActionGroupHistoryMap.remove(actionGroup);
+    }
+}
+
 bool UBShortcutManager::handleMouseEvent(QMouseEvent *event)
 {
     if (mMouseActions.contains(event->button()))
@@ -323,6 +337,18 @@ bool UBShortcutManager::handleTabletEvent(QTabletEvent *event)
         }
 
         return true;
+    }
+
+    return false;
+}
+
+bool UBShortcutManager::handleKeyReleaseEvent(QKeyEvent *event)
+{
+    for (UBActionGroupHistory* actionGroupHistory : mActionGroupHistoryMap.values())
+    {
+        if (actionGroupHistory->keyReleased(event)) {
+            return true;
+        }
     }
 
     return false;
@@ -479,6 +505,16 @@ bool UBShortcutManager::setData(const QModelIndex &index, const QVariant &value,
 
     case 3:
         action->setProperty(mouseButtonProperty, value);
+
+        for (Qt::MouseButton key : mMouseActions.keys())
+        {
+            if (mMouseActions[key] == action)
+            {
+                mMouseActions.remove(key);
+                break;
+            }
+        }
+
         mMouseActions[static_cast<Qt::MouseButton>(value.toInt())] = action;
         updateSettings(action);
         emit dataChanged(index, index);
@@ -486,6 +522,16 @@ bool UBShortcutManager::setData(const QModelIndex &index, const QVariant &value,
 
     case 4:
         action->setProperty(tabletButtonProperty, value);
+
+        for (Qt::MouseButton key : mTabletActions.keys())
+        {
+            if (mTabletActions[key] == action)
+            {
+                mTabletActions.remove(key);
+                break;
+            }
+        }
+
         mTabletActions[static_cast<Qt::MouseButton>(value.toInt())] = action;
         updateSettings(action);
         emit dataChanged(index, index);
@@ -748,4 +794,60 @@ void UBShortcutManager::updateSettings(const QAction *action) const
         list << QString("%1").arg(tabletButton);
         UBSettings::settings()->setValue(key, list);
     }
+}
+
+// ---------- UBActionGroupHistory ----------
+
+UBActionGroupHistory::UBActionGroupHistory(QActionGroup *parent)
+    : QObject(parent)
+    , mActionGroup(parent)
+    , mCurrentAction(parent->checkedAction())
+    , mPreviousAction(nullptr)
+    , mRevertingAction(nullptr)
+{
+    connect(parent, &QActionGroup::triggered, this, &UBActionGroupHistory::triggered);
+}
+
+void UBActionGroupHistory::triggered(QAction *action)
+{
+    if (mCurrentAction != action)
+    {
+        mPreviousAction = mCurrentAction;
+        mCurrentAction = action;
+    }
+}
+
+bool UBActionGroupHistory::keyReleased(QKeyEvent *event)
+{
+    int key = event->key() & ~Qt::KeyboardModifierMask;
+
+    for (QAction* action : mActionGroup->actions())
+    {
+        QKeySequence keySequence = action->shortcut();
+
+        if (keySequence.count() > 0)
+        {
+            int actionKey = action->shortcut()[0] & ~Qt::KeyboardModifierMask;
+
+            if (key == actionKey)
+            {
+                if (event->isAutoRepeat())
+                {
+                    if (!mRevertingAction)
+                    {
+                        mRevertingAction = mPreviousAction;;
+                    }
+                }
+                else if (mRevertingAction)
+                {
+                    mRevertingAction->trigger();
+                    mRevertingAction = nullptr;
+                }
+
+                return true;
+            }
+        }
+    }
+
+    return false;
 }

--- a/src/core/UBShortcutManager.h
+++ b/src/core/UBShortcutManager.h
@@ -36,11 +36,13 @@
 #include <QTabletEvent>
 
 class QAction;
+class QActionGroup;
 class UBMainWindow;
+class UBActionGroupHistory;
 
 class UBShortcutManager : public QAbstractTableModel
 {
-    Q_OBJECT;
+    Q_OBJECT
 
 private:
     UBShortcutManager();
@@ -57,8 +59,12 @@ public:
     void addActions(const QString& group, const QList<QAction*> actions, QWidget* widget = nullptr);
     void addMainActions(UBMainWindow* mainWindow);
 
+    void addActionGroup(QActionGroup* actionGroup);
+    void removeActionGroup(QActionGroup* actionGroup);
+
     bool handleMouseEvent(QMouseEvent* event);
     bool handleTabletEvent(QTabletEvent* event);
+    bool handleKeyReleaseEvent(QKeyEvent* event);
 
     // QAbstractTableModel overrides
     virtual int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
@@ -87,9 +93,28 @@ private:
     QList<QPair<QString,QList<QAction*>>> mActionGroups;
     QMap<Qt::MouseButton, QAction*> mMouseActions;
     QMap<Qt::MouseButton, QAction*> mTabletActions;
+    QMap<QActionGroup*, UBActionGroupHistory*> mActionGroupHistoryMap;
     bool mIgnoreCtrl;
 
     static UBShortcutManager* sShortcutManager;
+};
+
+class UBActionGroupHistory : public QObject
+{
+    Q_OBJECT
+
+public:
+    UBActionGroupHistory(QActionGroup* parent);
+
+public slots:
+    void triggered(QAction* action);
+    bool keyReleased(QKeyEvent* event);
+
+private:
+    QActionGroup* mActionGroup;
+    QAction* mCurrentAction;
+    QAction* mPreviousAction;
+    QAction* mRevertingAction;
 };
 
 #endif // UBSHORTCUTMANAGER_H

--- a/src/core/UBShortcutManager.h
+++ b/src/core/UBShortcutManager.h
@@ -1,0 +1,95 @@
+﻿/*
+ * Copyright (C) 2015-2018 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * Copyright (C) 2013 Open Education Foundation
+ *
+ * Copyright (C) 2010-2013 Groupement d'Intérêt Public pour
+ * l'Education Numérique en Afrique (GIP ENA)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef UBSHORTCUTMANAGER_H
+#define UBSHORTCUTMANAGER_H
+
+#include <QAbstractTableModel>
+#include <QList>
+#include <QMap>
+#include <QMouseEvent>
+#include <QPair>
+#include <QTabletEvent>
+
+class QAction;
+class UBMainWindow;
+
+class UBShortcutManager : public QAbstractTableModel
+{
+    Q_OBJECT;
+
+private:
+    UBShortcutManager();
+
+public:
+    static UBShortcutManager* shortcutManager();
+
+    enum {
+        ActionRole = Qt::UserRole,      // bool, true if row contains editable action
+        GroupHeaderRole,                // bool, true if row is group header
+        PrimaryShortcutRole             // QString, primary shortcut, only valid on column 2
+    };
+
+    void addActions(const QString& group, const QList<QAction*> actions, QWidget* widget = nullptr);
+    void addMainActions(UBMainWindow* mainWindow);
+
+    bool handleMouseEvent(QMouseEvent* event);
+    bool handleTabletEvent(QTabletEvent* event);
+
+    // QAbstractTableModel overrides
+    virtual int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
+    virtual int columnCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
+    virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) Q_DECL_OVERRIDE;
+
+    bool resetData(const QModelIndex &index);
+    bool checkData(const QModelIndex &index, const QVariant &value) const;
+    bool hasCtrlConflicts(const QKeySequence& additionalShortcut = QKeySequence()) const;
+
+    static QString buttonName(Qt::MouseButton button);
+    static Qt::MouseButton buttonIndex(QString button);
+
+public slots:
+    void ignoreCtrl(bool ignore);
+
+private:
+    QString groupOfAction(const QAction* action) const;
+    QList<QAction*>& actionsOfGroup(const QString& group);
+    QAction* getAction(const QModelIndex& index, QString* group = nullptr) const;
+    void updateSettings(const QAction* action) const;
+
+private:
+    QList<QPair<QString,QList<QAction*>>> mActionGroups;
+    QMap<Qt::MouseButton, QAction*> mMouseActions;
+    QMap<Qt::MouseButton, QAction*> mTabletActions;
+    bool mIgnoreCtrl;
+
+    static UBShortcutManager* sShortcutManager;
+};
+
+#endif // UBSHORTCUTMANAGER_H

--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,5 +1,6 @@
 
 HEADERS      += src/core/UB.h \
+                src/core/UBShortcutManager.h \
                 src/core/UBApplication.h \
                 src/core/UBSettings.h \
                 src/core/UBSetting.h \
@@ -18,6 +19,7 @@ HEADERS      += src/core/UB.h \
     $$PWD/UBForeignObjectsHandler.h
 
 SOURCES      += src/core/main.cpp \
+                src/core/UBShortcutManager.cpp \
                 src/core/UBApplication.cpp \
                 src/core/UBSettings.cpp \
                 src/core/UBSetting.cpp \

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -506,6 +506,7 @@ bool UBGraphicsScene::inputDeviceMove(const QPointF& scenePos, const qreal& pres
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)dc->stylusTool();
 
     QPointF position = QPointF(scenePos);
+    mCurrentPoint = position;
 
     if (currentTool == UBStylusTool::Eraser)
     {
@@ -673,14 +674,9 @@ bool UBGraphicsScene::inputDeviceRelease(int tool)
     }
 
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)tool;
-
-    if (currentTool == UBStylusTool::Eraser)
-        hideEraser();
-
-
     UBDrawingController *dc = UBDrawingController::drawingController();
 
-    if (dc->isDrawingTool() || mDrawWithCompass)
+    if (dc->isDrawingTool(tool) || mDrawWithCompass)
     {
         if(mArcPolygonItem){
 
@@ -2405,12 +2401,21 @@ void UBGraphicsScene::resizedMagnifier(qreal newPercent)
 
 void UBGraphicsScene::stylusToolChanged(int tool, int previousTool)
 {
-    if (mInputDeviceIsPressed && tool != previousTool)
+    if (tool != previousTool)
     {
-        // tool was changed while input device is pressed
-        // simulate release and press to terminate pervious strokes
-        inputDeviceRelease(previousTool);
-        inputDevicePress(mPreviousPoint);
+        hideTool();
+
+        if (mInputDeviceIsPressed)
+        {
+            // tool was changed while input device is pressed
+            // simulate release and press to terminate previous strokes
+            inputDeviceRelease(previousTool);
+            inputDevicePress(mCurrentPoint);
+        }
+        else if (previousTool >= 0)
+        {
+            inputDeviceMove(mCurrentPoint);
+        }
     }
 }
 

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -468,6 +468,7 @@ signals:
         QPointF mPreviousPoint;
         qreal mPreviousWidth;
         qreal mDistanceFromLastStrokePoint;
+        QPointF mCurrentPoint;
 
         QList<UBGraphicsPolygonItem*> mPreviousPolygonItems;
 

--- a/src/gui/UBActionPalette.cpp
+++ b/src/gui/UBActionPalette.cpp
@@ -68,7 +68,7 @@ void UBActionPalette::init(Qt::Orientation orientation)
     mButtonSize = QSize(32, 32);
     mIsClosable = false;
     mAutoClose = false;
-    mButtonGroup = 0;
+    mActionGroup = 0;
     mToolButtonStyle = Qt::ToolButtonIconOnly;
     mButtons.clear();
 
@@ -98,9 +98,10 @@ UBActionPaletteButton* UBActionPalette::createPaletteButton(QAction* action, QWi
     UBActionPaletteButton* button = new UBActionPaletteButton(action, parent);
     button->setIconSize(mButtonSize);
     button->setToolButtonStyle(mToolButtonStyle);
+    action->setProperty("id", mButtons.length());
 
-    if (mButtonGroup)
-        mButtonGroup->addButton(button, mButtons.length());
+    if (mActionGroup)
+        mActionGroup->addAction(action);
 
     mButtons << button;
 
@@ -155,16 +156,19 @@ void UBActionPalette::setButtonIconSize(const QSize& size)
 
 void UBActionPalette::groupActions()
 {
-    mButtonGroup = new QButtonGroup(this);
+    mActionGroup = new QActionGroup(this);
     int i = 0;
-    foreach(QToolButton* button, mButtons)
+    foreach(QAction* action, mActions)
     {
-        mButtonGroup->addButton(button, i);
-        ++i;
+        if (!action->property("ungrouped").toBool())
+        {
+            action->setProperty("id", i);
+            mActionGroup->addAction(action);
+            ++i;
+        }
     }
 
-    connect(mButtonGroup, qOverload<QAbstractButton *>(&QButtonGroup::buttonClicked),
-            this, &UBActionPalette::buttonGroupClicked);
+    connect(mActionGroup, SIGNAL(triggered(QAction*)), this, SIGNAL(buttonGroupClicked(QAction*)));
 }
 
 

--- a/src/gui/UBActionPalette.h
+++ b/src/gui/UBActionPalette.h
@@ -32,7 +32,7 @@
 
 #include <QtGui>
 #include <QPoint>
-#include <QButtonGroup>
+#include <QActionGroup>
 #include <QToolButton>
 
 #include "UBFloatingPalette.h"
@@ -83,7 +83,7 @@ class UBActionPalette : public UBFloatingPalette
 
     signals:
         void closed();
-        void buttonGroupClicked(QAbstractButton *button);
+        void buttonGroupClicked(QAction* action);
         void customMouseReleased();
 
     protected:
@@ -94,7 +94,7 @@ class UBActionPalette : public UBFloatingPalette
         virtual void updateLayout();
 
         QList<UBActionPaletteButton*> mButtons;
-        QButtonGroup* mButtonGroup;
+        QActionGroup* mActionGroup;
         QList<QAction*> mActions;
         QMap<QAction*, UBActionPaletteButton*> mMapActionToButton;
 

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -29,7 +29,6 @@ void UBBackgroundPalette::init()
     mButtonSize = QSize(32, 32);
     mIsClosable = false;
     mAutoClose = false;
-    mButtonGroup = 0;
     mToolButtonStyle = Qt::ToolButtonIconOnly;
     mButtons.clear();
 
@@ -60,8 +59,7 @@ void UBBackgroundPalette::init()
     mDrawIntermediateLinesCheckBox->setFixedSize(24,24);
     mDrawIntermediateLinesCheckBox->setCheckable(true);
     mActions << UBApplication::mainWindow->actionDrawIntermediateGridLines;
-    mButtons.removeLast(); // don't add to button group
-
+    UBApplication::mainWindow->actionDrawIntermediateGridLines->setProperty("ungrouped", true);
     connect(UBApplication::mainWindow->actionDrawIntermediateGridLines, SIGNAL(toggled(bool)), this, SLOT(toggleIntermediateLines(bool)));
 
     mBottomLayout->addSpacing(16);

--- a/src/gui/UBMainWindow.cpp
+++ b/src/gui/UBMainWindow.cpp
@@ -36,6 +36,7 @@
 #include "core/UBApplicationController.h"
 #include "board/UBBoardController.h"
 #include "core/UBDisplayManager.h"
+#include "core/UBShortcutManager.h"
 
 // work around for handling tablet events on MAC OS with Qt 4.8.0 and above
 #if defined(Q_OS_OSX)
@@ -76,6 +77,8 @@ UBMainWindow::UBMainWindow(QWidget *parent, Qt::WindowFlags flags)
 #else
     actionQuit->setShortcut(QKeySequence(Qt::ALT + Qt::Key_F4));
 #endif
+
+    UBShortcutManager::shortcutManager()->addMainActions(this);
 }
 
 UBMainWindow::~UBMainWindow()

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -36,6 +36,8 @@
 #include "core/UBApplication.h"
 #include "core/UBSettings.h"
 #include "core/UBApplicationController.h"
+#include "core/UBShortcutManager.h"
+
 
 #include "board/UBDrawingController.h"
 
@@ -87,6 +89,8 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
         connect(mActionGroup, SIGNAL(triggered(QAction*)), this, SIGNAL(buttonGroupClicked(QAction*)));
     }
 
+    UBShortcutManager::shortcutManager()->addActionGroup(mActionGroup);
+
     adjustSizeAndPosition();
 
     initPosition();
@@ -126,7 +130,10 @@ void UBStylusPalette::initPosition()
 
 UBStylusPalette::~UBStylusPalette()
 {
-
+    if (mActionGroup)
+    {
+        UBShortcutManager::shortcutManager()->removeActionGroup(mActionGroup);
+    }
 }
 
 void UBStylusPalette::stylusToolDoubleClicked()

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -78,13 +78,13 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
     {
         // VirtualKeyboard action is not in group
         // So, groupping all buttons, except last
-        mButtonGroup = new QButtonGroup(this);
-        for(int i=0; i < mButtons.size()-1; i++)
+        mActionGroup = new QActionGroup(this);
+        for(int i=0; i < mActions.size()-1; i++)
         {
-            mButtonGroup->addButton(mButtons[i], i);
+            mActions[i]->setProperty("id", i);
+            mActionGroup->addAction(mActions[i]);
         }
-        connect(mButtonGroup, qOverload<QAbstractButton *>(&QButtonGroup::buttonClicked),
-                this, &UBActionPalette::buttonGroupClicked);
+        connect(mActionGroup, SIGNAL(triggered(QAction*)), this, SIGNAL(buttonGroupClicked(QAction*)));
     }
 
     adjustSizeAndPosition();
@@ -131,7 +131,7 @@ UBStylusPalette::~UBStylusPalette()
 
 void UBStylusPalette::stylusToolDoubleClicked()
 {
-    emit stylusToolDoubleClicked(mButtonGroup->checkedId());
+    emit stylusToolDoubleClicked(mActionGroup->checkedAction()->property("id").toInt());
 }
 
 

--- a/src/gui/UBToolbarButtonGroup.cpp
+++ b/src/gui/UBToolbarButtonGroup.cpp
@@ -127,7 +127,11 @@ void UBToolbarButtonGroup::setIcon(const QIcon &icon, int index)
         QToolButton *button = qobject_cast<QToolButton*>(widget);
         if (button)
         {
-            button->setIcon(icon);
+            // change icon at action, so that updates of action do not overwrite the icon
+            for (QAction* action : button->actions())
+            {
+                action->setIcon(icon);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR is a subset of #955 with all the improvements in shortcut handling, but without the preferences dialog.

It contains all improvements described here: https://github.com/OpenBoard-org/OpenBoard/pull/955#issuecomment-2306416089. 

It also contains the option to use shortcuts without the `Ctrl` modifier by setting

```ini
[Shortcut]
IgnoreCtrl=true
```

in the configuration file. This is especially useful to activate shortcuts with a single hand.

Note that this PR already contains the full-fledged `UBShortcutManager`, which includes collecting shortcuts from various places and presenting them as a table model for a UI. This is the base for implementing a configuration dialog later, even if many of its functions are currently unused.