### PR TITLE
fix: snap to grid for angle-aligned lines

### DIFF
--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -586,13 +586,8 @@ bool UBGraphicsScene::inputDeviceMove(const QPointF& scenePos, const qreal& pres
                     QLineF radius(mPreviousPoint, position);
                     qreal angle = radius.angle();
                     angle = qRound(angle / step) * step;
-                    qreal radiusLength = radius.length();
-                    QPointF newPosition(
-                        mPreviousPoint.x() + radiusLength * cos((angle * PI) / 180),
-                        mPreviousPoint.y() - radiusLength * sin((angle * PI) / 180));
-                    QLineF chord(position, newPosition);
-                    if (chord.length() < qMin((int)16, (int)(radiusLength / 20)))
-                        altPosition = newPosition;
+                    radius.setAngle(angle);
+                    altPosition = radius.p2();
                 }
             }
 

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -249,7 +249,7 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
         UBGraphicsCache* graphicsCache();
 
         bool isSnapping() const;
-        QPointF snap(const QPointF& point, double* force = nullptr, std::optional<QPointF> proposedPoint = {}) const;
+        QPointF snap(const QPointF& point, double* force = nullptr, std::optional<QPointF> proposedPoint = {}, QPointF* gridSnapPoint = nullptr) const;
         QPointF snap(const std::vector<QPointF>& corners, int* snapIndex = nullptr) const;
         QPointF snap(const QRectF& rect, Qt::Corner* corner = nullptr) const;
         static QRectF itemRect(const QGraphicsItem* item);


### PR DESCRIPTION
This PR solves the issue reported here: https://github.com/OpenBoard-org/OpenBoard/pull/1013#issuecomment-2351172109

- snap-to-grid did not work for lines that also fulfill the snap-to-angle criterion
- check and compare the snap points for both criteria
- if they result in the same line angle, then the snap-to-grid criterion is preferred