### PR TITLE
build: adapt to poppler 26.02

### DIFF
--- a/src/pdf/XPDFRenderer.cpp
+++ b/src/pdf/XPDFRenderer.cpp
@@ -235,7 +235,11 @@ QImage* XPDFRenderer::createPDFImageUncached(int pageNumber, qreal xscale, qreal
         if(mSplashUncached)
             delete mSplashUncached;
 
+#if POPPLER_VERSION_MAJOR > 26 || (POPPLER_VERSION_MAJOR == 26 && POPPLER_VERSION_MINOR >= 2)
+        mSplashUncached = new SplashOutputDev(splashModeRGB8, 1, constants::paperColor);
+#else
         mSplashUncached = new SplashOutputDev(splashModeRGB8, 1, false, constants::paperColor);
+#endif
         mSplashUncached->startDoc(mDocument);
 
         int rotation = 0; // in degrees (get it from the worldTransform if we want to support rotation)

--- a/src/pdf/XPDFRenderer.h
+++ b/src/pdf/XPDFRenderer.h
@@ -42,6 +42,7 @@
 #include <poppler/GlobalParams.h>
 #include <poppler/SplashOutputDev.h>
 #include <poppler/PDFDoc.h>
+#include <poppler/cpp/poppler-version.h>
 
 class PDFDoc;
 
@@ -105,7 +106,11 @@ class XPDFRenderer : public PDFRenderer
                     cachedImage = QImage();
                     delete splash;
                 }
+#if POPPLER_VERSION_MAJOR > 26 || (POPPLER_VERSION_MAJOR == 26 && POPPLER_VERSION_MINOR >= 2)
+                splash = new SplashOutputDev(splashModeRGB8, 1, paperColor);
+#else
                 splash = new SplashOutputDev(splashModeRGB8, 1, false, paperColor);
+#endif
                 cachedPageNumber = pageNumber;
             }
 


### PR DESCRIPTION
- poppler 26.02 removes an obsolete parameter from the constructor of SplashOutputDev
- conditionally remove this parameter depending on poppler version