### PR TITLE
fix: tool usage with tablet eraser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 ![GitHub Repo forks](https://img.shields.io/github/forks/OpenBoard-org/openboard)
 # OpenBoard
 [![latest release](https://img.shields.io/github/v/release/OpenBoard-org/openboard.svg)]()
-[![Commits since last release](https://img.shields.io/github/commits-since/OpenBoard-org/openboard/v1.7.2/dev)]()
+[![Commits since last release](https://img.shields.io/github/commits-since/OpenBoard-org/openboard/v1.7.3/dev)]()
 [![Github Repo Contributors](https://img.shields.io/github/contributors/OpenBoard-org/openboard.svg)]()
-[![downloads v1.7.2](https://img.shields.io/github/downloads/OpenBoard-org/openboard/v1.7.2/total)]()
+[![downloads v1.7.3](https://img.shields.io/github/downloads/OpenBoard-org/openboard/v1.7.3/total)]()
 [![Github All Releases](https://img.shields.io/github/downloads/OpenBoard-org/OpenBoard/total.svg)]()
 
 OpenBoard is an open source cross-platform interactive white board application designed primarily for use in schools. It was originally forked from Open-Sankoré, which was itself based on Uniboard.
 
 ### Installing
-1.7.2 installers are available for Windows, macOS and Debian on the [Download's page](https://github.com/OpenBoard-org/OpenBoard/wiki/Downloads).
+1.7.3 installers are available for Windows, macOS and Debian on the [Download's page](https://github.com/OpenBoard-org/OpenBoard/wiki/Downloads).
 
 ### Supported platforms 
 
 | Version   | officially maintained platforms | branch |
 |------------|--------------------------------------------------------|----|
-| 1.7.2 (latest stable)     | Windows 10+, macOS 12+ (for both `x64_64` and `arm64`), Debian 12  | `master` |
-| 1.7.3 (active development)     | Windows 10+, macOS 12+ (for both `x64_64` and `arm64`), Debian 12 | `dev` |
+| 1.7.3 (latest stable)     | Windows 10+, macOS 12+ (for both `x64_64` and `arm64`), Debian 12  | `master` |
+| 1.7.4 (active development)     | Windows 10+, macOS 12+ (for both `x64_64` and `arm64`), Debian 12 | `dev` |
 
 ### Communnity-driven packages
 On Linux, Debian is the only officially maintained platform. For other platforms, you can thank the awesome community of OpenBoard that provides community-driven packages on a number of other distributions. Check on [this page](https://github.com/OpenBoard-org/OpenBoard/wiki/Downloads) to see if you find what you're looking for. If you actually want to provide support and to be referenced on this page, please open an issue with the relevant information, and we'll be glad to add your contribution.

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -369,6 +369,8 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
     QPointF scenePos = viewportTransform ().inverted ().map (tabletPos);
 
     qreal pressure = 1.0;
+    currentTool = (UBStylusTool::Enum)dc->stylusTool();
+
     if (((currentTool == UBStylusTool::Pen || currentTool == UBStylusTool::Line) && mPenPressureSensitive) ||
             (currentTool == UBStylusTool::Marker && mMarkerPressureSensitive))
         pressure = event->pressure ();

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,5 @@
 VERSION_MAJ   = 1
 VERSION_MIN   = 7
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 VERSION_TYPE = r        # a = alpha, b = beta, rc = release candidate, r = release, other => error
-VERSION_BUILD = 241104  # for non-release builds
+VERSION_BUILD = 241217  # for non-release builds


### PR DESCRIPTION
This PR tries to fix #437. 

- use correct tool after switching to/from tablet eraser
- re-evaluate `currentTool` after changing it by the tablet eraser

However I need some testers, as I do not have a tablet with an eraser function. I will add this PR as a patch to my experimental builds, so that experimental packages are available later this day.

@bruening-bw : there will be packages for several versions of Debian available. So it would be helpful if you could test whether this fixes the issue for you.