### PR TITLE
fix: sync thumbnails view with document

### DIFF
--- a/src/core/UBPersistenceManager.cpp
+++ b/src/core/UBPersistenceManager.cpp
@@ -321,12 +321,12 @@ QDialog::DialogCode UBPersistenceManager::processInteractiveReplacementDialog(st
 
                         if (UBApplication::documentController->selectedDocument() == replacedProxy)
                         {
-                            UBApplication::documentController->pureSetDocument(pProxy);
+                            UBApplication::documentController->setDocument(pProxy);
                         }
 
                         if (UBApplication::boardController->selectedDocument() == replacedProxy)
                         {
-                            UBApplication::boardController->pureSetDocument(pProxy);
+                            UBApplication::boardController->setDocument(pProxy);
                         }
                     }
                     else
@@ -382,12 +382,12 @@ QDialog::DialogCode UBPersistenceManager::processInteractiveReplacementDialog(st
 
                         if (UBApplication::documentController->selectedDocument() == replacedProxy)
                         {
-                            UBApplication::documentController->pureSetDocument(pProxy);
+                            UBApplication::documentController->setDocument(pProxy);
                         }
 
                         if (UBApplication::boardController->selectedDocument() == replacedProxy)
                         {
-                            UBApplication::boardController->pureSetDocument(pProxy);
+                            UBApplication::boardController->setDocument(pProxy);
                         }
                     }
                     else

--- a/src/document/UBDocumentContainer.cpp
+++ b/src/document/UBDocumentContainer.cpp
@@ -51,15 +51,10 @@ void UBDocumentContainer::setDocument(std::shared_ptr<UBDocumentProxy> document,
 {
     if (mCurrentDocument != document || forceReload)
     {
-        pureSetDocument(document);
+        mCurrentDocument = document;
+        mActiveDocument = UBDocument::getDocument(mCurrentDocument);
         emit documentSet(document);
     }
-}
-
-void UBDocumentContainer::pureSetDocument(std::shared_ptr<UBDocumentProxy> document)
-{
-    mCurrentDocument = document;
-    mActiveDocument = UBDocument::getDocument(mCurrentDocument);
 }
 
 std::shared_ptr<UBDocument> UBDocumentContainer::activeDocument()

--- a/src/document/UBDocumentContainer.h
+++ b/src/document/UBDocumentContainer.h
@@ -45,7 +45,6 @@ class UBDocumentContainer : public QObject
         virtual ~UBDocumentContainer();
 
         void setDocument(std::shared_ptr<UBDocumentProxy> document, bool forceReload = false);
-        void pureSetDocument(std::shared_ptr<UBDocumentProxy> document);
 
         std::shared_ptr<UBDocumentProxy> selectedDocument(){return mCurrentDocument;}
         std::shared_ptr<UBDocument> activeDocument();


### PR DESCRIPTION
This PR fixes https://github.com/letsfindaway/OpenBoard/issues/232

- calling pureSetDocument leaves the controller in an inconsistent state
- remove this function and always use setDocument instead
- a guard condition in this function avoids unnecessary work when the document is not changed