### PR TITLE
feat: document converter 1.8.0 to 1.7.x

### DIFF
--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -709,6 +709,7 @@ void UBSvgSubsetAdaptor::UBSvgSubsetReader::processElement()
                     UBGraphicsSvgItem* svgItem = svgItemFromSvg();
                     if (svgItem)
                     {
+                        svgItem->setSourceUrl(QUrl::fromLocalFile(href));
                         svgItem->setFlag(QGraphicsItem::ItemIsMovable, true);
                         svgItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 
@@ -725,6 +726,7 @@ void UBSvgSubsetAdaptor::UBSvgSubsetReader::processElement()
                     UBGraphicsPixmapItem* pixmapItem = pixmapItemFromSvg();
                     if (pixmapItem)
                     {
+                        pixmapItem->setSourceUrl(QUrl::fromLocalFile(href));
                         pixmapItem->setFlag(QGraphicsItem::ItemIsMovable, true);
                         pixmapItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 

--- a/src/core/UBPersistenceManager.h
+++ b/src/core/UBPersistenceManager.h
@@ -167,6 +167,7 @@ class UBPersistenceManager : public QObject
         void documentSceneDeleted(std::shared_ptr<UBDocumentProxy> pDocumentProxy, int pIndex);
 
 private:
+        friend class UBDocumentVersionConverter;
         static int sceneCount(const std::shared_ptr<UBDocumentProxy> pDocumentProxy);
         static QStringList getSceneFileNames(const QString& folder);
         void renamePage(std::shared_ptr<UBDocumentProxy> pDocumentProxy,

--- a/src/document/CMakeLists.txt
+++ b/src/document/CMakeLists.txt
@@ -7,6 +7,12 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBDocumentController.h
     UBDocumentProxy.cpp
     UBDocumentProxy.h
+    UBDocumentToc.cpp
+    UBDocumentToc.h
+    UBDocumentVersionConverter.cpp
+    UBDocumentVersionConverter.h
     UBSortFilterProxyModel.cpp
     UBSortFilterProxyModel.h
+    UBTocSerializer.cpp
+    UBTocSerializer.h
 )

--- a/src/document/UBDocumentController.cpp
+++ b/src/document/UBDocumentController.cpp
@@ -63,6 +63,7 @@
 
 #include "document/UBDocument.h"
 #include "document/UBDocumentProxy.h"
+#include "document/UBDocumentVersionConverter.h"
 
 #include "ui_documents.h"
 
@@ -537,30 +538,49 @@ QVariant UBDocumentTreeModel::data(const QModelIndex &index, int role) const
                 dataNode->proxyData() &&
                 dataNode->proxyData()->isBroken();
 
-            if (isBrokenDocumentNode) {
+            if (isBrokenDocumentNode)
+            {
                 return QIcon(":images/toolbar/warning.png");
             }
 
-            if (mCurrentNode && mCurrentNode == dataNode) {
+            if (mCurrentNode && mCurrentNode == dataNode)
+            {
                 return QIcon(":images/currentDocument.png");
-            } else {
-                if (index == trashIndex()) {
-                    return QIcon(":images/trash.png");
-                } else if (isConstant(index)) {
-                    return QIcon(":images/libpalette/ApplicationsCategory.svg");
-                }
-                switch (static_cast<int>(dataNode->nodeType()))
-                {
-                    case UBDocumentTreeNode::Catalog :
-                        return QIcon(":images/folder.png");
-                    case UBDocumentTreeNode::Document :
-                    {
-                        const auto proxy = dataNode->proxyData();
-                        if (proxy && proxy->isInFavoriteList()) {
-                            return QIcon(":images/libpalette/miniFavorite.png");
-                        }
+            }
 
+            if (index == trashIndex())
+            {
+                return QIcon(":images/trash.png");
+            }
+
+            if (isConstant(index))
+            {
+                return QIcon(":images/libpalette/ApplicationsCategory.svg");
+            }
+
+            switch (static_cast<int>(dataNode->nodeType()))
+            {
+                case UBDocumentTreeNode::Catalog :
+                    return QIcon(":images/folder.png");
+
+                case UBDocumentTreeNode::Document :
+                {
+                    const auto proxy = dataNode->proxyData();
+
+                    if (proxy && proxy->isInFavoriteList())
+                    {
+                        return QIcon(":images/libpalette/miniFavorite.png");
+                    }
+
+                    const auto version = QVersionNumber::fromString(proxy->metaData(UBSettings::documentVersion).toString());
+
+                    if (version <= QVersionNumber::fromString(UBSettings::currentFileVersion))
+                    {
                         return QIcon(":images/toolbar/board.png");
+                    }
+                    else
+                    {
+                        return QIcon(":images/toolbar/warning.png");
                     }
                 }
             }
@@ -2079,8 +2099,6 @@ void UBDocumentController::showBrokenDocumentWarning()
 
 void UBDocumentController::TreeViewSelectionChanged(const QModelIndex &current, const QModelIndex &previous)
 {
-    Q_UNUSED(previous)
-
     UBDocumentTreeModel *docModel = UBPersistenceManager::persistenceManager()->mDocumentTreeStructureModel;
 
     QModelIndex current_index = mapIndexToSource(current);
@@ -2092,11 +2110,27 @@ void UBDocumentController::TreeViewSelectionChanged(const QModelIndex &current, 
 
     if(current_index.isValid() && mDocumentUI->documentTreeView->selectionModel()->selectedRows(0).size() == 1)
     {
-        currentDocumentProxy = docModel->proxyData(current_index);
-        if (docModel->isDocument(current_index) && isBrokenDocument(currentDocumentProxy))
+        if (docModel->isDocument(current_index))
         {
-            showBrokenDocumentWarning();
+            currentDocumentProxy = docModel->proxyData(current_index);
+            const auto converter{UBDocumentVersionConverter{currentDocumentProxy}};
+            const auto result = converter.convert();
+
+            if (result == UBDocumentVersionConverter::DENIED || result == UBDocumentVersionConverter::FAILED)
+            {
+                // deferred selection of previous entry to avoid double triggering of selection change
+                QTimer::singleShot(0, [this, previous](){
+                    mDocumentUI->documentTreeView->selectionModel()->select(previous, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+                });
+                return;
+            }
+
+            if (isBrokenDocument(currentDocumentProxy))
+            {
+                showBrokenDocumentWarning();
+            }
         }
+
         setDocument(currentDocumentProxy, false);
     }
     //N/C - NNE  - 20140414 : END
@@ -2179,7 +2213,7 @@ void UBDocumentController::TreeViewSelectionChanged(const QItemSelection &select
         }
         else
         {
-            TreeViewSelectionChanged(selected.indexes().at(0), QModelIndex());
+            TreeViewSelectionChanged(selected.indexes().at(0), deselected.indexes().empty() ? QModelIndex() : deselected.indexes().at(0));
         }
     }
 }
@@ -3494,15 +3528,9 @@ bool UBDocumentController::isOKToOpenDocument(std::shared_ptr<UBDocumentProxy> p
     }
     else
     {
-        if (UBApplication::mainWindow->yesNoQuestion(tr("Open Document"),
-                                                     tr("The document '%1' has been generated with a newer version of OpenBoard (%2). By opening it, you may lose some information. Do you want to proceed?").arg(proxy->name(), docVersion)))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        const auto converter{UBDocumentVersionConverter{proxy}};
+        const auto result = converter.convert();
+        return result == UBDocumentVersionConverter::CONVERTED || result == UBDocumentVersionConverter::SKIPPED;
     }
 }
 

--- a/src/document/UBDocumentProxy.cpp
+++ b/src/document/UBDocumentProxy.cpp
@@ -129,7 +129,9 @@ int UBDocumentProxy::pageCount()
 
 bool UBDocumentProxy::isBroken() const
 {
-    return mPageCount <= 0;
+    const auto documentVersion = QVersionNumber::fromString(metaData(UBSettings::documentVersion).toString());
+
+    return mPageCount <= 0 && documentVersion <= QVersionNumber::fromString(UBSettings::currentFileVersion);
 }
 
 

--- a/src/document/UBDocumentProxy.h
+++ b/src/document/UBDocumentProxy.h
@@ -39,6 +39,7 @@ class UBGraphicsScene;
 class UBDocumentProxy
 {
     friend class UBPersistenceManager;
+    friend class UBDocumentVersionConverter;
 
     public:
 

--- a/src/document/UBDocumentToc.cpp
+++ b/src/document/UBDocumentToc.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2015-2025 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "UBDocumentToc.h"
+
+#include <QUuid>
+
+#include "document/UBTocSerializer.h"
+
+static const QString UUID{"uuid"};
+static const QString PAGE_ID{"id"};
+static const QString ASSETS("assets");
+
+UBDocumentToc::UBDocumentToc(const QString& documentPath)
+    : mDocumentPath{documentPath}
+{
+}
+
+UBDocumentToc::UBDocumentToc(const UBDocumentToc& other, const QString& documentPath)
+    : mDocumentPath{documentPath}
+    , mVersion{other.mVersion}
+    , mToc{other.mToc}
+{
+}
+
+QVersionNumber UBDocumentToc::version() const
+{
+    return mVersion;
+}
+
+int UBDocumentToc::pageCount() const
+{
+    return mToc.count();
+}
+
+int UBDocumentToc::insert(int index)
+{
+    if (index >= 0 && index <= mToc.count())
+    {
+        int pageId = nextAvailablePageId();
+        mToc.insert(index, {{PAGE_ID, pageId}});
+        mModified = true;
+        return pageId;
+    }
+
+    return -1;
+}
+
+void UBDocumentToc::move(int fromIndex, int toIndex)
+{
+    if (fromIndex < 0 || fromIndex >= mToc.count() || toIndex < 0 || toIndex >= mToc.count())
+    {
+        return;
+    }
+
+    auto entry = mToc.at(fromIndex);
+    mToc.removeAt(fromIndex);
+    mToc.insert(toIndex, entry);
+    mModified = true;
+}
+
+void UBDocumentToc::remove(int index)
+{
+    if (index >= 0 && index < mToc.count())
+    {
+        mToc.remove(index);
+        mModified = true;
+    }
+}
+
+QUuid UBDocumentToc::uuid(int index) const
+{
+    if (index < 0 || index >= mToc.count())
+    {
+        return {};
+    }
+
+    return mToc.at(index).value(UUID).toUuid();
+}
+
+void UBDocumentToc::setUuid(int index, const QUuid& uuid)
+{
+    if (index < 0)
+    {
+        return;
+    }
+
+    assureSize(index);
+    mToc[index][UUID] = uuid;
+    mModified = true;
+}
+
+int UBDocumentToc::findUuid(const QUuid& sceneUuid) const
+{
+    for (int i = 0; i < mToc.size(); ++i)
+    {
+        if (uuid(i) == sceneUuid)
+        {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+int UBDocumentToc::pageId(int index) const
+{
+    if (index < 0 || index >= mToc.count())
+    {
+        return -1;
+    }
+
+    return mToc.at(index).value(PAGE_ID).toInt();
+}
+
+void UBDocumentToc::setPageId(int index, int pageId)
+{
+    if (index < 0)
+    {
+        return;
+    }
+
+    assureSize(index);
+    mToc[index][PAGE_ID] = pageId;
+    mModified = true;
+}
+
+QStringList UBDocumentToc::assets(int index) const
+{
+    if (index < 0 || index >= mToc.count())
+    {
+        return {};
+    }
+
+    return mToc.at(index).value(ASSETS).toStringList();
+}
+
+void UBDocumentToc::setAssets(int index, const QStringList& assets)
+{
+    if (index < 0)
+    {
+        return;
+    }
+
+    assureSize(index);
+    mToc[index][ASSETS] = assets;
+    mModified = true;
+}
+
+void UBDocumentToc::unsetAssets(int index)
+{
+    mToc[index].remove(ASSETS);
+}
+
+bool UBDocumentToc::hasAssetsEntry(int index) const
+{
+    if (index < 0 || index >= mToc.count())
+    {
+        return false;
+    }
+
+    return mToc.at(index).contains(ASSETS);
+}
+
+bool UBDocumentToc::load()
+{
+    UBTocJsonSerializer serializer(mDocumentPath);
+    const auto ok = serializer.load(mVersion, mToc);
+
+    for (const auto& entry : mToc)
+    {
+        mNextAvailablePageId = std::max(mNextAvailablePageId, entry[PAGE_ID].toInt() + 1);
+    }
+
+    mModified = false;
+    return ok;
+}
+
+void UBDocumentToc::save()
+{
+    if (mModified)
+    {
+        UBTocJsonSerializer serializer(mDocumentPath);
+        serializer.save(mVersion, mToc);
+        mModified = false;
+    }
+}
+
+int UBDocumentToc::nextAvailablePageId()
+{
+    return mNextAvailablePageId++;
+}
+
+void UBDocumentToc::assureSize(int index)
+{
+    if (index >= mToc.count())
+    {
+        mToc.resize(index + 1);
+    }
+}

--- a/src/document/UBDocumentToc.h
+++ b/src/document/UBDocumentToc.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015-2025 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <QString>
+#include <QVariant>
+#include <QVector>
+#include <QVersionNumber>
+
+
+static const QVersionNumber DOCUMENT_TOC_VERSION{1, 0};
+
+class UBDocumentToc
+{
+public:
+    UBDocumentToc(const QString& documentPath);
+    UBDocumentToc(const UBDocumentToc& other, const QString& documentPath);
+
+    QVersionNumber version() const;
+
+    // size
+    int pageCount() const;
+
+    // insert, move and remove
+    int insert(int index);
+    void move(int fromIndex, int toIndex);
+    void remove(int index);
+
+    // access values
+    QUuid uuid(int index) const;
+    void setUuid(int index, const QUuid& uuid);
+    int findUuid(const QUuid& sceneUuid) const;
+
+    int pageId(int index) const;
+    void setPageId(int index, int pageId);
+
+    QStringList assets(int index) const;
+    void setAssets(int index, const QStringList& assets);
+    void unsetAssets(int index);
+    bool hasAssetsEntry(int index) const;
+
+    // load and save
+    bool load();
+    void save();
+
+    // next available pageId
+    int nextAvailablePageId();
+
+private:
+    void assureSize(int index);
+
+private:
+    const QString mDocumentPath;
+    QVersionNumber mVersion{DOCUMENT_TOC_VERSION};
+    QVector<QVariantMap> mToc;
+    int mNextAvailablePageId{0};
+    bool mModified{false};
+};

--- a/src/document/UBDocumentVersionConverter.cpp
+++ b/src/document/UBDocumentVersionConverter.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2015-2026 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "UBDocumentVersionConverter.h"
+
+#include "adaptors/UBMetadataDcSubsetAdaptor.h"
+
+#include "core/UBApplication.h"
+#include "core/UBPersistenceManager.h"
+#include "core/UBSettings.h"
+
+#include "document/UBDocumentProxy.h"
+#include "document/UBDocumentToc.h"
+
+#include "gui/UBMainWindow.h"
+
+#include <QDebug>
+#include <QHash>
+#include <QStack>
+#include <QVersionNumber>
+
+
+constexpr int TMP_ID{99999};
+
+UBDocumentVersionConverter::UBDocumentVersionConverter(std::shared_ptr<UBDocumentProxy> proxy)
+    : mProxy(proxy)
+{
+
+}
+
+UBDocumentVersionConverter::ConversionResult UBDocumentVersionConverter::convert() const
+{
+    // check validity of proxy
+    if (!mProxy)
+    {
+        return SKIPPED;
+    }
+
+    // check document version
+    QVersionNumber documentVersion = QVersionNumber::fromString(mProxy->metaData(UBSettings::documentVersion).toString());
+
+    if (documentVersion < QVersionNumber{4, 9, 0})
+    {
+        // no conversion necessary
+        return SKIPPED;
+    }
+
+    // ask user
+    const auto accept = UBApplication::mainWindow->yesNoQuestion(
+                tr("This document was created using OpenBoard 1.8"),
+                tr("This document was created using OpenBoard 1.8, and its content has been reorganized. "
+                   "We strongly recommend updating OpenBoard to version 1.8.\n\n"
+                   "If you wish to continue, the document will be converted "
+                   "to be compatible with version 1.7.7. This may take a few minutes. "
+                   "You will still be able to open it in OpenBoard 1.8, "
+                   "but it will then be converted again to the 1.8 format.\n\n"
+                   "Do you want to continue?"));
+
+    if (!accept)
+    {
+        return DENIED;
+    }
+
+    // load the TOC
+    UBDocumentToc toc{mProxy->persistencePath()};
+
+    if (!toc.load())
+    {
+        qDebug() << "unable to load TOC from" << mProxy->persistencePath();
+        return FAILED;
+    }
+
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+
+    reorderPages(toc);
+    copyAssets(toc);
+
+    // update document version in metadata
+    mProxy->setMetaData(UBSettings::documentVersion, UBSettings::currentFileVersion);
+    UBMetadataDcSubsetAdaptor::persist(mProxy);
+
+    // adjust page count
+    mProxy->setPageCount(toc.pageCount());
+
+    // delete the TOC
+    QFile::remove(mProxy->persistencePath() + "/toc.json");
+
+    QApplication::restoreOverrideCursor();
+
+    return CONVERTED;
+}
+
+void UBDocumentVersionConverter::reorderPages(UBDocumentToc& toc) const
+{
+    // create a map for fast reverse lookup
+    QHash<int, int> indexById;
+
+    for (int index = 0; index < toc.pageCount(); ++index)
+    {
+        indexById[toc.pageId(index)] = index;
+    }
+
+    auto persistenceManager = UBPersistenceManager::persistenceManager();
+
+    for (int index = 0; index < toc.pageCount(); ++index)
+    {
+        if (toc.pageId(index) == index)
+        {
+            // page id is already matching the index
+            continue;
+        }
+
+        // build a stack of rename operations until we find a free name or a loop
+        QStack<int> indexStack;
+        int currentIndex = index;
+
+        do
+        {
+            indexStack.push(currentIndex);
+
+            if (!indexById.contains(currentIndex))
+            {
+                break;
+            }
+
+            currentIndex = indexById[currentIndex];
+        } while (currentIndex != index);
+
+        // if we found a loop, move the first page out of the way
+        if (currentIndex == index)
+        {
+            persistenceManager->renamePage(mProxy, toc.pageId(index), TMP_ID);
+            toc.setPageId(index, TMP_ID);
+        }
+
+        // now process the stack
+        while (!indexStack.empty())
+        {
+            const auto ix = indexStack.pop();
+
+            // rename toc.pageId(ix) to ix
+            persistenceManager->renamePage(mProxy, toc.pageId(ix), ix);
+            toc.setPageId(ix, ix);
+        }
+    }
+}
+
+void UBDocumentVersionConverter::copyAssets(const UBDocumentToc& toc) const
+{
+    // find the scenes with images and copy the asset files
+    const auto prefix = UBPersistenceManager::imageDirectory + "/";
+
+    for (int index = 0; index < toc.pageCount(); ++index)
+    {
+        const auto images = toc.assets(index).filter(prefix);
+
+        if (!images.empty())
+        {
+            // load scene and find image items
+            const auto scene = UBPersistenceManager::persistenceManager()->loadDocumentScene(mProxy, index, false);
+            const auto items = scene->items();
+
+            for (const auto item : items)
+            {
+                if (item->type() == UBGraphicsItemType::SvgItemType || item->type() == UBGraphicsItemType::PixmapItemType)
+                {
+                    const auto ubitem = dynamic_cast<UBItem*>(item);
+
+                    if (ubitem)
+                    {
+                        const auto itemUuid = ubitem->uuid();
+
+                        // now copy the asset file
+                        const auto asset = ubitem->sourceUrl().toLocalFile();
+                        const auto documentPath = mProxy->persistencePath() + "/";
+
+                        auto copiedAsset = asset;
+                        const auto itemUuidString = itemUuid.toString();
+                        copiedAsset.replace(prefix.size(), itemUuidString.size(), itemUuidString);
+
+                        QFile::copy(documentPath + asset, documentPath + copiedAsset);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/document/UBDocumentVersionConverter.h
+++ b/src/document/UBDocumentVersionConverter.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015-2026 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+
+#include <QObject>
+
+
+// forward
+class UBDocumentProxy;
+class UBDocumentToc;
+
+
+class UBDocumentVersionConverter : public QObject
+{
+    Q_OBJECT
+
+public:
+    UBDocumentVersionConverter(std::shared_ptr<UBDocumentProxy> proxy);
+
+    enum ConversionResult {
+        DENIED,    // user aborted conversion
+        CONVERTED,  // document successfully converted
+        FAILED,     // conversion failed
+        SKIPPED     // document already in requiert format
+    };
+
+    ConversionResult convert() const;
+
+private:
+    void reorderPages(UBDocumentToc& toc) const;
+    void copyAssets(const UBDocumentToc& toc) const;
+
+private:
+    std::shared_ptr<UBDocumentProxy> mProxy;
+};
+

--- a/src/document/UBTocSerializer.cpp
+++ b/src/document/UBTocSerializer.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015-2025 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "UBTocSerializer.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+static const QString VERSION{"version"};
+static const QString PAGES("pages");
+
+UBTocSerializer::UBTocSerializer(QString path)
+    : mPath{path}
+{
+}
+
+UBTocJsonSerializer::UBTocJsonSerializer(QString filename)
+    : UBTocSerializer{filename}
+{
+}
+
+bool UBTocJsonSerializer::load(QVersionNumber& version, QVector<QVariantMap>& toc)
+{
+    if (!toc.isEmpty())
+    {
+        qWarning() << "Refused to load non-empty TOC";
+        return false;
+    }
+
+    QFile file{mPath + "/toc.json"};
+
+    if (!file.open(QFile::ReadOnly))
+    {
+        qDebug() << "Cannot load TOC: Cannot open file" << file.fileName();
+        return false;
+    }
+
+    const auto json = file.readAll();
+    file.close();
+    QJsonParseError error;
+    const auto jsonDoc = QJsonDocument::fromJson(json, &error);
+
+    if (error.error != QJsonParseError::NoError)
+    {
+        qWarning() << "Parse error reading TOC:" << error.errorString() << "at" << error.offset;
+        return false;
+    }
+
+    if (!jsonDoc.isObject())
+    {
+        qWarning() << "Error reading TOC: JSON document is not an object";
+        return false;
+    }
+
+    version = QVersionNumber::fromString(jsonDoc.object().value(VERSION).toString());
+
+    const auto pages = jsonDoc.object().value(PAGES);
+
+    if (!pages.isArray())
+    {
+        qWarning() << "Error reading TOC: pages is not an array";
+        return false;
+    }
+
+    int index = 0;
+
+    toc.resize(pages.toArray().size());
+
+    for (const auto entry : pages.toArray())
+    {
+        if (!entry.isObject())
+        {
+            qWarning() << "Error reading TOC: JSON entry is not an object";
+            return false;
+        }
+
+        toc[index++] = entry.toObject().toVariantMap();
+    }
+
+    return true;
+}
+
+bool UBTocJsonSerializer::save(const QVersionNumber& version, const QVector<QVariantMap>& toc)
+{
+    QJsonArray list;
+
+    for (const auto entry : toc)
+    {
+        list.append(QJsonObject::fromVariantMap(entry));
+    }
+
+    QJsonObject document;
+    document[VERSION] = version.toString();
+    document[PAGES] = list;
+
+    QJsonDocument doc{document};
+    auto json = doc.toJson(QJsonDocument::Indented);
+
+    // reduce indentation to one space
+    json.replace("    ", " ");
+
+    QFile file{mPath + "/toc.json"};
+
+    if (!file.open(QFile::WriteOnly))
+    {
+        qWarning() << "Cannot save TOC: Cannot open file" << file.fileName();
+        return false;
+    }
+
+    file.write(json);
+    file.close();
+    return true;
+}

--- a/src/document/UBTocSerializer.h
+++ b/src/document/UBTocSerializer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015-2025 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <QString>
+#include <QVariantMap>
+#include <QVector>
+#include <QVersionNumber>
+
+
+class UBTocSerializer
+{
+public:
+    UBTocSerializer(QString path);
+    virtual ~UBTocSerializer() = default;
+
+    virtual bool load(QVersionNumber& version, QVector<QVariantMap>& toc) = 0;
+    virtual bool save(const QVersionNumber& version, const QVector<QVariantMap>& toc) = 0;
+
+protected:
+    QString mPath;
+};
+
+
+class UBTocJsonSerializer : public UBTocSerializer
+{
+public:
+    UBTocJsonSerializer(QString filename);
+    virtual ~UBTocJsonSerializer() = default;
+
+    virtual bool load(QVersionNumber& version, QVector<QVariantMap>& toc) override;
+    virtual bool save(const QVersionNumber& version, const QVector<QVariantMap>& toc) override;
+};

--- a/src/document/document.pri
+++ b/src/document/document.pri
@@ -3,11 +3,16 @@ HEADERS += \
     src/document/UBDocumentContainer.h \
     src/document/UBDocumentController.h \
     src/document/UBDocumentProxy.h \
-    src/document/UBSortFilterProxyModel.h
+    src/document/UBDocumentToc.h \
+    src/document/UBDocumentVersionConverter.h \
+    src/document/UBSortFilterProxyModel.h \
+    src/document/UBTocSerializer.h
 SOURCES += \
     src/document/UBDocument.cpp \
     src/document/UBDocumentContainer.cpp \
     src/document/UBDocumentController.cpp \
     src/document/UBDocumentProxy.cpp \
-    src/document/UBSortFilterProxyModel.cpp
-
+    src/document/UBDocumentToc.cpp \
+    src/document/UBDocumentVersionConverter.cpp \
+    src/document/UBSortFilterProxyModel.cpp \
+    src/document/UBTocSerializer.cpp


### PR DESCRIPTION
This PR adds a converter to read documents from OB 1.8.0 and convert it to the 1.7.x format.

- add `UBDocummentVersionConverter`
- add `UBDocumentToc` and `UBTocSerializer` from 1.8.0
- invoke converter when selecting a document
- show warning icon for 1.8.0 documents in document tree view

The PR tries to make only the minimal necessary changes to the existing source code to avoid any regression.