### PR TITLE
fix: small scene shifts when switching pages

### DIFF
--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -160,7 +160,8 @@ class UBBoardController : public UBDocumentContainer
             return mSystemScaleFactor;
         }
         qreal currentZoom();
-        void persistViewPositionOnCurrentScene();
+        void persistViewPositionOnCurrentScene() const;
+        void restoreViewPositionOnCurrentScene() const;
         void persistCurrentScene(bool isAnAutomaticBackup = false, bool forceImmediateSave = false);
         void showNewVersionAvailable(bool automatic, const UBVersion &installedVersion, const UBSoftwareUpdate &softwareUpdate);
         void setBoxing(QRect displayRect);
@@ -215,7 +216,7 @@ class UBBoardController : public UBDocumentContainer
         void zoomOut(QPointF scenePoint = QPointF(0,0));
         void zoomRestore();
         void centerRestore();
-        void centerOn(QPointF scenePoint = QPointF(0,0));
+        void centerOn(QPointF scenePoint = QPointF(0,0)) const;
         void zoom(const qreal ratio, QPointF scenePoint);
         void handScroll(qreal dx, qreal dy);
         void previousScene();
@@ -294,7 +295,6 @@ class UBBoardController : public UBDocumentContainer
     private:
         void initBackgroundGridSize();
         void updatePageSizeState();
-        void saveViewState();
         int autosaveTimeoutFromSettings();
 
         UBMainWindow *mMainWindow;

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -85,26 +85,21 @@ class UBBoardController : public UBDocumentContainer
         void setActiveSceneIndex(int i);
         void closing();
 
-        int currentPage();
+        int currentPage() const;
 
-        QWidget* controlContainer()
+        QWidget* controlContainer() const
         {
             return mControlContainer;
         }
 
-        UBBoardView* controlView()
+        UBBoardView* controlView() const
         {
             return mControlView;
         }
 
-        UBBoardView* displayView()
+        UBBoardView* displayView() const
         {
             return mDisplayView;
-        }
-
-        std::shared_ptr<UBGraphicsScene> activeScene()
-        {
-            return mActiveScene;
         }
 
         void setPenColorOnDarkBackground(const QColor& pColor)
@@ -135,31 +130,31 @@ class UBBoardController : public UBDocumentContainer
             mMarkerColorOnLightBackground = pColor;
         }
 
-        QColor penColorOnDarkBackground()
+        QColor penColorOnDarkBackground() const
         {
             return mPenColorOnDarkBackground;
         }
 
-        QColor penColorOnLightBackground()
+        QColor penColorOnLightBackground() const
         {
             return mPenColorOnLightBackground;
         }
 
-        QColor markerColorOnDarkBackground()
+        QColor markerColorOnDarkBackground() const
         {
             return mMarkerColorOnDarkBackground;
         }
 
-        QColor markerColorOnLightBackground()
+        QColor markerColorOnLightBackground() const
         {
             return mMarkerColorOnLightBackground;
         }
 
-        qreal systemScaleFactor()
+        qreal systemScaleFactor() const
         {
             return mSystemScaleFactor;
         }
-        qreal currentZoom();
+        qreal currentZoom() const;
         void persistViewPositionOnCurrentScene() const;
         void restoreViewPositionOnCurrentScene() const;
         void persistCurrentScene(bool isAnAutomaticBackup = false, bool forceImmediateSave = false);
@@ -170,7 +165,7 @@ class UBBoardController : public UBDocumentContainer
         static QUrl expandWidgetToTempDir(const QByteArray& pZipedData, const QString& pExtension = QString("wgt"));
 
         void setPageSize(QSize newSize);
-        UBBoardPaletteManager *paletteManager()
+        UBBoardPaletteManager *paletteManager() const
         {
             return mPaletteManager;
         }
@@ -188,12 +183,12 @@ class UBBoardController : public UBDocumentContainer
         UBGraphicsItem *duplicateItem(UBItem *item);
         void deleteScene(int index);
 
-        bool cacheIsVisible() {return mCacheWidgetIsEnabled;}
+        bool cacheIsVisible() const {return mCacheWidgetIsEnabled;}
 
-        QString actionGroupText(){ return mActionGroupText;}
-        QString actionUngroupText(){ return mActionUngroupText;}
+        QString actionGroupText() const { return mActionGroupText;}
+        QString actionUngroupText() const { return mActionUngroupText;}
 
-        std::shared_ptr<UBGraphicsScene> initialDocumentScene()
+        std::shared_ptr<UBGraphicsScene> initialDocumentScene() const
         {
             return mInitialDocumentScene;
         }
@@ -281,7 +276,7 @@ class UBBoardController : public UBDocumentContainer
         void initToolbarTexts();
         void updateActionStates();
         void updateSystemScaleFactor();
-        QString truncate(QString text, int maxWidth);
+        QString truncate(QString text, int maxWidth) const;
 
     protected slots:
         void selectionChanged();
@@ -295,7 +290,7 @@ class UBBoardController : public UBDocumentContainer
     private:
         void initBackgroundGridSize();
         void updatePageSizeState();
-        int autosaveTimeoutFromSettings();
+        int autosaveTimeoutFromSettings() const;
 
         UBMainWindow *mMainWindow;
         std::shared_ptr<UBGraphicsScene> mActiveScene;

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -1740,6 +1740,13 @@ void UBBoardView::wheelEvent (QWheelEvent *wheelEvent)
 
     // event not handled, send it to QAbstractScrollArea to scroll with wheel event
     QAbstractScrollArea::wheelEvent(wheelEvent);
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    // workaround: foreground not repainted after scrolling on Qt5 (fixed in Qt6)
+    // setForegroundBrush internally invokes the private function uopdateAll() unconditionally
+    setForegroundBrush(foregroundBrush());
+#endif
+
     UBApplication::applicationController->adjustDisplayView();
 }
 

--- a/src/domain/UBGraphicsScene.cpp
+++ b/src/domain/UBGraphicsScene.cpp
@@ -398,16 +398,6 @@ void UBGraphicsScene::selectionChangedProcessing()
     }
 }
 
-void UBGraphicsScene::setLastCenter(QPointF center)
-{
-    mViewState.setLastSceneCenter(center);
-}
-
-QPointF UBGraphicsScene::lastCenter()
-{
-    return mViewState.lastSceneCenter();
-}
-
 bool UBGraphicsScene::inputDevicePress(const QPointF& scenePos, const qreal& pressure, Qt::KeyboardModifiers modifiers)
 {
     bool accepted = false;

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -156,9 +156,6 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
         UBGraphicsW3CWidgetItem* addW3CWidget(const QUrl& pWidgetUrl, const QPointF& pPos = QPointF(0, 0));
         void addGraphicsWidget(UBGraphicsWidgetItem* graphicsWidget, const QPointF& pPos = QPointF(0, 0));
 
-        QPointF lastCenter();
-        void setLastCenter(QPointF center);
-
         UBGraphicsMediaItem* addMedia(const QUrl& pMediaFileUrl, bool shouldPlayAsap, const QPointF& pPos = QPointF(0, 0));
         UBGraphicsMediaItem* addVideo(const QUrl& pVideoFileUrl, bool shouldPlayAsap, const QPointF& pPos = QPointF(0, 0));
         UBGraphicsMediaItem* addAudio(const QUrl& pAudioFileUrl, bool shouldPlayAsap, const QPointF& pPos = QPointF(0, 0));
@@ -272,16 +269,6 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
                     horizontalPosition = pHorizontalPosition;
                     verticalPostition = pVerticalPostition;
                     mLastSceneCenter = sceneCenter;
-                }
-
-                QPointF lastSceneCenter() // Save Scene Center to replace the view when the scene becomes active
-                {
-                    return mLastSceneCenter;
-                }
-
-                void setLastSceneCenter(QPointF center)
-                {
-                    mLastSceneCenter = center;
                 }
 
                 QPointF mLastSceneCenter;

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -257,25 +257,20 @@ class UBGraphicsScene: public UBCoreGraphicsScene, public UBItem, public std::en
             public:
                 SceneViewState()
                 {
-                    zoomFactor = 1;
-                    horizontalPosition = 0;
-                    verticalPostition = 0;
-                    mLastSceneCenter = QPointF();
                 }
 
                 SceneViewState(qreal pZoomFactor, int pHorizontalPosition, int pVerticalPostition, QPointF sceneCenter = QPointF())// 1595/1605
+                    : zoomFactor{pZoomFactor}
+                    , horizontalPosition{pHorizontalPosition}
+                    , verticalPostition{pVerticalPostition}
+                    , mLastSceneCenter{sceneCenter}
                 {
-                    zoomFactor = pZoomFactor;
-                    horizontalPosition = pHorizontalPosition;
-                    verticalPostition = pVerticalPostition;
-                    mLastSceneCenter = sceneCenter;
                 }
 
-                QPointF mLastSceneCenter;
-
-                qreal zoomFactor;
-                int horizontalPosition;
-                int verticalPostition;
+                qreal zoomFactor{1};
+                int horizontalPosition{0};
+                int verticalPostition{0};
+                QPointF mLastSceneCenter{};
         };
 
         SceneViewState viewState() const

--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -207,7 +207,6 @@ void UBBoardThumbnailsView::mousePressEvent(QMouseEvent *event)
         UBApplication::boardController->persistViewPositionOnCurrentScene();
         UBApplication::boardController->persistCurrentScene();
         UBApplication::boardController->setActiveDocumentScene(item->sceneIndex());
-        UBApplication::boardController->centerOn(UBApplication::boardController->activeScene()->lastCenter());
     }
 
     mLongPressTimer.start();


### PR DESCRIPTION
This PR fixes the small shift of scenes when switching pages initially reported in #1009. Even if the effects of this problem depend on the Qt version use, it is an unclean procedure in the OpenBoard code that causes this.

There are two methods to move the visible region of a `QGraphicsView`:

- We can change the value of the horizontal and vertical scroll bar. These values are integers, so we can only move by pixels.
- Or we can change the transformation matrix of the view. This is the transformation from scene coordinates to view coordinates and everything is floating point here.

OpenBoard uses both, and that is not a good idea:

- When using the Hand tool, only the transform is changed.
- When using the zoom, transform and scrollbar values are changed.
- When using the mouse wheel, only the scrollbar values are changed.
- When switching pages, the viewport center is saved and a combination of `centerOn()` (changing scrollbar values) and `translate()` (changing transformation) is used to restore it.

Even with this PR scrollbar values and transformations are used, but they are clearly separated. A first idea of using transformations only was skipped, because the scroll area of the `QGraphicsView` cannot be guaranteed to never scroll. E.g. the mouse wheel produces an event, which is processed by the scroll area and affects the scrollbar values.

To remember the position and zoom factor of a scene, a `SceneViewState` is used which already provides the necessary information. It was however not consistently used. 

Here is a list of tests I have successfully performed with the updated code:

- [x] Switch pages with prev/next
- [x] Switch pages with first/last
- [x] Switch pages with thumbnails
- [x] Switch pages using Document mode
- [x] Switch zoomed page
- [x] Switch page moved by hand tool
- [x] Switch page scrolled by wheel
- [x] Clear page
- [x] Double-click and long-click with hand
- [x] perform all tests with second display
- [x] Perform all tests with Qt5 and Qt6

Technical details of the changes:

- visible scene area is affected by scene transformation and the view scrollbar values
- clearly separate changes to those two
- save and restore both using the `SceneViewState`
- `UBBoardController`:
  - always use `centerRestore` when re-centering a scene
  - `UBBoardController::centerOn` only affect transformation
  - fix keeping the scene point when zooming
  - save scrollbars and transform in `persistViewPositionOnCurrentScene`
  - add a `restoreViewPositionOnCurrentScene`
  - save and restore view position in `setActiveDocumentScene`
  - remove redundant `saveViewState`
- `UBGraphicsScene`:
  - remove no longer used `lastCenter` and `setLastCenter`
  - remove associated no longer used `SceneViewState` functions