### PR TITLE
fix: Recreate source widget when starting the recording

### DIFF
--- a/src/podcast/UBPodcastController.cpp
+++ b/src/podcast/UBPodcastController.cpp
@@ -316,6 +316,8 @@ void UBPodcastController::start()
 
         mVideoFrameSizeAtStart = QSize(width, height);
 
+        mSourceWidget = nullptr;
+
         applicationMainModeChanged(UBApplication::applicationController->displayMode());
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Reusing the same source widget when the video size has changed leads to incorrect transformations, a distorted video and leaves artifacts. Instead reset the widget to force a recalculation of the viewport transformation and other necessary updates.

A more targeted approach might be possible, but likely complex and without much benefit. Some attempts have been made and were unsuccessful.

Fixes #1381 #1231