### PR TITLE
fix: German translation for Cache

### DIFF
--- a/resources/i18n/OpenBoard_de.ts
+++ b/resources/i18n/OpenBoard_de.ts
@@ -3298,7 +3298,7 @@ Miniaturansicht der Seite %1 wird geladen</translation>
     <message>
         <location filename="../../src/tools/UBToolsManager.cpp" line="113"/>
         <source>Cache</source>
-        <translation>Zwischenspeicher</translation>
+        <translation>Guckloch</translation>
     </message>
     <message>
         <location filename="../../src/tools/UBToolsManager.cpp" line="73"/>


### PR DESCRIPTION
The English word "cache" may mean "intermediate storage", but also "hideaway". For the Cache application it means "hideaway", because the application hides the page and only reveals a small part..

So instead of "Zwischenspeicher" I propose to much more appropriate translation "Guckloch" (peep hole).