### PR TITLE
fix: copy ItemOwnZValue when cloning item

### DIFF
--- a/src/domain/UBGraphicsMediaItem.cpp
+++ b/src/domain/UBGraphicsMediaItem.cpp
@@ -523,6 +523,7 @@ void UBGraphicsMediaItem::copyItemParameters(UBItem *copy) const
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
         cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
         cp->setData(UBGraphicsItemData::ItemIsHiddenOnDisplay, this->data(UBGraphicsItemData::ItemIsHiddenOnDisplay));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setSourceUrl(this->sourceUrl());
         cp->setSize(rect().width(), rect().height());
 

--- a/src/domain/UBGraphicsPDFItem.cpp
+++ b/src/domain/UBGraphicsPDFItem.cpp
@@ -134,6 +134,7 @@ void UBGraphicsPDFItem::copyItemParameters(UBItem *copy) const
         cp->setFlag(QGraphicsItem::ItemIsMovable, true);
         cp->setFlag(QGraphicsItem::ItemIsSelectable, true);
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setSourceUrl(this->sourceUrl());
         cp->setZValue(this->zValue());
     }

--- a/src/domain/UBGraphicsPixmapItem.cpp
+++ b/src/domain/UBGraphicsPixmapItem.cpp
@@ -163,6 +163,7 @@ void UBGraphicsPixmapItem::copyItemParameters(UBItem *copy) const
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
         cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
         cp->setData(UBGraphicsItemData::ItemIsHiddenOnDisplay, this->data(UBGraphicsItemData::ItemIsHiddenOnDisplay));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setSourceUrl(this->sourceUrl());
 
         cp->setZValue(this->zValue());

--- a/src/domain/UBGraphicsPolygonItem.cpp
+++ b/src/domain/UBGraphicsPolygonItem.cpp
@@ -177,6 +177,7 @@ void UBGraphicsPolygonItem::copyItemParameters(UBItem *copy) const
         cp->setColorOnLightBackground(this->colorOnLightBackground());
 
         cp->setZValue(this->zValue());
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
     }
 }

--- a/src/domain/UBGraphicsStrokesGroup.cpp
+++ b/src/domain/UBGraphicsStrokesGroup.cpp
@@ -209,6 +209,7 @@ void UBGraphicsStrokesGroup::copyItemParameters(UBItem *copy) const
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
         cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
         cp->setData(UBGraphicsItemData::ItemIsHiddenOnDisplay, this->data(UBGraphicsItemData::ItemIsHiddenOnDisplay));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setZValue(this->zValue());
     }
 }

--- a/src/domain/UBGraphicsSvgItem.cpp
+++ b/src/domain/UBGraphicsSvgItem.cpp
@@ -183,6 +183,7 @@ void UBGraphicsSvgItem::copyItemParameters(UBItem *copy) const
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
         cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
         cp->setData(UBGraphicsItemData::ItemIsHiddenOnDisplay, this->data(UBGraphicsItemData::ItemIsHiddenOnDisplay));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setSourceUrl(this->sourceUrl());
         cp->setZValue(this->zValue());
     }

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -372,6 +372,7 @@ void UBGraphicsTextItem::copyItemParameters(UBItem *copy) const
         cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
         cp->setData(UBGraphicsItemData::ItemIsHiddenOnDisplay, this->data(UBGraphicsItemData::ItemIsHiddenOnDisplay));
         cp->setData(UBGraphicsItemData::ItemEditable, data(UBGraphicsItemData::ItemEditable).toBool());
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setTextWidth(this->textWidth());
         cp->setTextHeight(this->textHeight());
 

--- a/src/domain/UBGraphicsWidgetItem.cpp
+++ b/src/domain/UBGraphicsWidgetItem.cpp
@@ -1507,6 +1507,7 @@ void UBGraphicsW3CWidgetItem::copyItemParameters(UBItem *copy) const
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
         cp->setData(UBGraphicsItemData::ItemLocked, this->data(UBGraphicsItemData::ItemLocked));
         cp->setData(UBGraphicsItemData::ItemIsHiddenOnDisplay, this->data(UBGraphicsItemData::ItemIsHiddenOnDisplay));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setSourceUrl(this->sourceUrl());
 
         cp->resize(this->size());

--- a/src/tools/UBGraphicsCurtainItem.cpp
+++ b/src/tools/UBGraphicsCurtainItem.cpp
@@ -169,6 +169,7 @@ void UBGraphicsCurtainItem::copyItemParameters(UBItem *copy) const
         cp->setFlag(QGraphicsItem::ItemIsMovable, true);
         cp->setFlag(QGraphicsItem::ItemIsSelectable, true);
         cp->setData(UBGraphicsItemData::ItemLayerType, this->data(UBGraphicsItemData::ItemLayerType));
+        cp->setData(UBGraphicsItemData::ItemOwnZValue, this->data(UBGraphicsItemData::ItemOwnZValue));
         cp->setZValue(this->zValue());
     }
 }


### PR DESCRIPTION
This PR should fix #1167

- for most items, only zValue was copied when cloning
- now also copy the ItemOwnZValue data property

Notes:

- It could also be an idea to use `UBGraphicsItem::assignZValue()` in these cases. which assigns a z value to both, the data property and the item itself. However I'm not sure whether these values could differ while cloning.
- As the z value is something common to all items, we could also extract copying of this parameter to a base class. However I did not want to introduce such a change here without discussion. There are possibly other such common parameters which should be copied for all item types.