### PR TITLE
[Bug] Text typo in "Hints and tips" in step 11 solved

### DIFF
--- a/resources/startupHints/locales/en/11.html
+++ b/resources/startupHints/locales/en/11.html
@@ -21,7 +21,7 @@
 		<p>You can open this tool like this : </p>
 		<div class="image"><img src="../../assets/hint11/podcast-gif1.gif" alt=""></div>
 
-		<p>You'll see the folowwing interface appear at the bottom right of the whiteboard :</p>
+		<p>You'll see the following interface appear at the bottom right of the whiteboard :</p>
 		<div class="image"><img src="../../assets/hint11/podcast2.png" alt=""></div>
 
 		<p>Click on the red button to start recording.</p>
@@ -37,3 +37,4 @@
 	</footer>
 </body>
 </html>
+


### PR DESCRIPTION
[Bug] Text typo in "Hints and tips" in step 11 solved Solved [this issue](https://github.com/OpenBoard-org/OpenBoard/issues/1395)