### PR TITLE
chore: default to Qt6 and C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.16)
 #       Typically set to /usr or /opt
 #   QT_VERSION
 #       Qt Version to use
-#       Set to empty, 5 or 6, defaults to auto-selection with preference to 5
+#       Set to empty, 5 or 6, defaults to auto-selection with preference to 6
 #
 # Typical invocation
 #   cmake -S <srcdir> -B <builddir> -DCMAKE_INSTALL_PREFIX:PATH=/usr
@@ -81,7 +81,7 @@ set(OPENBOARD_MIMEICON_FILE resources/linux/ch.openboard.application-ubz.svg)
 # Basic compiler settings
 # ==========================================================================
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to use - defaults to C++17")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to use - defaults to C++20")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)

--- a/cmake/DependencyQt.cmake
+++ b/cmake/DependencyQt.cmake
@@ -14,7 +14,7 @@ set(QT_COMPONENTS
 )
 
 if(QT_VERSION STREQUAL "")
-    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+    find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
     set(QT_VERSION ${QT_VERSION_MAJOR})
 endif()
 


### PR DESCRIPTION
The defaults used by the CMake build files are outdated. Update them to reasonable defaults.

- prefer Qt6 if both Qt5 and Qt6 are detected
- use C++20 by default