### PR TITLE
fix: rearrange board thumbnails after duplicating scene

### DIFF
--- a/src/gui/UBBoardThumbnailsView.cpp
+++ b/src/gui/UBBoardThumbnailsView.cpp
@@ -160,7 +160,7 @@ void UBBoardThumbnailsView::resizeEvent(QResizeEvent *event)
     bool scrollbarWasHidden = mScrollbarVisible && !verticalScrollBar()->isVisible();
 
     // Refresh the scene, except if resizing because scrollbar was hidden
-    if (event->size().width() > 0 && !scrollbarWasHidden && mDocument)
+    if (event->oldSize().width() == 0 || (event->size().width() > 0 && !scrollbarWasHidden && mDocument))
     {
         mDocument->thumbnailScene()->arrangeThumbnails();
         ensureVisibleThumbnail(UBApplication::boardController->activeSceneIndex());


### PR DESCRIPTION
- When duplicating a scene in board mode while the left palette is hidden and then showing the palette, the thumbnail arrangement was broken.
- Unconditionally rearrange thumbnails when showing palette.

This PR fixes #1421.

This fix should also be applied to the `dev` branch.