### PR TITLE
fix: blurry screenshots

### DIFF
--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -2353,13 +2353,22 @@ void UBBoardController::grabScene(const QRectF& pSceneRect)
 {
     if (mActiveScene)
     {
-        QImage image(pSceneRect.width(), pSceneRect.height(), QImage::Format_ARGB32);
+        /*
+         * To get the pixel size on screen for the screenshot
+         * we use the system scale factor to align to the pixels
+         * and use an additional factor of two to provide more details
+         */
+        const auto scalingFactor = 2. * mSystemScaleFactor;
+        const auto pixelSize = pSceneRect.size() * scalingFactor;
+        QImage image(pixelSize.toSize(), QImage::Format_ARGB32);
         image.fill(Qt::transparent);
 
-        QRectF targetRect(0, 0, pSceneRect.width(), pSceneRect.height());
+        QRectF targetRect{{0, 0}, pixelSize};
         QPainter painter(&image);
         painter.setRenderHint(QPainter::SmoothPixmapTransform);
         painter.setRenderHint(QPainter::Antialiasing);
+        painter.setRenderHint(QPainter::TextAntialiasing);
+        painter.setRenderHint(QPainter::LosslessImageRendering);
 
         mActiveScene->setRenderingContext(UBGraphicsScene::NonScreen);
         mActiveScene->setRenderingQuality(UBItem::RenderingQualityHigh, UBItem::CacheNotAllowed);
@@ -2370,8 +2379,7 @@ void UBBoardController::grabScene(const QRectF& pSceneRect)
 //        mActiveScene->setRenderingQuality(UBItem::RenderingQualityNormal);
         mActiveScene->setRenderingQuality(UBItem::RenderingQualityHigh, UBItem::CacheAllowed);
 
-
-        mPaletteManager->addItem(QPixmap::fromImage(image));
+        mPaletteManager->addItem(QPixmap::fromImage(image), QPointF{}, 1. / scalingFactor);
         QDateTime now = QDateTime::currentDateTime();
         selectedDocument()->setMetaData(UBSettings::documentUpdatedAt, UBStringUtils::toUtcIsoDateTime(now));
     }

--- a/src/core/UBApplicationController.cpp
+++ b/src/core/UBApplicationController.cpp
@@ -301,26 +301,24 @@ void UBApplicationController::addCapturedPixmap(const QPixmap &pPixmap, bool pag
 {
     if (!pPixmap.isNull())
     {
-        qreal sf = UBApplication::boardController->systemScaleFactor();
-        qreal scaledWidth = ((qreal)pPixmap.width()) / sf;
-        qreal scaledHeight = ((qreal)pPixmap.height()) / sf;
+        // make all scaling calculations floating point
+        const auto sf = UBApplication::boardController->systemScaleFactor();
+        const QSizeF pageNominalSize{UBApplication::boardController->activeScene()->nominalSize()};
+        const QSizeF pixmapSize{pPixmap.size()};
 
-        QSize pageNominalSize = UBApplication::boardController->activeScene()->nominalSize();
-
-        int newWidth = qMin((int)scaledWidth, pageNominalSize.width());
-        int newHeight = qMin((int)scaledHeight, pageNominalSize.height());
+        QSizeF scaledSize{pixmapSize / sf};
+        QSizeF newSize{scaledSize.boundedTo(pageNominalSize)};
 
         if (pageMode)
         {
-            newHeight = pPixmap.height();
+            newSize.setHeight(pixmapSize.height());
         }
 
-        QSizeF scaledSize(scaledWidth, scaledHeight);
-        scaledSize.scale(newWidth, newHeight, Qt::KeepAspectRatio);
+        scaledSize.scale(newSize, Qt::KeepAspectRatio);
 
-        qreal scaleFactor = qMin(scaledSize.width() / (qreal)pPixmap.width(), scaledSize.height() / (qreal)pPixmap.height());
+        qreal scaleFactor = qMin(scaledSize.width() / pixmapSize.width(), scaledSize.height() / pixmapSize.height());
 
-        QPointF pos(0.0, 0.0);
+        QPointF pos{};
 
         if (pageMode)
         {

--- a/src/desktop/UBCustomCaptureWindow.cpp
+++ b/src/desktop/UBCustomCaptureWindow.cpp
@@ -81,7 +81,13 @@ int UBCustomCaptureWindow::execute(const QPixmap &pScreenPixmap)
 
     // necessary so that changing geometry really affects the widget
     showNormal();
-    setGeometry(UBApplication::displayManager->screenGeometry(ScreenRole::Desktop));
+    const auto geo = UBApplication::displayManager->screenGeometry(ScreenRole::Desktop);
+    setGeometry(geo);
+
+    // for some Qt versions it is also necessary to do explicit move and resize
+    move(geo.topLeft());
+    resize(geo.size());
+
     this->show();
     setWindowOpacity(1.0);
 


### PR DESCRIPTION
This PR addresses the issue #1378 about screenshot resolution.

- general: align pixels of screenshot to display resolution
- apply system scale factor for board screenshots
- use double the resolution to improve appearance when zoomed
- use floating point calculations for desktop and web screenshots
- workaround to position `UBCustomCaptureWindow` on some Qt versions
