### PR TITLE
fix: align size of magnet icon

### DIFF
--- a/resources/images/stylusPalette/snap.svg
+++ b/resources/images/stylusPalette/snap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+	 viewBox="3 3 42 42" style="enable-background:new 0 0 48 48;" xml:space="preserve">
 <style type="text/css">
 	.st0{opacity:0.2;}
 	.st1{fill:url(#XMLID_00000115514554791065067760000012489703680898575503_);}

--- a/resources/images/stylusPalette/snapOn.svg
+++ b/resources/images/stylusPalette/snapOn.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+	 viewBox="3 3 42 42" style="enable-background:new 0 0 48 48;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:url(#sphere_00000165197213314460928750000017148520640734379697_);}
 	.st1{opacity:0.2;}


### PR DESCRIPTION
This PR fixes #1118 and aligns the size of the new magnet icon with the other icons in the Stylus palette.

- change viewport to 42x42 px