### PR TITLE
fix: thumbnail size and UI buttons

### DIFF
--- a/src/gui/UBThumbnail.cpp
+++ b/src/gui/UBThumbnail.cpp
@@ -272,7 +272,7 @@ void UBThumbnail::mousePressEvent(QGraphicsSceneMouseEvent* event)
     {
         using namespace UBThumbnailUI;
 
-        const auto p = event->pos();
+        const auto p = event->pos() - mPixmapItem->pos();
 
         if (mDeletable && getIcon("close")->triggered(p))
         {

--- a/src/gui/UBThumbnailScene.cpp
+++ b/src/gui/UBThumbnailScene.cpp
@@ -340,6 +340,7 @@ void UBThumbnailScene::reloadThumbnail(int pageIndex)
         if (thumbnail)
         {
             thumbnail->setPixmap(UBThumbnailAdaptor::get(mDocument->proxy(), pageIndex));
+            arrangeThumbnails(pageIndex, pageIndex + 1);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/letsfindaway/OpenBoard/issues/213

- rearrange a thumbnail after updating the pixmap to cope with changes in pixmap aspect ratio
- evaluate mouse events on thumbnail UI buttons relative to the pixmap item position