### PR TITLE
Add preference to disable automatic pen/eraser switching

### DIFF
--- a/resources/forms/preferences.ui
+++ b/resources/forms/preferences.ui
@@ -951,7 +951,7 @@
        <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="autoSwitchToEraserCheckBox">
          <property name="text">
-          <string>Automatically switch to eraser when tablet eraser is detected</string>
+          <string>Ignore broken eraser detection for tablets</string>
          </property>
         </widget>
        </item>

--- a/resources/forms/preferences.ui
+++ b/resources/forms/preferences.ui
@@ -948,6 +948,13 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="autoSwitchToEraserCheckBox">
+         <property name="text">
+          <string>Automatically switch to eraser when tablet eraser is detected</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="markerTab">

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -350,13 +350,13 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)dc->stylusTool ();
 
     if (event->type () == QEvent::TabletPress || event->type () == QEvent::TabletEnterProximity) {
-        const bool autoSwitch = UBSettings::settings()->boardAutoSwitchToEraser->get().toBool();
+        const bool ignoreBrokenEraser = UBSettings::settings()->boardIgnoreBrokenEraserDetection->get().toBool();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         if (event->pointerType () == QPointingDevice::PointerType::Eraser) {
 #else
         if (event->pointerType () == QTabletEvent::Eraser) {
 #endif
-            if (autoSwitch) {
+            if (!ignoreBrokenEraser) {
                 dc->setStylusTool (UBStylusTool::Eraser);
                 mUsingTabletEraser = true;
             }

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -350,13 +350,16 @@ void UBBoardView::tabletEvent (QTabletEvent * event)
     UBStylusTool::Enum currentTool = (UBStylusTool::Enum)dc->stylusTool ();
 
     if (event->type () == QEvent::TabletPress || event->type () == QEvent::TabletEnterProximity) {
+        const bool autoSwitch = UBSettings::settings()->boardAutoSwitchToEraser->get().toBool();
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         if (event->pointerType () == QPointingDevice::PointerType::Eraser) {
 #else
         if (event->pointerType () == QTabletEvent::Eraser) {
 #endif
-            dc->setStylusTool (UBStylusTool::Eraser);
-            mUsingTabletEraser = true;
+            if (autoSwitch) {
+                dc->setStylusTool (UBStylusTool::Eraser);
+                mUsingTabletEraser = true;
+            }
         }
         else {
             if (mUsingTabletEraser && currentTool == UBStylusTool::Eraser)

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -271,6 +271,8 @@ void UBPreferencesController::wire()
     connect(mPenProperties->circleCheckBox, SIGNAL(clicked(bool)), settings, SLOT(setPenPreviewCircle(bool)));
     connect(mPenProperties->circleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(penPreviewFromSizeChanged(int)));
 
+    connect(mPreferencesUI->autoSwitchToEraserCheckBox, SIGNAL(clicked(bool)), settings->boardAutoSwitchToEraser, SLOT(setBool(bool)));
+
     // marker
     QList<QColor> markerLightBackgroundColors = settings->boardMarkerLightBackgroundColors->colors();
     QList<QColor> markerDarkBackgroundColors = settings->boardMarkerDarkBackgroundColors->colors();
@@ -342,6 +344,7 @@ void UBPreferencesController::init()
     mPenProperties->pressureSensitiveCheckBox->setChecked(settings->boardPenPressureSensitive->get().toBool());
     mPenProperties->circleCheckBox->setChecked(settings->showPenPreviewCircle->get().toBool());
     mPenProperties->circleSpinBox->setValue(settings->penPreviewFromSize->get().toInt());
+    mPreferencesUI->autoSwitchToEraserCheckBox->setChecked(settings->boardAutoSwitchToEraser->get().toBool());
 
     // marker tab
     mMarkerProperties->fineSlider->setValue(settings->boardMarkerFineWidth->get().toDouble() * sSliderRatio);

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -271,7 +271,7 @@ void UBPreferencesController::wire()
     connect(mPenProperties->circleCheckBox, SIGNAL(clicked(bool)), settings, SLOT(setPenPreviewCircle(bool)));
     connect(mPenProperties->circleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(penPreviewFromSizeChanged(int)));
 
-    connect(mPreferencesUI->autoSwitchToEraserCheckBox, SIGNAL(clicked(bool)), settings->boardAutoSwitchToEraser, SLOT(setBool(bool)));
+    connect(mPreferencesUI->autoSwitchToEraserCheckBox, SIGNAL(clicked(bool)), settings->boardIgnoreBrokenEraserDetection, SLOT(setBool(bool)));
 
     // marker
     QList<QColor> markerLightBackgroundColors = settings->boardMarkerLightBackgroundColors->colors();
@@ -344,7 +344,7 @@ void UBPreferencesController::init()
     mPenProperties->pressureSensitiveCheckBox->setChecked(settings->boardPenPressureSensitive->get().toBool());
     mPenProperties->circleCheckBox->setChecked(settings->showPenPreviewCircle->get().toBool());
     mPenProperties->circleSpinBox->setValue(settings->penPreviewFromSize->get().toInt());
-    mPreferencesUI->autoSwitchToEraserCheckBox->setChecked(settings->boardAutoSwitchToEraser->get().toBool());
+    mPreferencesUI->autoSwitchToEraserCheckBox->setChecked(settings->boardIgnoreBrokenEraserDetection->get().toBool());
 
     // marker tab
     mMarkerProperties->fineSlider->setValue(settings->boardMarkerFineWidth->get().toDouble() * sSliderRatio);

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -285,7 +285,7 @@ void UBSettings::init()
     boardMarkerPressureSensitive = new UBSetting(this, "Board", "MarkerPressureSensitive", false);
 
     boardUseHighResTabletEvent = new UBSetting(this, "Board", "UseHighResTabletEvent", true);
-    boardAutoSwitchToEraser = new UBSetting(this, "Board", "AutoSwitchToEraser", true);
+    boardIgnoreBrokenEraserDetection = new UBSetting(this, "Board", "IgnoreBrokenEraserDetection", false);
 
     boardInterpolatePenStrokes = new UBSetting(this, "Board", "InterpolatePenStrokes", true);
     boardSimplifyPenStrokes = new UBSetting(this, "Board", "SimplifyPenStrokes", true);

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -285,6 +285,7 @@ void UBSettings::init()
     boardMarkerPressureSensitive = new UBSetting(this, "Board", "MarkerPressureSensitive", false);
 
     boardUseHighResTabletEvent = new UBSetting(this, "Board", "UseHighResTabletEvent", true);
+    boardAutoSwitchToEraser = new UBSetting(this, "Board", "AutoSwitchToEraser", true);
 
     boardInterpolatePenStrokes = new UBSetting(this, "Board", "InterpolatePenStrokes", true);
     boardSimplifyPenStrokes = new UBSetting(this, "Board", "SimplifyPenStrokes", true);

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -287,6 +287,7 @@ class UBSettings : public QObject
         UBSetting* boardMarkerPressureSensitive;
 
         UBSetting* boardUseHighResTabletEvent;
+        UBSetting* boardAutoSwitchToEraser;
 
         UBSetting* boardInterpolatePenStrokes;
         UBSetting* boardSimplifyPenStrokes;

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -287,7 +287,7 @@ class UBSettings : public QObject
         UBSetting* boardMarkerPressureSensitive;
 
         UBSetting* boardUseHighResTabletEvent;
-        UBSetting* boardAutoSwitchToEraser;
+        UBSetting* boardIgnoreBrokenEraserDetection;
 
         UBSetting* boardInterpolatePenStrokes;
         UBSetting* boardSimplifyPenStrokes;


### PR DESCRIPTION
Fixes the annoyance where Openboard auto-switches to the eraser tool when a tablet device (like the Promethean Activ Panel) detects the eraser pointer type. There is now a checkbox in the Pen preferences tab to turn this off. Defaults to on so nothing changes for existing users.

Closes #1432