### PR TITLE
refactor: use different setContent overload

### DIFF
--- a/src/gui/UBBackgroundManager.cpp
+++ b/src/gui/UBBackgroundManager.cpp
@@ -300,8 +300,12 @@ QPixmap UBBackgroundManager::createButtonPixmap(const QDomDocument& bgDoc, bool 
     }
 
     QDomDocument doc;
-
-    if (!doc.setContent(&templateFile, true))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    auto result = doc.setContent(&templateFile, QDomDocument::ParseOption::UseNamespaceProcessing);
+#else
+    auto result = doc.setContent(&templateFile, true)
+#endif
+    if (!result)
     {
         qWarning() << "Cannot load template file" << templateFile.fileName();
         return {};


### PR DESCRIPTION
4586cc3d32ac0ca5c2d455d4aad87ba0ea51776b added a deprecated use of setContent.

Similar to a5141d84ca1b4737b42133395fe6571945a4e7ca, namespace processing can be specified via ParseOptions instead of a boolean value.