### PR TITLE
Fix Qt 6.8 warnings

### DIFF
--- a/plugins/cffadaptor/src/UBCFFAdaptor.cpp
+++ b/plugins/cffadaptor/src/UBCFFAdaptor.cpp
@@ -442,7 +442,6 @@ bool UBCFFAdaptor::UBToCFFConverter::parse()
 }
 bool UBCFFAdaptor::UBToCFFConverter::parseMetadata()
 {
-    int errorLine, errorColumn;
     QFile metaDataFile(sourcePath + "/" + fMetadata);
 
     if (!metaDataFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -450,10 +449,23 @@ bool UBCFFAdaptor::UBToCFFConverter::parseMetadata()
         qDebug() << errorStr;
         return false;
 
-    } else if (!mDataModel->setContent(metaDataFile.readAll(), true, &errorStr, &errorLine, &errorColumn)) {
-        qWarning() << "Error:Parseerroratline" << errorLine << ","
-                   << "column" << errorColumn << ":" << errorStr;
-        return false;
+    } else {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+        QDomDocument::ParseResult result = mDataModel->setContent(metaDataFile.readAll(), QDomDocument::ParseOption::UseNamespaceProcessing);
+        if (!result) {
+            errorStr = result.errorMessage;
+            qWarning() << "Error:Parseerroratline" << result.errorLine << ","
+                       << "column" << result.errorColumn << ":" << errorStr;
+            return false;
+        }
+#else
+        int errorLine, errorColumn;
+        if (!mDataModel->setContent(metaDataFile.readAll(), true, &errorStr, &errorLine, &errorColumn)) {
+            qWarning() << "Error:Parseerroratline" << errorLine << ","
+                       << "column" << errorColumn << ":" << errorStr;
+            return false;
+        }
+#endif
     }
 
     QDomElement nextInElement = mDataModel->documentElement();
@@ -560,17 +572,29 @@ QDomElement UBCFFAdaptor::UBToCFFConverter::parsePage(const QString &pageFileNam
     qDebug() << "begin parsing page" + pageFileName;
     mSvgElements.clear(); //clean Svg elements map before parsing new page
 
-    int errorLine, errorColumn;
-
     QFile pageFile(sourcePath + "/" + pageFileName);
     if (!pageFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qDebug() << "can't open file" << pageFileName << "for reading";
         return QDomElement();
-    } else if (!mDataModel->setContent(pageFile.readAll(), true, &errorStr, &errorLine, &errorColumn)) {
-        qWarning() << "Error:Parseerroratline" << errorLine << ","
-                   << "column" << errorColumn << ":" << errorStr;
-        pageFile.close();
-        return QDomElement();
+    } else {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+        QDomDocument::ParseResult result = mDataModel->setContent(pageFile.readAll(), QDomDocument::ParseOption::UseNamespaceProcessing);
+        if (!result) {
+            errorStr = result.errorMessage;
+            qWarning() << "Error:Parseerroratline" << result.errorLine << ","
+                       << "column" << result.errorColumn << ":" << errorStr;
+            pageFile.close();
+            return QDomElement();
+        }
+#else
+        int errorLine, errorColumn;
+        if (!mDataModel->setContent(pageFile.readAll(), true, &errorStr, &errorLine, &errorColumn)) {
+            qWarning() << "Error:Parseerroratline" << errorLine << ","
+                       << "column" << errorColumn << ":" << errorStr;
+            pageFile.close();
+            return QDomElement();
+        }
+#endif
     }
 
     QDomElement page;

--- a/src/adaptors/UBCFFSubsetAdaptor.cpp
+++ b/src/adaptors/UBCFFSubsetAdaptor.cpp
@@ -147,9 +147,17 @@ UBCFFSubsetAdaptor::UBCFFSubsetReader::UBCFFSubsetReader(std::shared_ptr<UBDocum
     : mProxy(proxy)
     , mGSectionContainer(NULL)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    QDomDocument::ParseResult result = mDOMdoc.setContent(content, QDomDocument::ParseOption::UseNamespaceProcessing);
+    int errorLine = result.errorLine;
+    int errorColumn = result.errorColumn;
+    QString errorStr = result.errorMessage;
+#else
     int errorLine, errorColumn;
     QString errorStr;
-    if(!mDOMdoc.setContent(content, true, &errorStr, &errorLine, &errorColumn)){
+    bool result = mDOMdoc.setContent(content, true, &errorStr, &errorLine, &errorColumn);
+#endif
+    if(!result){
         qWarning() << "Error:Parseerroratline" << errorLine << ","
                   << "column" << errorColumn << ":" << errorStr;
     } else {

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -177,7 +177,11 @@ QDomDocument UBSvgSubsetAdaptor::loadSceneDocument(std::shared_ptr<UBDocumentPro
             return doc;
         }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+        doc.setContent(&file, QDomDocument::ParseOption::UseNamespaceProcessing);
+#else
         doc.setContent(&file, true);
+#endif
         file.close();
     }
 

--- a/src/core/UBForeignObjectsHandler.cpp
+++ b/src/core/UBForeignObjectsHandler.cpp
@@ -172,10 +172,16 @@ static QDomDocument createDomFromSvg(const QString &svgUrl)
         if (inFile.open(QIODevice::ReadOnly)) {
             QString domString(inFile.readAll());
 
-            int errorLine = 0; int errorColumn = 0;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+            QDomDocument::ParseResult result = xmlDom.setContent(domString);
+            int errorLine = result.errorLine;
+            int errorColumn = result.errorColumn;
+#else
+            int errorLine, errorColumn;
             QString errorStr;
-
-            if (xmlDom.setContent(domString, &errorStr, &errorLine, &errorColumn)) {
+            bool result = xmlDom.setContent(domString, &errorStr, &errorLine, &errorColumn);
+#endif
+            if (result) {
                 return xmlDom;
             } else {
                 qDebug() << "Error reading content of " << mFoldersXmlStorageName << '\n'

--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -239,10 +239,16 @@ void UBPersistenceManager::createDocumentProxiesStructure(bool interactive)
         if (inFile.open(QIODevice::ReadOnly)) {
             QString domString(inFile.readAll());
 
-            int errorLine = 0; int errorColumn = 0;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+            QDomDocument::ParseResult result = xmlDom.setContent(domString);
+            int errorLine = result.errorLine;
+            int errorColumn = result.errorColumn;
+#else
+            int errorLine, errorColumn;
             QString errorStr;
-
-            if (xmlDom.setContent(domString, &errorStr, &errorLine, &errorColumn)) {
+            bool result = xmlDom.setContent(domString, &errorStr, &errorLine, &errorColumn);
+#endif
+            if (result) {
                 loadFolderTreeFromXml("", xmlDom.firstChildElement());
             } else {
                 qDebug() << "Error reading content of " << mFoldersXmlStorageName << '\n'

--- a/src/frameworks/UBStringUtils.cpp
+++ b/src/frameworks/UBStringUtils.cpp
@@ -152,7 +152,7 @@ QDateTime UBStringUtils::fromUtcIsoDate(const QString& dateString)
     QString nonConstDateString = dateString;
     nonConstDateString.replace("ZZ", "Z");
     QDateTime date = QDateTime::fromString(nonConstDateString, Qt::ISODate);
-    date.setTimeSpec(Qt::UTC);
+    date.setTimeZone(QTimeZone::utc());
     return date.toLocalTime();
 }
 

--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -408,6 +408,7 @@ BrowserWindow* UBWebController::browserWindow() const
     return mCurrentWebBrowser;
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 8, 0))
 QWebEnginePage::PermissionPolicy UBWebController::hasFeaturePermission(const QUrl &securityOrigin, QWebEnginePage::Feature feature)
 {
     QPair<QUrl,QWebEnginePage::Feature> featurePermission(securityOrigin, feature);
@@ -425,6 +426,7 @@ void UBWebController::setFeaturePermission(const QUrl &securityOrigin, QWebEngin
     QPair<QUrl,QWebEnginePage::Feature> featurePermission(securityOrigin, feature);
     mFeaturePermissions[featurePermission] = policy;
 }
+#endif // QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
 
 void UBWebController::injectScripts(QWebEngineView *view)
 {

--- a/src/web/UBWebController.h
+++ b/src/web/UBWebController.h
@@ -92,8 +92,10 @@ class UBWebController : public QObject
         QWebEngineProfile* webProfile() const;
         QList<UBEmbedContent> getEmbeddedContent(const QWebEngineView* view) const;
         BrowserWindow* browserWindow() const;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 8, 0))
         QWebEnginePage::PermissionPolicy hasFeaturePermission(const QUrl &securityOrigin, QWebEnginePage::Feature feature);
         void setFeaturePermission(const QUrl &securityOrigin, QWebEnginePage::Feature feature, QWebEnginePage::PermissionPolicy policy);
+#endif
 
         static void injectScripts(QWebEngineView* view);
 
@@ -163,7 +165,9 @@ private:
         QMenu* mHistoryBackMenu;
         QMenu* mHistoryForwardMenu;
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 8, 0))
         QMap<QPair<QUrl,QWebEnginePage::Feature>,QWebEnginePage::PermissionPolicy> mFeaturePermissions;
+#endif
 
         bool cookieAutoDelete;
         QStringList cookieKeepDomains;

--- a/src/web/simplebrowser/webpage.h
+++ b/src/web/simplebrowser/webpage.h
@@ -53,6 +53,9 @@
 
 #include <QWebEngineCertificateError>
 #include <QWebEnginePage>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 8, 0))
+#include <QWebEnginePermission>
+#endif
 #include <QWebEngineRegisterProtocolHandlerRequest>
 #include <QtWebEngineWidgetsVersion>
 
@@ -73,7 +76,11 @@ protected:
 
 private slots:
     void handleAuthenticationRequired(const QUrl &requestUrl, QAuthenticator *auth);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 8, 0))
+    void handlePermissionRequested(QWebEnginePermission permission);
+#else
     void handleFeaturePermissionRequested(const QUrl &securityOrigin, Feature feature);
+#endif
     void handleProxyAuthenticationRequired(const QUrl &requestUrl, QAuthenticator *auth, const QString &proxyHost);
     void handleRegisterProtocolHandlerRequested(QWebEngineRegisterProtocolHandlerRequest request);
 #if !defined(QT_NO_SSL) || QTWEBENGINEWIDGETS_VERSION >= QT_VERSION_CHECK(5, 12, 0)


### PR DESCRIPTION
In the upcoming Qt 6.8 release, several deprecations and changes are made. In preparation for that, this PR resolves the emitted warnings when building with Qt 6.8 Beta 3.

Except for the new permissions system introduced in 6.8, the changes modernise the current code and adopt current best practices.

The permissions system changes how Qt handles permission requests from websites. Most importantly, it saves the permissions itself, so we don't have to.
Tested with `permission.site`. All new code is enclosed in preprocessor directives, as is the old permission management, to remove it with Qt 6.8+.

Builds fine with Qt 6.7.2, Qt 6.8 Beta 3, Qt 5.15.14.