### PR TITLE
Performance: background loader

### DIFF
--- a/src/adaptors/UBThumbnailAdaptor.cpp
+++ b/src/adaptors/UBThumbnailAdaptor.cpp
@@ -83,6 +83,27 @@ void UBThumbnailAdaptor::generateMissingThumbnails(std::shared_ptr<UBDocumentPro
     }
 }
 
+QPixmap UBThumbnailAdaptor::generateMissingThumbnail(std::shared_ptr<UBDocumentProxy> proxy, int pageIndex)
+{
+    QString thumbFileName = proxy->persistencePath() + UBFileSystemUtils::digitFileFormat("/page%1.thumbnail.jpg", pageIndex);
+
+    QFile thumbFile(thumbFileName);
+
+    if (!thumbFile.exists())
+    {
+        std::shared_ptr<UBGraphicsScene> scene = UBSvgSubsetAdaptor::loadScene(proxy, pageIndex);
+
+        if (scene)
+        {
+            persistScene(proxy, scene, pageIndex);
+        }
+    }
+
+    QPixmap pix;
+    pix.load(thumbFileName);
+    return pix;
+}
+
 QPixmap UBThumbnailAdaptor::get(std::shared_ptr<UBDocumentProxy> proxy, int pageIndex)
 {
     QString fileName = proxy->persistencePath() + UBFileSystemUtils::digitFileFormat("/page%1.thumbnail.jpg", pageIndex);

--- a/src/adaptors/UBThumbnailAdaptor.h
+++ b/src/adaptors/UBThumbnailAdaptor.h
@@ -47,6 +47,7 @@ public:
 
     static QPixmap get(std::shared_ptr<UBDocumentProxy> proxy, int index);
     static void load(std::shared_ptr<UBDocumentProxy> proxy, QList<std::shared_ptr<QPixmap>>& list);
+    static QPixmap generateMissingThumbnail(std::shared_ptr<UBDocumentProxy> proxy, int pageIndex);
 
 private:
     static void generateMissingThumbnails(std::shared_ptr<UBDocumentProxy> proxy);

--- a/src/frameworks/CMakeLists.txt
+++ b/src/frameworks/CMakeLists.txt
@@ -1,4 +1,6 @@
 target_sources(openboard PRIVATE
+    UBBackgroundLoader.cpp
+    UBBackgroundLoader.h
     UBBase32.cpp
     UBBase32.h
     UBCoreGraphicsScene.cpp

--- a/src/frameworks/UBBackgroundLoader.cpp
+++ b/src/frameworks/UBBackgroundLoader.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015-2025 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "UBBackgroundLoader.h"
+
+#include <QFile>
+
+#include "core/UBApplication.h"
+
+UBBackgroundLoader::UBBackgroundLoader(QObject* parent)
+    : QThread{parent}
+{
+}
+
+UBBackgroundLoader::UBBackgroundLoader(QList<std::pair<int, QString>> paths, QObject* parent)
+    : QThread{parent}
+{
+    mPaths.insert(mPaths.cend(), paths.constBegin(), paths.constEnd());
+    mPathCounter.release(paths.size());
+}
+
+UBBackgroundLoader::~UBBackgroundLoader()
+{
+    abort();
+    wait();
+}
+
+bool UBBackgroundLoader::isResultAvailable()
+{
+    QMutexLocker lock{&mMutex};
+    return !mResults.empty();
+}
+
+std::pair<int, QByteArray> UBBackgroundLoader::takeResult()
+{
+    QMutexLocker lock{&mMutex};
+
+    if (mResults.empty())
+    {
+        return {};
+    }
+
+    const auto result = mResults.front();
+    mResults.pop_front();
+    return result;
+}
+
+void UBBackgroundLoader::start()
+{
+    mRunning = true;
+    QThread::start();
+}
+
+void UBBackgroundLoader::addPaths(QList<std::pair<int, QString>> paths)
+{
+    QMutexLocker lock{&mMutex};
+    mPaths.insert(mPaths.cend(), paths.constBegin(), paths.constEnd());
+    mPathCounter.release(paths.size());
+}
+
+void UBBackgroundLoader::abort()
+{
+    mRunning = false;
+    mPathCounter.release();
+}
+
+void UBBackgroundLoader::run()
+{
+    while (mRunning && !UBApplication::isClosing)
+    {
+        mPathCounter.acquire();
+
+        if (mRunning && !UBApplication::isClosing)
+        {
+            std::pair<int, QString> path;
+
+            {
+                QMutexLocker lock{&mMutex};
+                path = mPaths.front();
+                mPaths.pop_front();
+            }
+
+            QFile file{path.second};
+            QByteArray result;
+
+            if (file.open(QFile::ReadOnly))
+            {
+                result = file.readAll();
+                file.close();
+            }
+
+            {
+                QMutexLocker lock{&mMutex};
+                mResults.push_back({path.first, result});
+            }
+
+            emit resultAvailable(path.first, result);
+        }
+    }
+
+    quit();
+}

--- a/src/frameworks/UBBackgroundLoader.h
+++ b/src/frameworks/UBBackgroundLoader.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015-2025 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <QMutex>
+#include <QObject>
+#include <QSemaphore>
+#include <QThread>
+#include <deque>
+
+class UBBackgroundLoader : public QThread
+{
+    Q_OBJECT
+
+public:
+    explicit UBBackgroundLoader(QObject* parent = nullptr);
+    UBBackgroundLoader(QList<std::pair<int, QString>> paths, QObject* parent = nullptr);
+    virtual ~UBBackgroundLoader();
+
+    bool isResultAvailable();
+    std::pair<int, QByteArray> takeResult();
+
+public slots:
+    void start();
+    void addPaths(QList<std::pair<int, QString>> paths);
+    void abort();
+
+signals:
+    void resultAvailable(int index, QByteArray data);
+
+protected:
+    void run() override;
+
+private:
+    std::deque<std::pair<int, QString>> mPaths{};
+    std::deque<std::pair<int, QByteArray>> mResults{};
+    QMutex mMutex{};
+    QSemaphore mPathCounter{};
+    bool mRunning{false};
+};

--- a/src/frameworks/frameworks.pri
+++ b/src/frameworks/frameworks.pri
@@ -6,6 +6,7 @@ HEADERS      += src/frameworks/UBGeometryUtils.h \
                 src/frameworks/UBVersion.h \
                 src/frameworks/UBCoreGraphicsScene.h \
                 src/frameworks/UBCryptoUtils.h \
+                src/frameworks/UBBackgroundLoader.h \
                 src/frameworks/UBBase32.h
 
 SOURCES      += src/frameworks/UBGeometryUtils.cpp \
@@ -15,6 +16,7 @@ SOURCES      += src/frameworks/UBGeometryUtils.cpp \
                 src/frameworks/UBVersion.cpp \
                 src/frameworks/UBCoreGraphicsScene.cpp \
                 src/frameworks/UBCryptoUtils.cpp \
+                src/frameworks/UBBackgroundLoader.cpp \
                 src/frameworks/UBBase32.cpp
 
 

--- a/src/gui/UBThumbnailScene.h
+++ b/src/gui/UBThumbnailScene.h
@@ -28,6 +28,7 @@
 #include "core/UBSettings.h"
 
 // forward
+class UBBackgroundLoader;
 class UBDocument;
 class UBGraphicsScene;
 class UBThumbnail;
@@ -76,4 +77,5 @@ private:
     UBDocument* mDocument{nullptr};
     QList<UBThumbnail*> mThumbnailItems{};
     int mThumbnailWidth{UBSettings::defaultThumbnailWidth};
+    UBBackgroundLoader* mLoader{nullptr};
 };


### PR DESCRIPTION
This PR adds a background loader to read thumbnail files in another thread so that disk I/O, especially with a slow network drive, does not interfere with user actions.

The new class `UBBackgroundLoader` takes a list of file names and produces a list of results containing the data in these files in the same sequence. The I/O operations are performed on another thread.

The `UBThumbnailScene` is adapted to use the background loader for reading thumbnail file data. This avoids blocking operations on the main thread and improves user experiences during thumbnail loading.