### PR TITLE
feat: display snap indicator at the respective corner

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -857,12 +857,6 @@ void UBBoardView::handleItemMouseMove(QMouseEvent *event)
             movingItem->setPos(newPos);
 
             mLastPressedMousePos = scenePos + offset;
-
-            // display snap indicator
-            if (!offset.isNull())
-            {
-                updateSnapIndicator(corner);
-            }
         }
         else
         {
@@ -948,7 +942,7 @@ void UBBoardView::setMultiselection(bool enable)
     mMultipleSelectionIsEnabled = enable;
 }
 
-void UBBoardView::updateSnapIndicator(Qt::Corner corner)
+void UBBoardView::updateSnapIndicator(Qt::Corner corner, QPointF snapPoint)
 {
     if (!mSnapIndicator)
     {
@@ -956,7 +950,7 @@ void UBBoardView::updateSnapIndicator(Qt::Corner corner)
         mSnapIndicator->resize(60, 60);
     }
 
-    mSnapIndicator->appear(corner);
+    mSnapIndicator->appear(corner, snapPoint);
 }
 
 void UBBoardView::setBoxing(const QMargins& margins)

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -67,7 +67,7 @@ public:
     bool isMultipleSelectionEnabled() { return mMultipleSelectionIsEnabled; }
 
     void setBoxing(const QMargins& margins);
-    void updateSnapIndicator(Qt::Corner corner);
+    void updateSnapIndicator(Qt::Corner corner, QPointF snapPoint);
 
     // work around for handling tablet events on MAC OS with Qt 4.8.0 and above
 #if defined(Q_OS_OSX)

--- a/src/board/UBDrawingController.cpp
+++ b/src/board/UBDrawingController.cpp
@@ -34,6 +34,7 @@
 
 #include "domain/UBGraphicsScene.h"
 #include "board/UBBoardController.h"
+#include "board/UBBoardView.h"
 #include "tools/UBAbstractDrawRuler.h"
 
 #include "gui/UBMainWindow.h"
@@ -148,6 +149,17 @@ void UBDrawingController::setStylusTool(int tool)
             UBApplication::mainWindow->actionText->setChecked(true);
         else if (mStylusTool == UBStylusTool::Capture)
             UBApplication::mainWindow->actionCapture->setChecked(true);
+
+        // workaround for #827
+        // glitches when moving objects fast
+        if (mStylusTool == UBStylusTool::Selector || mStylusTool == UBStylusTool::Play)
+        {
+            UBApplication::boardController->controlView()->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+        }
+        else
+        {
+            UBApplication::boardController->controlView()->setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
+        }
 
         emit stylusToolChanged(tool, previousTool);
         if (mStylusTool != UBStylusTool::Selector)

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -580,12 +580,6 @@ void UBGraphicsDelegateFrame::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
                 moveX += snapVector.x();
                 moveY += snapVector.y();
                 move.setP2(move.p2() + snapVector);
-
-                // display snap indicator
-                if (!snapVector.isNull())
-                {
-                    UBApplication::boardController->controlView()->updateSnapIndicator(corner);
-                }
             }
         }
 

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2587,11 +2587,19 @@ QPointF UBGraphicsScene::snap(const std::vector<QPointF>& corners, int* snapInde
 QPointF UBGraphicsScene::snap(const QRectF& rect, Qt::Corner* corner) const
 {
     int snapIndex;
-    const auto offset = snap({rect.topLeft(), rect.topRight(), rect.bottomLeft(), rect.bottomRight()}, &snapIndex);
+    std::vector<QPointF> rectPoints{rect.topLeft(), rect.topRight(), rect.bottomLeft(), rect.bottomRight()};
+    const auto offset = snap(rectPoints, &snapIndex);
+    const auto snapCorner = Qt::Corner(snapIndex);
 
     if (corner)
     {
-        *corner = Qt::Corner(snapIndex);
+        *corner = snapCorner;
+    }
+
+    if (!offset.isNull())
+    {
+        auto* view = UBApplication::boardController->controlView();
+        view->updateSnapIndicator(snapCorner, rectPoints.at(snapIndex) + offset);
     }
 
     return offset;

--- a/src/domain/UBSelectionFrame.cpp
+++ b/src/domain/UBSelectionFrame.cpp
@@ -211,12 +211,6 @@ void UBSelectionFrame::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
                 QRectF movedBounds = mStartingBounds.translated(dp);
                 QPointF snapVector = ubscene->snap(movedBounds, &corner);
                 dp += snapVector;
-
-                // display snap indicator
-                if (mOperationMode == om_moving && !snapVector.isNull())
-                {
-                    UBApplication::boardController->controlView()->updateSnapIndicator(corner);
-                }
             }
         }
         else if (mOperationMode == om_rotating)

--- a/src/gui/UBSnapIndicator.h
+++ b/src/gui/UBSnapIndicator.h
@@ -35,7 +35,7 @@ class UBSnapIndicator : public QLabel
 public:
     UBSnapIndicator(QWidget* parent);
 
-    void appear(Qt::Corner corner);
+    void appear(Qt::Corner corner, QPointF snapPoint);
 
     int alpha() const;
     void setAlpha(int opacity);


### PR DESCRIPTION
This PR addresses comment https://github.com/OpenBoard-org/OpenBoard/pull/1013#issuecomment-2360432207. The snap indicator is now shown at the point which caused the snapping. If this is outside of the visible area of the view, then the indicator is shown at the edge of the visible area.

- display snap indicator at the corner of the moved object which snapped
- limit indicator position by visible area of the view
- move appearing of the snap indicator to the snap(QRectF) function
- for rotated objects this makes it obvious that the corners of the bounding rectangle snap, not the corners of the object itself

Additionally this PR solves the problem with glitches when moving objects in a second commit.

- the already known problem with glitches when moving objects and the thumbnail palette is visible gets worse when moving objects with snapping
- this commit solves this problem by @Vekhir proposal to switch the view update mode depending on the current tool

See https://github.com/OpenBoard-org/OpenBoard/issues/827#issuecomment-1821556616