### PR TITLE
workaround: control screen positioning with Qt 6

### DIFF
--- a/src/core/UBDisplayManager.cpp
+++ b/src/core/UBDisplayManager.cpp
@@ -381,6 +381,9 @@ void UBDisplayManager::positionScreens()
 
         qDebug() << "control geometry" << geometry;
         controlWidget->setGeometry(geometry);
+        // with Qt6, setGeometry has not the desired effect so we additionally use move and resize
+        controlWidget->move(geometry.topLeft());
+        controlWidget->resize(geometry.size());
         UBPlatformUtils::showFullScreen(controlWidget);
     }
 


### PR DESCRIPTION
This PR adds a workaround for control screen positioning with Qt 6as reported in #1080. For me this problem occurs on my system (Leap 15.6, X11)

- when compiling with Qt 6.6 or Qt 6.7
- with 2 physical monitors connected
- for the Flatpak and the distribution packages.

This PR mitigates this problem.

- Positioning and sizing of control screen does not work with Qt 6
- setGeometry() has not the desired effect
- additionally use move() and resize()