### PR TITLE
Fix Qt 6.11 warning

### DIFF
--- a/src/podcast/ffmpeg/UBMicrophoneInput.cpp
+++ b/src/podcast/ffmpeg/UBMicrophoneInput.cpp
@@ -291,6 +291,11 @@ void UBMicrophoneInput::onAudioInputStateChanged(QAudio::State state)
             }
             break;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 11, 0))
+        case QAudio::IdleState:
+            qWarning() << "Audio buffer full. Further input might not get processed.";
+            break;
+#endif
         // handle other states?
 
         default:
@@ -385,8 +390,10 @@ QString UBMicrophoneInput::getErrorString(QAudio::Error errorCode)
         case QAudio::IOError :
             return "Error reading from audio device";
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 11, 0))
         case QAudio::UnderrunError :
             return "Underrun error";
+#endif
 
         case QAudio::FatalError :
             return "Fatal error; audio device unusable";


### PR DESCRIPTION
[Recent documentation changes](https://code.qt.io/cgit/qt/qtmultimedia.git/commit/?id=bc93bbdd58d009e38cd40ad0366db0696a2ba7b7) in Qt 6.10 clarifies that the IdleState is entered if data from the microphone might not get processed. [Another change](https://code.qt.io/cgit/qt/qtmultimedia.git/commit/?id=ab7de3397df541212151f045091c1a1a988d5885) in Qt 6.11 then deprecates `QAudio::UnderrunError` because it can never be emitted (instead, the state changes to IdleState).

Add a warning that data might not get processed if entering the IdleState. This can be useful to help investigate data corruption issues.

Documentation suggests that this is the case since 6.0, but doesn't state it outright, so the change is applied for 6.11+ only.