### PR TITLE
fix: paste svg image to board

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2561,10 +2561,13 @@ void UBBoardController::processMimeData(const QMimeData* pMimeData, const QPoint
     {
         const QStringList formats = pMimeData->formats();
         QString selectedFormat;
+        UBMimeType::Enum ubMimeType{UBMimeType::UNKNOWN};
 
         for (const QString& format : formats)
-        {
-            if (format.startsWith("image/"))
+        {            
+            ubMimeType = UBFileSystemUtils::mimeTypeFromString(format);
+
+            if (ubMimeType == UBMimeType::VectorImage || ubMimeType == UBMimeType::RasterImage)
             {
                 selectedFormat = format;
                 break;
@@ -2575,9 +2578,11 @@ void UBBoardController::processMimeData(const QMimeData* pMimeData, const QPoint
 
         if (selectedFormat.isEmpty())
         {
+            // should never happen, but just in case
             // create an image and fill the buffer with PNG data
             QImage img = qvariant_cast<QImage> (pMimeData->imageData());
             img.save(&buffer, "png");
+            ubMimeType = UBMimeType::RasterImage;
         }
         else
         {
@@ -2585,11 +2590,19 @@ void UBBoardController::processMimeData(const QMimeData* pMimeData, const QPoint
             buffer.setData(pMimeData->data(selectedFormat));
         }
 
-        // validate that the image is really an image, webkit does not fill properly the image mime data
-        if (!buffer.data().isEmpty())
+        if (ubMimeType == UBMimeType::VectorImage)
         {
-            mActiveScene->addImage(buffer.data(), NULL, pPos, 1.);
+            mActiveScene->addSvg({}, pPos, buffer.data());
             return;
+        }
+        else if (ubMimeType == UBMimeType::RasterImage)
+        {
+            // validate that the image is really an image, webkit does not fill properly the image mime data
+            if (!buffer.data().isEmpty())
+            {
+                mActiveScene->addImage(buffer.data(), nullptr, pPos, 1.);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
- select first mime type containing a known image format
- create SVG image if it is a vector image
- create bitmap image if it is a raster image

We first convert the mime type string to a `UBMimeType` to check whether it is an image format supported by OpenBoard. Note, that for example Inkscape first lists an `image/x-inkscape.svg` before `image/svg+xml` in the format list and we have to make sure to select the latter. Therefore just checking for the mime type prefix is not sufficient.

We then act according to the result and either call `addSvg()` or `addImage()` at the `UBBoardController`.

Renaming of file extensions, i.e. inserting the additional `.png` for the file stored in the `images` folder is only done in `addImage()`.

Fixes #1298