### PR TITLE
fix: avoid some wayland problems

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -96,6 +96,14 @@ int main(int argc, char *argv[])
     if (qEnvironmentVariableIsSet("QT_NO_GLIB"))
         qunsetenv("QT_NO_GLIB");
 
+    // force using xwayland when running on wayland
+#ifdef Q_OS_LINUX
+    if (qgetenv("XDG_SESSION_TYPE") == "wayland")
+    {
+        qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+#endif
+
     Q_INIT_RESOURCE(OpenBoard);
 
     qInstallMessageHandler(ub_message_output);


### PR DESCRIPTION
As distributions move from X11 to Wayland as default, more and more people are using OpenBoard on Wayland. However there are some known problems, e.g. the following:

- #843, #1041
- #1164
- No screenshots and no screen mirroring in Desktop mode due to Wayland restrictions

The first two of these problems can be mitigated by using the `xcb` backend to force using `xwayland`. This PR sets the corresponding environment variable to enable the xcb` backend:

- use QT_QPA_PLATFORM=xcb when running on wayland
- avoids crash when using the screen configuration list
- avoids invisible window on Qt 6.8

Due to the severity of these problems I will include this PR in all by builds in the future and recommend to merge it as it has no impact for X11 sessions or for other operating systems.