### PR TITLE
Build failure: Add missing QDebug header

### DIFF
--- a/src/frameworks/UBBackgroundLoader.cpp
+++ b/src/frameworks/UBBackgroundLoader.cpp
@@ -22,6 +22,7 @@
 
 #include "UBBackgroundLoader.h"
 
+#include <QDebug>
 #include <QFile>
 #include <QFutureWatcher>
 #include <QtConcurrentMap>


### PR DESCRIPTION
@kaamui 
Since #1268, a missing header leads to this cryptic error when building on Arch with Qt 6.9:

```
/build/openboard-git/src/OpenBoard/src/frameworks/UBBackgroundLoader.cpp: In destructor ‘virtual UBBackgroundLoader::~UBBackgroundLoader()’:
/build/openboard-git/src/OpenBoard/src/frameworks/UBBackgroundLoader.cpp:53:11: error: invalid use of incomplete type ‘class QDebug’
   53 |     qDebug() << "Destruct UBBackgroundLoader";
      |           ^
In file included from /usr/include/qt6/QtCore/qglobal.h:45,
                 from /usr/include/qt6/QtCore/qfuture.h:7,
                 from /usr/include/qt6/QtCore/QFuture:1,
                 from /build/openboard-git/src/OpenBoard/src/frameworks/UBBackgroundLoader.h:25,
                 from /build/openboard-git/src/OpenBoard/src/frameworks/UBBackgroundLoader.cpp:23:
/usr/include/qt6/QtCore/qtypeinfo.h:15:7: note: forward declaration of ‘class QDebug’
   15 | class QDebug;
      |       ^~~~~~
/build/openboard-git/src/OpenBoard/src/frameworks/UBBackgroundLoader.cpp: In member function ‘void UBBackgroundLoader::load(const QList<std::pair<int, QString> >&, int)’:
/build/openboard-git/src/OpenBoard/src/frameworks/UBBackgroundLoader.cpp:77:11: error: invalid use of incomplete type ‘class QDebug’
   77 |     qDebug() << "UBBackgroundLoader: Start loading" << paths.at(0).second;
      |           ^
/usr/include/qt6/QtCore/qtypeinfo.h:15:7: note: forward declaration of ‘class QDebug’
   15 | class QDebug;
      |       ^~~~~~

```

Adding the <QDebug> header to the file fixes this issue.