### PR TITLE
Declare the missing #include <optional> in UBSvgSubsetAdaptor.h

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.h
+++ b/src/adaptors/UBSvgSubsetAdaptor.h
@@ -34,6 +34,8 @@
 #include <QtXml>
 #include <QGraphicsItem>
 
+#include <optional>
+
 #include "frameworks/UBGeometryUtils.h"
 
 class UBGraphicsSvgItem;


### PR DESCRIPTION
In `UBSvgSubsetAdaptor.h`, `std::optional` is not defined.
It throws an error with Qt 5.15.6 and GCC 11.4 (ubuntu 22.04)
from the `dev` branch.

The PR adds the missing declaration.
Issue was described here #1344 