### PR TITLE
Fix widget name in preferences.ui

### DIFF
--- a/resources/forms/preferences.ui
+++ b/resources/forms/preferences.ui
@@ -1175,7 +1175,7 @@
          <property name="styleSheet">
           <string notr="true">QScrollArea:disabled {border: 1px solid red;}</string>
          </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents">
+         <widget class="QWidget" name="scrollAreaWidgetContents_2">
           <property name="geometry">
            <rect>
             <x>0</x>


### PR DESCRIPTION
#955 introduced a new preference dialog which includes a new scroll area. The chosen name for it isn't unique however, thus this warning appears during building:
```
[  3%] Automatic MOC and UIC for target openboard
AutoUic: /build/openboard-git/src/OpenBoard/resources/forms/preferences.ui: Warning: The name 'scrollAreaWidgetContents' (QWidget) is already in use, defaulting to 'scrollAreaWidgetContents1'.
```

It's better for us to control the name instead of some default, and adapt the name to the used convention with underscore and number.