### PR TITLE
fix: crash when accessing list

### DIFF
--- a/src/core/UBPersistenceWorker.h
+++ b/src/core/UBPersistenceWorker.h
@@ -68,6 +68,7 @@ public slots:
 protected:
    bool mReceivedApplicationClosing;
    QSemaphore mSemaphore;
+   QMutex mMutex;
    QList<PersistenceInformation> saves;
 };
 


### PR DESCRIPTION
Cherry-picked from `letsfindaway/try-fix-import`

This PR fixes a sporadic crash occurring when a huge number of pages is saved, e.g. during PDF import.

- the list of saves in `UBPersistenceWorker` is accessed by more than one thread.
- protect access to the list with a mutex