### PR TITLE
fix: dropping pdf url to board

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -1466,11 +1466,10 @@ UBItem *UBBoardController::downloadFinished(bool pSuccess, QUrl sourceUrl, QUrl 
             if (pdfFile.open())
             {
                 pdfFile.write(pData);
+                pdfFile.close();
                 QStringList fileNames;
                 fileNames << pdfFile.fileName();
                 numberOfImportedDocuments = UBDocumentManager::documentManager()->addFilesToDocument(selectedDocument(), fileNames);
-
-                pdfFile.close();
             }
         }
 


### PR DESCRIPTION
This PR solves a problem when dropping a PDF url to the board. Expected behavior is that the same functions are executed as when dropping a PDF document to the board. Instead in most cases just nothing happens.

- when dropping a url to the board, the data is downloaded and then processed in `UBBoardController::downloadFinished`
- for a pdf, the data is written to a temporary file and then imported
- before importing, the file must be closed to write pending data from buffers to disk
- however the file was only closed after the import, so the data was not completely written to disk