### PR TITLE
fix: possible crash in UBThumbnailScene

### DIFF
--- a/src/gui/UBDocumentThumbnailsView.cpp
+++ b/src/gui/UBDocumentThumbnailsView.cpp
@@ -50,7 +50,6 @@
 UBDocumentThumbnailsView::UBDocumentThumbnailsView(QWidget* parent)
     : UBThumbnailsView(parent)
     , mThumbnailWidth(UBSettings::defaultThumbnailWidth)
-    , mLastSelectedThumbnail(0)
     , mSelectionSpan(0)
 
 {
@@ -103,11 +102,12 @@ void UBDocumentThumbnailsView::setThumbnailWidth(qreal pThumbnailWidth)
 
         if (mDocument)
         {
-            mDocument->thumbnailScene()->arrangeThumbnails();
+            auto thumbnailScene = mDocument->thumbnailScene();
+            thumbnailScene->arrangeThumbnails();
 
-            if (mLastSelectedThumbnail)
+            if (thumbnailScene->lastSelectedThumbnail())
             {
-                ensureVisible(mLastSelectedThumbnail);
+                ensureVisible(thumbnailScene->lastSelectedThumbnail());
             }
         }
     }
@@ -165,11 +165,13 @@ void UBDocumentThumbnailsView::mousePressEvent(QMouseEvent *event)
         return;
     }
 
+    auto thumbnailScene = document()->thumbnailScene();
+
     if (Qt::ShiftModifier & event->modifiers())
     {
-        if (mLastSelectedThumbnail)
+        if (thumbnailScene->lastSelectedThumbnail())
         {
-            int index1 = mLastSelectedThumbnail->sceneIndex();
+            int index1 = thumbnailScene->lastSelectedThumbnail()->sceneIndex();
             int index2 = sceneItem->sceneIndex();
 
             mSelectionSpan = index2 - index1;
@@ -180,14 +182,12 @@ void UBDocumentThumbnailsView::mousePressEvent(QMouseEvent *event)
     {
         if (!sceneItem->isSelected())
         {
-            mLastSelectedThumbnail = sceneItem;
-            int index = mLastSelectedThumbnail->sceneIndex();
+            int index = sceneItem->sceneIndex();
             selectItemAt(index, Qt::ControlModifier & event->modifiers());
         }
         else
         {
-            mLastSelectedThumbnail = nullptr;
-            sceneItem->setSelected(false);
+            thumbnailScene->hightlightItem(sceneItem->sceneIndex(), false, false);
         }
 
         mSelectionSpan = 0;
@@ -264,9 +264,11 @@ void UBDocumentThumbnailsView::mouseReleaseEvent(QMouseEvent *event)
 
 void UBDocumentThumbnailsView::keyPressEvent(QKeyEvent *event)
 {
-    if (mLastSelectedThumbnail)
+    auto thumbnailScene = document()->thumbnailScene();
+
+    if (thumbnailScene->lastSelectedThumbnail())
     {
-        const int startSelectionIndex = mLastSelectedThumbnail->sceneIndex();
+        const int startSelectionIndex = thumbnailScene->lastSelectedThumbnail()->sceneIndex();
         const int previousSelectedThumbnailIndex = startSelectionIndex + mSelectionSpan;
 
         switch (event->key())
@@ -308,7 +310,6 @@ void UBDocumentThumbnailsView::keyPressEvent(QKeyEvent *event)
                         if (toSelectIndex < 0) break;
                     }
 
-                    mLastSelectedThumbnail = document()->thumbnailScene()->thumbnailAt(toSelectIndex);
                     selectItemAt(toSelectIndex, Qt::ControlModifier & event->modifiers());
                     mSelectionSpan = 0;
                 }
@@ -360,7 +361,6 @@ void UBDocumentThumbnailsView::keyPressEvent(QKeyEvent *event)
                     const auto selectedItem = document()->thumbnailScene()->thumbnailAt(selectedIndex);
 
                     selectItemAt(selectedIndex, Qt::ControlModifier & event->modifiers());
-                    mLastSelectedThumbnail = selectedItem;
                     mSelectionSpan = 0;
                 }
             }
@@ -376,7 +376,6 @@ void UBDocumentThumbnailsView::keyPressEvent(QKeyEvent *event)
                 else
                 {
                     selectItemAt(0, Qt::ControlModifier & event->modifiers());
-                    mLastSelectedThumbnail = document()->thumbnailScene()->thumbnailAt(0);
                     mSelectionSpan = 0;
                 }
             }
@@ -393,7 +392,6 @@ void UBDocumentThumbnailsView::keyPressEvent(QKeyEvent *event)
                 {
                     const auto selectIndex = document()->thumbnailScene()->thumbnailCount() - 1;
                     selectItemAt(selectIndex, Qt::ControlModifier & event->modifiers());
-                    mLastSelectedThumbnail = document()->thumbnailScene()->thumbnailAt(selectIndex);
                     mSelectionSpan = 0;
                 }
             }
@@ -428,11 +426,13 @@ void UBDocumentThumbnailsView::resizeEvent(QResizeEvent *event)
 
     if (document())
     {
-        document()->thumbnailScene()->arrangeThumbnails();
+        auto thumbnailScene = document()->thumbnailScene();
 
-        if (mLastSelectedThumbnail)
+        thumbnailScene->arrangeThumbnails();
+
+        if (thumbnailScene->lastSelectedThumbnail())
         {
-            ensureVisible(mLastSelectedThumbnail);
+            ensureVisible(thumbnailScene->lastSelectedThumbnail());
         }
     }
 
@@ -451,16 +451,6 @@ void UBDocumentThumbnailsView::selectItemAt(int pIndex, bool extend)
     const auto thumbnailScene = document()->thumbnailScene();
     thumbnailScene->hightlightItem(pIndex, !extend);
     ensureVisible(thumbnailScene->thumbnailAt(pIndex));
-}
-
-void UBDocumentThumbnailsView::unselectItemAt(int pIndex)
-{
-    UBThumbnail* itemToUnselect = document()->thumbnailScene()->thumbnailAt(pIndex);
-
-    if (itemToUnselect)
-    {
-        itemToUnselect->setSelected(false);
-    }
 }
 
 
@@ -483,7 +473,7 @@ void UBDocumentThumbnailsView::selectAll()
 
     for (int i = 0; i < thumbnailScene->thumbnailCount(); i++)
     {
-        thumbnailScene->thumbnailAt(i)->setSelected(true);
+        thumbnailScene->hightlightItem(i);
     }
 }
 

--- a/src/gui/UBDocumentThumbnailsView.h
+++ b/src/gui/UBDocumentThumbnailsView.h
@@ -58,7 +58,6 @@ class UBDocumentThumbnailsView : public UBThumbnailsView
         std::shared_ptr<UBDocument> document() const;
         QList<QGraphicsItem*> selectedItems();
         void selectItemAt(int pIndex, bool extend = false);
-        void unselectItemAt(int pIndex);
         void clearSelection();
 
         qreal thumbnailWidth()
@@ -114,7 +113,6 @@ class UBDocumentThumbnailsView : public UBThumbnailsView
 
         qreal mThumbnailWidth;
 
-        UBThumbnail* mLastSelectedThumbnail;
         int mSelectionSpan;
         QElapsedTimer mClickTime;
 

--- a/src/gui/UBThumbnailScene.cpp
+++ b/src/gui/UBThumbnailScene.cpp
@@ -116,7 +116,7 @@ void UBThumbnailScene::arrangeThumbnails(int fromIndex, int toIndex)
     view->setSceneRect(sceneRect);
 }
 
-void UBThumbnailScene::hightlightItem(int index, bool only)
+void UBThumbnailScene::hightlightItem(int index, bool only, bool selected)
 {
     if (only)
     {
@@ -129,11 +129,16 @@ void UBThumbnailScene::hightlightItem(int index, bool only)
                 thumbnail->setSelected(false);
             }
         }
+
+        mLastSelectedThumbnail = nullptr;
     }
 
     if (index >= 0 && index < mThumbnailItems.size())
     {
-        thumbnailAt(index)->setSelected(true);
+        auto thumbnail = thumbnailAt(index);
+        thumbnail->setSelected(selected);
+
+        mLastSelectedThumbnail = selected ? thumbnail : nullptr;
     }
 }
 
@@ -164,6 +169,11 @@ UBThumbnail* UBThumbnailScene::thumbnailAt(int index)
     }
 
     return nullptr;
+}
+
+UBThumbnail* UBThumbnailScene::lastSelectedThumbnail() const
+{
+    return mLastSelectedThumbnail;
 }
 
 /**
@@ -267,6 +277,11 @@ void UBThumbnailScene::deleteThumbnail(int pageIndex, bool rearrange)
 
         if (thumbnail)
         {
+            if (thumbnail == mLastSelectedThumbnail)
+            {
+                mLastSelectedThumbnail = nullptr;
+            }
+
             removeItem(thumbnail);
             delete thumbnail;
         }

--- a/src/gui/UBThumbnailScene.cpp
+++ b/src/gui/UBThumbnailScene.cpp
@@ -237,7 +237,7 @@ void UBThumbnailScene::insertThumbnail(int pageIndex, std::shared_ptr<UBGraphics
     {
         if (mThumbnailItems.size() == 1)
         {
-            mThumbnailItems.first()->setDeletable(true);
+            thumbnailAt(0)->setDeletable(true);
         }
 
         auto thumbnailItem = new UBThumbnail;
@@ -264,8 +264,13 @@ void UBThumbnailScene::deleteThumbnail(int pageIndex, bool rearrange)
     if (pageIndex < mThumbnailItems.size())
     {
         auto thumbnail = mThumbnailItems.at(pageIndex);
-        removeItem(thumbnail);
-        delete thumbnail;
+
+        if (thumbnail)
+        {
+            removeItem(thumbnail);
+            delete thumbnail;
+        }
+
         mThumbnailItems.removeAt(pageIndex);
 
         if (rearrange)
@@ -283,7 +288,7 @@ void UBThumbnailScene::deleteThumbnail(int pageIndex, bool rearrange)
 
     if (mThumbnailItems.size() == 1)
     {
-        mThumbnailItems.first()->setDeletable(false);
+        thumbnailAt(0)->setDeletable(false);
     }
 }
 
@@ -422,7 +427,7 @@ void UBThumbnailScene::loadNextThumbnail()
         // finished. set undeletable if only one page
         if (mThumbnailItems.size() == 1)
         {
-            mThumbnailItems.first()->setDeletable(false);
+            thumbnailAt(0)->setDeletable(false);
         }
 
         // delete background loader
@@ -448,6 +453,10 @@ void UBThumbnailScene::renumberThumbnails(int fromIndex, int toIndex) const
     for (int index = fromIndex; index < toIndex; ++index)
     {
         auto item = mThumbnailItems.at(index);
-        item->setSceneIndex(index);
+
+        if (item)
+        {
+            item->setSceneIndex(index);
+        }
     }
 }

--- a/src/gui/UBThumbnailScene.h
+++ b/src/gui/UBThumbnailScene.h
@@ -55,9 +55,10 @@ public:
     // thumbnail management
     void createThumbnails(int startIndex = 0);
     void arrangeThumbnails(int fromIndex = 0, int toIndex = -1);
-    void hightlightItem(int index, bool only = false);
+    void hightlightItem(int index, bool only = false, bool selected = true);
     int thumbnailCount() const;
     UBThumbnail* thumbnailAt(int index);
+    UBThumbnail* lastSelectedThumbnail() const;
 
 protected:
     // only to be called from UBDocument
@@ -78,4 +79,5 @@ private:
     QVector<UBThumbnail*> mThumbnailItems{};
     int mThumbnailWidth{UBSettings::defaultThumbnailWidth};
     UBBackgroundLoader* mLoader{nullptr};
+    UBThumbnail* mLastSelectedThumbnail{nullptr};
 };


### PR DESCRIPTION
- fix access to still not loaded thumbnails
  - either check for `nullptr`
  - or load thumbnail before accessing

Fixes https://github.com/letsfindaway/OpenBoard/issues/209