### PR TITLE
[Building/Packaging] Explicit cast to string_view to resolve build failure

### DIFF
--- a/src/pdf/XPDFRenderer.cpp
+++ b/src/pdf/XPDFRenderer.cpp
@@ -61,7 +61,9 @@ XPDFRenderer::XPDFRenderer(const QString &filename, bool importingFile)
 #endif
         globalParams->setupBaseFonts(QFile::encodeName(UBPlatformUtils::applicationResourcesDirectory() + "/" + "fonts").data());
     }
-#if POPPLER_VERSION_MAJOR > 22 || (POPPLER_VERSION_MAJOR == 22 && POPPLER_VERSION_MINOR >= 3)
+#if POPPLER_VERSION_MAJOR > 25 || (POPPLER_VERSION_MAJOR == 25 && POPPLER_VERSION_MINOR >= 12)
+    mDocument = new PDFDoc(std::make_unique<GooString>(static_cast<std::string_view>(filename.toLocal8Bit())));
+#elif POPPLER_VERSION_MAJOR > 22 || (POPPLER_VERSION_MAJOR == 22 && POPPLER_VERSION_MINOR >= 3)
     mDocument = new PDFDoc(std::make_unique<GooString>(filename.toLocal8Bit()));
 #else
     mDocument = new PDFDoc(new GooString(filename.toLocal8Bit()), 0, 0, 0); // the filename GString is deleted on PDFDoc desctruction


### PR DESCRIPTION
@kaamui 
Poppler 25.12 allows string_view and char* for GooString. QByteArray can be converted to both, so choose one explicitly to avoid the "call of overloaded ‘GooString(QByteArray)’ is ambiguous" error:

```
/build/openboard-git/src/OpenBoard/src/pdf/XPDFRenderer.cpp:65:55:   required from here
   65 |     mDocument = new PDFDoc(std::make_unique<GooString>(filename.toLocal8Bit()));
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/unique_ptr.h:1084:30: error: call of overloaded ‘GooString(QByteArray)’ is ambiguous
 1084 |     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/unique_ptr.h:1084:30: note: there are 9 candidates
In file included from /usr/include/poppler/Object.h:46,
                 from /build/openboard-git/src/OpenBoard/src/pdf/XPDFRenderer.h:41:
/usr/include/poppler/goo/GooString.h:91:14: note: candidate 1: ‘GooString::GooString(std::string_view)’
   91 |     explicit GooString(std::string_view str) : std::string(str) { }
      |              ^~~~~~~~~
/usr/include/poppler/goo/GooString.h:73:14: note: candidate 2: ‘GooString::GooString(const char*)’
   73 |     explicit GooString(const char *sA) : std::string(sA ? sA : "") { }
      |              ^~~~~~~~~
```

