### PR TITLE
fix: crash when closing while scene is loading

### DIFF
--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -79,6 +79,8 @@ UBDocumentController* UBApplication::documentController = 0;
 
 UBMainWindow* UBApplication::mainWindow = 0;
 
+bool UBApplication::isClosing = false;
+
 const QString UBApplication::mimeTypeUniboardDocument = QString("application/vnd.mnemis-uniboard-document");
 const QString UBApplication::mimeTypeUniboardPage = QString("application/vnd.mnemis-uniboard-page");
 const QString UBApplication::mimeTypeUniboardPageItem =  QString("application/vnd.mnemis-uniboard-page-item");
@@ -507,6 +509,8 @@ void UBApplication::closeEvent(QCloseEvent *event)
 
 void UBApplication::closing()
 {
+    isClosing = true;
+
     if (UBSettings::settings()->emptyTrashForOlderDocuments->get().toBool())
     {
         UBDocumentTreeModel *docModel = UBPersistenceManager::persistenceManager()->mDocumentTreeStructureModel;

--- a/src/core/UBApplication.h
+++ b/src/core/UBApplication.h
@@ -78,6 +78,8 @@ class UBApplication : public SingleApplication
 
         static UBMainWindow* mainWindow;
 
+        static bool isClosing;
+
         static UBApplication* app()
         {
             return dynamic_cast<UBApplication*>qApp;

--- a/src/core/UBSceneCache.cpp
+++ b/src/core/UBSceneCache.cpp
@@ -322,6 +322,13 @@ void UBSceneCache::SceneCacheEntry::startLoading()
 {
     mTimer = new QTimer;
     QObject::connect(mTimer, &QTimer::timeout, mTimer, [this](){
+        if (UBApplication::isClosing)
+        {
+            mTimer->stop();
+            delete mTimer;
+            return;
+        }
+
         if (mContext)
         {
             mContext->step();


### PR DESCRIPTION
This PR provides a fix for issue https://github.com/letsfindaway/OpenBoard/issues/191.

- OpenBoard crashes when it is terminated while a scene is loading in background
- the timer used for background loading still runs and accesses resources no longer available
- add a flag `isClosing` to `UBApplication`
- check flag in timer routine in `UBSceneCache`