### PR TITLE
fix: spinning message after UBZ import

### DIFF
--- a/src/adaptors/UBImportDocument.cpp
+++ b/src/adaptors/UBImportDocument.cpp
@@ -191,6 +191,8 @@ std::shared_ptr<UBDocumentProxy> UBImportDocument::importFile(const QFile& pFile
 
     std::shared_ptr<UBDocumentProxy> newDocument = UBPersistenceManager::persistenceManager()->createDocumentFromDir(documentRootFolder, pGroup, "", false, false, true);
 
+    UBApplication::showMessage(tr("Import successful."));
+
     return newDocument;
 }
 


### PR DESCRIPTION
- after import of a UBZ file, the message showing the import progress was not muted
- add a success message without spinner at the end