### PR TITLE
fix: terminate podcast on program exit

### DIFF
--- a/src/podcast/UBPodcastController.cpp
+++ b/src/podcast/UBPodcastController.cpp
@@ -110,15 +110,19 @@ UBPodcastController::UBPodcastController(QObject* pParent)
     connect(UBApplication::webController, SIGNAL(activeWebPageChanged(WebView*)),
             this, SLOT(webActiveWebPageChanged(WebView*)));
 
-    connect(UBApplication::app(), SIGNAL(lastWindowClosed()),
-            this, SLOT(applicationAboutToQuit()));
-
+    connect(UBApplication::mainWindow, &UBMainWindow::closeEvent_Signal, this, &UBPodcastController::applicationAboutToQuit);
 }
 
 
 UBPodcastController::~UBPodcastController()
 {
-    // NOOP
+    QElapsedTimer elapsed;
+    elapsed.start();
+
+    while (mRecordingState != Stopped && elapsed.elapsed() < 1000)
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+    }
 }
 
 

--- a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
+++ b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
@@ -270,10 +270,17 @@ UBFFmpegVideoEncoder::UBFFmpegVideoEncoder(QObject* parent)
 UBFFmpegVideoEncoder::~UBFFmpegVideoEncoder()
 {
     if (mVideoWorker)
-        delete mVideoWorker;
+    {
+        UBFFmpegVideoEncoder::stop();
+        mVideoWorker->deleteLater();
+    }
 
     if (mVideoEncoderThread)
+    {
+        mVideoEncoderThread->quit();
+        mVideoEncoderThread->wait();
         delete mVideoEncoderThread;
+    }
 
     if (mAudioInput)
         delete mAudioInput;


### PR DESCRIPTION
- When OpenBoard is closed while a podcast is running the application is hanging waiting for a thread to finish.
- Cleanly terminate the podcast recording before closing the application.

Fixes https://github.com/letsfindaway/OpenBoard/issues/223

**Note:** The `lastWindowClosed` signal is not emitted from the application when terminating OpenBoard. We therefore now connect to `UBMainWindow::closeEvent_Signal`. This also affects other locations, but there we always have another way in place to detect termination, so I did not touch them.