### PR TITLE
fix: index range check for thumbnails

### DIFF
--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -305,7 +305,7 @@ void UBBoardThumbnailsView::mousePressAndHoldEvent(QPoint pos)
 void UBBoardThumbnailsView::updateThumbnailPixmap(const QRectF region)
 {
     int index = UBApplication::boardController->activeSceneIndex();
-    if (mThumbnails.size() > 0)
+    if (mThumbnails.size() > index)
     {
         mThumbnails.at(index)->updatePixmap(region);
     }


### PR DESCRIPTION
This PR fixes a possible crash which can be reproduced with the following steps:

1. Start OpenBoard.
2. Go to document mode and open a document with a small number of pages, let's say only one.
3. Again go to document mode and open a document with more pages.
4. In this document, go to a page with a higher number than the first document's page count.
5. Open the favorites in the library palette. You see the opened documents.
6. Drag the first document to the board. everything is ok.
7. Drag the second document to the board. OpenBoard crashes.

The reason is that when dragging the second document and switching to the selected page of that document the thumbnail update is triggered, even if the thumbnails for that document have not been created.

This PR is very simple and just fixes the range check.

- fix crash by out-of-range index when updating thumbnails
- correctly check against number of list elements