### PR TITLE
Fixes a typo - Licences should be Licenses in Preferences dialog.

### DIFF
--- a/resources/i18n/OpenBoard_en.ts
+++ b/resources/i18n/OpenBoard_en.ts
@@ -3791,7 +3791,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../forms/preferences.ui" line="1103"/>
         <source>Licences</source>
-        <translation type="unfinished"></translation>
+        <translation>Licenses</translation>
     </message>
     <message>
         <location filename="../forms/preferences.ui" line="3104"/>


### PR DESCRIPTION
Fixes the issue #1349.