### PR TITLE
fix: import file only once to document

### DIFF
--- a/src/core/UBDocumentManager.cpp
+++ b/src/core/UBDocumentManager.cpp
@@ -257,12 +257,12 @@ int UBDocumentManager::addFilesToDocument(std::shared_ptr<UBDocumentProxy> docum
         QFile file(fileName);
         QFileInfo fileInfo(file);
 
+        UBApplication::setDisabled(true);
+
         foreach (UBImportAdaptor *adaptor, mImportAdaptors)
         {
             if (adaptor->supportedExtentions().lastIndexOf(fileInfo.suffix().toLower()) != -1)
             {
-                UBApplication::setDisabled(true);
-
                 if (adaptor->isDocumentBased())
                 {
                     //issue 1629 - NNE - 20131212 : Resolve a segfault, but for .ubx, actually
@@ -270,7 +270,10 @@ int UBDocumentManager::addFilesToDocument(std::shared_ptr<UBDocumentProxy> docum
                     UBDocumentBasedImportAdaptor* importAdaptor = dynamic_cast<UBDocumentBasedImportAdaptor*>(adaptor);
 
                     if (importAdaptor && importAdaptor->addFileToDocument(document, file))
+                    {
                         nImportedDocuments++;
+                        break;
+                    }
                 }
                 else
                 {
@@ -301,13 +304,13 @@ int UBDocumentManager::addFilesToDocument(std::shared_ptr<UBDocumentProxy> docum
                     UBPersistenceManager::persistenceManager()->persistDocumentMetadata(document);
                     UBApplication::showMessage(tr("Import of file %1 successful.").arg(file.fileName()));
                     nImportedDocuments++;
+                    break;
                 }
-
-                UBApplication::setDisabled(false);
             }
         }
 
         doc->thumbnailScene()->createThumbnails(currentNumberOfPages);
+        UBApplication::setDisabled(false);
     }
     return nImportedDocuments;
 }


### PR DESCRIPTION
This PR fixes #1156 where the first page of a PDF document was repeated at the end when importing the PDF by dropping it to the board.

- when importing a file to the board, the file was offered to all import adapters
- if multiple import adapters support the same file extension, then the file was imported multiple times
- this was especially true for pdf documents, where in some environments also the image adapter supported rendering a pdf document (preview image of first page)
- this commit leaves the loop iterating over the adapters once one of them has successfully imported the file

@sebojolais: could you test this PR whether it fixes the problem for you?