### PR TITLE
fix: rotate flipped item in group

### DIFF
--- a/src/domain/UBSelectionFrame.cpp
+++ b/src/domain/UBSelectionFrame.cpp
@@ -260,8 +260,9 @@ void UBSelectionFrame::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
             qreal cntrX = nextRotCenter.x();
             qreal cntrY = nextRotCenter.y();
 
+            const auto flipped = ownTransform.m11() * ownTransform.m22() < 0;
             ownTransform.translate(cntrX, cntrY);
-            ownTransform.rotate(-dAngle);
+            ownTransform.rotate(flipped ? dAngle : -dAngle);
             ownTransform.translate(-cntrX, -cntrY);
 
             item->update();


### PR DESCRIPTION
- flipped items in a selection group rotated in the wrong direction
- determine whether an item is flipped
- choose the rotation direction accordingly

Fixes #1460