### PR TITLE
fix: enable Cookie storage

### DIFF
--- a/src/web/UBWebController.cpp
+++ b/src/web/UBWebController.cpp
@@ -95,7 +95,7 @@ UBWebController::UBWebController(UBMainWindow* mainWindow)
     }
     else
     {
-        mWebProfile = QWebEngineProfile::defaultProfile();
+        mWebProfile = new QWebEngineProfile("Default");
         mWebProfile->setHttpCacheType(QWebEngineProfile::DiskHttpCache);
     }
 


### PR DESCRIPTION
- default WebEngine profile is private browsing since Qt 6
- use a named profile to enable cookie storage as with Qt 5
- name it Default, so that it actually uses the same location

Fixes #1437

This PR is also relevant for `dev`.