### PR TITLE
fix: shortcuts while editing text item

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2450,13 +2450,14 @@ void UBBoardController::processMimeData(const QMimeData* pMimeData, const QPoint
         if("" != pMimeData->text()){
             // Sometimes, it is possible to have an URL as text. we check here if it is the case
             QString qsTmp = pMimeData->text().remove(QChar('\0'));
-            if(qsTmp.startsWith("http"))
+
+            if (qsTmp.startsWith("http:") || qsTmp.startsWith("https:"))
+            {
                 downloadURL(QUrl(qsTmp), QString(), pPos);
-            else{
-                if(mActiveScene->selectedItems().count() && mActiveScene->selectedItems().at(0)->type() == UBGraphicsItemType::TextItemType)
-                    dynamic_cast<UBGraphicsTextItem*>(mActiveScene->selectedItems().at(0))->setHtml(pMimeData->text());
-                else
-                    mActiveScene->addTextHtml("", pPos)->setHtml(pMimeData->text());
+            }
+            else
+            {
+                mActiveScene->addTextHtml("", pPos)->setHtml(qsTmp);
             }
         }
         else{

--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -324,9 +324,7 @@ int UBApplication::exec(const QString& pFileToImport)
 
     mainWindow->setAttribute(Qt::WA_NativeWindow, true);
 
-    mainWindow->actionCopy->setShortcuts(QKeySequence::Copy);
-    mainWindow->actionPaste->setShortcuts(QKeySequence::Paste);
-    mainWindow->actionCut->setShortcuts(QKeySequence::Cut);
+    enableEditingShortcuts(true);
 
     UBThumbnailUI::_private::initCatalog();
 
@@ -774,6 +772,22 @@ void UBApplication::cleanup()
     boardController = NULL;
     webController = NULL;
     documentController = NULL;
+}
+
+void UBApplication::enableEditingShortcuts(bool enable)
+{
+    if (enable)
+    {
+        mainWindow->actionCopy->setShortcuts(QKeySequence::Copy);
+        mainWindow->actionPaste->setShortcuts(QKeySequence::Paste);
+        mainWindow->actionCut->setShortcuts(QKeySequence::Cut);
+    }
+    else
+    {
+        mainWindow->actionCopy->setShortcuts({});
+        mainWindow->actionPaste->setShortcuts({});
+        mainWindow->actionCut->setShortcuts({});
+    }
 }
 
 QString UBApplication::urlFromHtml(QString html)

--- a/src/core/UBApplication.h
+++ b/src/core/UBApplication.h
@@ -68,6 +68,8 @@ class UBApplication : public SingleApplication
 
         void cleanup();
 
+        void enableEditingShortcuts(bool enable);
+
         static QPointer<QUndoStack> undoStack;
 
         static UBDisplayManager* displayManager;

--- a/src/domain/UBGraphicsTextItem.cpp
+++ b/src/domain/UBGraphicsTextItem.cpp
@@ -323,6 +323,21 @@ void UBGraphicsTextItem::keyReleaseEvent(QKeyEvent *event)
     QGraphicsTextItem::keyReleaseEvent(event);
 }
 
+void UBGraphicsTextItem::focusInEvent(QFocusEvent* event)
+{
+    // disable global editing shortcuts while text item is focussed
+    // so that they are passed to the item
+    UBApplication::app()->enableEditingShortcuts(false);
+    QGraphicsTextItem::focusInEvent(event);
+}
+
+void UBGraphicsTextItem::focusOutEvent(QFocusEvent* event)
+{
+    // re-enable global editing shortcuts when loosing focus
+    UBApplication::app()->enableEditingShortcuts(true);
+    QGraphicsTextItem::focusOutEvent(event);
+}
+
 void UBGraphicsTextItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     // Never draw the rubber band, we draw our custom selection with the DelegateFrame

--- a/src/domain/UBGraphicsTextItem.h
+++ b/src/domain/UBGraphicsTextItem.h
@@ -48,19 +48,19 @@ class UBGraphicsTextItem : public QGraphicsTextItem, public UBItem, public UBRes
 
         enum { Type = UBGraphicsItemType::TextItemType };
 
-        virtual int type() const
+        virtual int type() const override
         {
             return Type;
         }
 
-        virtual UBItem* deepCopy() const;
+        virtual UBItem* deepCopy() const override;
 
-        virtual void copyItemParameters(UBItem *copy) const;
+        virtual void copyItemParameters(UBItem *copy) const override;
 
-        virtual std::shared_ptr<UBGraphicsScene> scene();
+        virtual std::shared_ptr<UBGraphicsScene> scene() override;
 
-        virtual QRectF boundingRect() const;
-        virtual QPainterPath shape() const;
+        virtual QRectF boundingRect() const override;
+        virtual QPainterPath shape() const override;
 
         void setTextWidth(qreal width);
         void setTextHeight(qreal height);
@@ -69,9 +69,9 @@ class UBGraphicsTextItem : public QGraphicsTextItem, public UBItem, public UBRes
 
         void contentsChanged();
 
-        virtual void resize(qreal w, qreal h);
+        virtual void resize(qreal w, qreal h) override;
 
-        virtual QSizeF size() const;
+        virtual QSizeF size() const override;
 
         static QColor lastUsedTextColor;
 
@@ -112,18 +112,21 @@ class UBGraphicsTextItem : public QGraphicsTextItem, public UBItem, public UBRes
         void documentSizeChanged(const QSizeF & newSize);
 
     private:
-        virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
-        virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-        virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+        virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+        virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+        virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
-        virtual void keyPressEvent(QKeyEvent *event);
-        virtual void keyReleaseEvent(QKeyEvent *event);
+        virtual void keyPressEvent(QKeyEvent *event) override;
+        virtual void keyReleaseEvent(QKeyEvent *event) override;
 
-        virtual void dragMoveEvent(QGraphicsSceneDragDropEvent *event);
+        virtual void focusInEvent(QFocusEvent* event) override;
+        virtual void focusOutEvent(QFocusEvent* event) override;
 
-        virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+        virtual void dragMoveEvent(QGraphicsSceneDragDropEvent *event) override;
 
-        virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+        virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+
+        virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
         qreal mTextHeight;
 


### PR DESCRIPTION
- While editing a text item, secondary shortcuts like `Shift+Ins` have not been processed properly
- Instead they have been routed to the board controller
- Add `UBApplication::enableEditingShortcuts` to enable/disable global action shortcuts for cut/copy/paste
- Disable these shortcuts while a text item is selected
- Reorder and cleanup includes in `UBGraphicsTextItemDelegate`

Fixes #1367