### PR TITLE
Feat: rotate snap indicator and snap rotated items

### DIFF
--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -944,7 +944,7 @@ void UBBoardView::setMultiselection(bool enable)
     mMultipleSelectionIsEnabled = enable;
 }
 
-void UBBoardView::updateSnapIndicator(Qt::Corner corner, QPointF snapPoint)
+void UBBoardView::updateSnapIndicator(Qt::Corner corner, QPointF snapPoint, double angle)
 {
     if (!mSnapIndicator)
     {
@@ -952,7 +952,7 @@ void UBBoardView::updateSnapIndicator(Qt::Corner corner, QPointF snapPoint)
         mSnapIndicator->resize(120, 120);
     }
 
-    mSnapIndicator->appear(corner, snapPoint);
+    mSnapIndicator->appear(corner, snapPoint, angle);
 }
 
 void UBBoardView::setBoxing(const QMargins& margins)

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -67,7 +67,7 @@ public:
     bool isMultipleSelectionEnabled() { return mMultipleSelectionIsEnabled; }
 
     void setBoxing(const QMargins& margins);
-    void updateSnapIndicator(Qt::Corner corner, QPointF snapPoint);
+    void updateSnapIndicator(Qt::Corner corner, QPointF snapPoint, double angle = 0);
 
     // work around for handling tablet events on MAC OS with Qt 4.8.0 and above
 #if defined(Q_OS_OSX)

--- a/src/board/UBBoardView.h
+++ b/src/board/UBBoardView.h
@@ -165,8 +165,9 @@ private:
     bool mOkOnWidget;
 
     bool mWidgetMoved;
+    QPointF mFirstPressedMousePos;
     QPointF mLastPressedMousePos;
-
+    QList<QPointF> mCornerPoints;
 
     /* when an item is moved around, the tracking must stop if the object is deleted */
     QGraphicsItem *_movingItem;

--- a/src/domain/UBGraphicsDelegateFrame.h
+++ b/src/domain/UBGraphicsDelegateFrame.h
@@ -119,8 +119,8 @@ class UBGraphicsDelegateFrame: public QGraphicsRectItem, public QObject
         QRect mAngleRect;
 
         QPointF mStartingPoint;
-        QRectF mStartingBounds;
         QTransform mInitialTransform;
+        QList<QPointF> mCornerPoints;
         QSizeF mOriginalSize;
         QPointF mFixedPoint;
 

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -2626,7 +2626,7 @@ QPointF UBGraphicsScene::snap(const QRectF& rect, Qt::Corner* corner) const
 
 QRectF UBGraphicsScene::itemRect(const QGraphicsItem* item)
 {
-    // compute an item's rectangle in scene coordinates
+    // compute an item's rectangle in item coordinates
     // taking into account the shape of the item and
     // the nature of nominal lines
     QRectF bounds = item->boundingRect();
@@ -2655,9 +2655,7 @@ QRectF UBGraphicsScene::itemRect(const QGraphicsItem* item)
         }
     }
 
-    QRectF rect = item->mapRectToScene(bounds);
-
-    return rect;
+    return bounds;
 }
 
 void UBGraphicsScene::addMask(const QPointF &center)

--- a/src/gui/UBSnapIndicator.h
+++ b/src/gui/UBSnapIndicator.h
@@ -35,7 +35,7 @@ class UBSnapIndicator : public QLabel
 public:
     UBSnapIndicator(QWidget* parent);
 
-    void appear(Qt::Corner corner, QPointF snapPoint);
+    void appear(Qt::Corner corner, QPointF snapPoint, double angle = 0);
 
     int alpha() const;
     void setAlpha(int opacity);
@@ -46,7 +46,7 @@ protected:
     virtual void paintEvent(QPaintEvent* event) override;
 
 private:
-    Qt::Corner mCorner{Qt::TopLeftCorner};
+    double mAngle{0};
     int mAlpha;
     QColor mColor{0x62a7e0};
     QPropertyAnimation* mAnimation;


### PR DESCRIPTION
This PR applies the snap-to-grid function correctly to rotated items. It tries to make snapping more foreseeable and toi better fit user expectations for rotated items.

- When moving an arbitrarily rotated item the corners of the item snap. Snap indicators are now correctly shown at the item corners. Until now, a scene bounding rectangle of the item snapped and the snap indicators have been shown on that virtual, invisible rectangle.
- Snapping is now also correctly applied to flipped items.
- Resizing of rotated items can now also snap to the grid if the angle is 0°, 90°, 180° or 270°. For other angles it makes no sense to snap resizing.
- Scaling of an item (i.e. resizing with the bottom-right handle) never snaps.

See also https://github.com/letsfindaway/OpenBoard/issues/185 for a discussion of this feature and the list of tests I have conducted.