### PR TITLE
Fix GCC warnings about incomplete classes

### DIFF
--- a/src/adaptors/UBExportDocumentSetAdaptor.cpp
+++ b/src/adaptors/UBExportDocumentSetAdaptor.cpp
@@ -25,21 +25,9 @@
  */
 
 
+
+
 #include "UBExportDocumentSetAdaptor.h"
-#include "UBExportDocument.h"
-
-#include "adaptors/UBPageMapper.h"
-
-#include "frameworks/UBPlatformUtils.h"
-
-#include "core/UBDocumentManager.h"
-#include "core/UBApplication.h"
-
-#include "document/UBDocumentProxy.h"
-#include "document/UBDocumentController.h"
-#include "document/UBDocumentToc.h"
-
-#include "core/UBPersistenceManager.h"
 
 #ifdef Q_OS_OSX
     #include <quazip.h>
@@ -49,7 +37,21 @@
     #include "quazipfile.h"
 #endif
 
+#include "adaptors/UBPageMapper.h"
+
 #include "core/memcheck.h"
+#include "core/UBApplication.h"
+#include "core/UBDocumentManager.h"
+#include "core/UBPersistenceManager.h"
+#include "core/UBSettings.h"
+
+#include "document/UBDocumentProxy.h"
+#include "document/UBDocumentController.h"
+#include "document/UBDocumentToc.h"
+
+#include "frameworks/UBPlatformUtils.h"
+
+#include "UBExportDocument.h"
 
 UBExportDocumentSetAdaptor::UBExportDocumentSetAdaptor(QObject *parent)
     : UBExportAdaptor(parent)

--- a/src/adaptors/UBSvgSubsetAdaptor.cpp
+++ b/src/adaptors/UBSvgSubsetAdaptor.cpp
@@ -49,6 +49,7 @@
 #include "domain/UBGraphicsStrokesGroup.h"
 #include "domain/UBGraphicsGroupContainerItem.h"
 #include "domain/UBGraphicsGroupContainerItemDelegate.h"
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBItem.h"
 
 #include "gui/UBBackgroundRuling.h"

--- a/src/adaptors/UBWidgetUpgradeAdaptor.cpp
+++ b/src/adaptors/UBWidgetUpgradeAdaptor.cpp
@@ -25,16 +25,20 @@
  */
 
 
-#include "UBWidgetUpgradeAdaptor.h"
 
-#include "core/UBPersistenceManager.h"
-#include "document/UBDocumentProxy.h"
-#include "frameworks/UBPlatformUtils.h"
+
+#include "UBWidgetUpgradeAdaptor.h"
 
 #include <QCryptographicHash>
 #include <QDomDocument>
 
 #include "core/memcheck.h"
+#include "core/UBPersistenceManager.h"
+#include "core/UBSettings.h"
+
+#include "document/UBDocumentProxy.h"
+
+#include "frameworks/UBPlatformUtils.h"
 
 UBWidgetUpgradeAdaptor::UBWidgetUpgradeAdaptor()
 {

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -59,6 +59,7 @@
 #include "document/UBDocumentProxy.h"
 
 #include "domain/UBGraphicsGroupContainerItem.h"
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBGraphicsItemUndoCommand.h"
 #include "domain/UBGraphicsMediaItem.h"
 #include "domain/UBGraphicsPDFItem.h"

--- a/src/board/UBBoardController.h
+++ b/src/board/UBBoardController.h
@@ -39,13 +39,18 @@
 
 #include "core/UB.h"
 #include "core/UBApplicationController.h"
+
 #include "document/UBDocumentContainer.h"
+
+#include "domain/UBGraphicsMediaItem.h"
+
+#include "gui/UBBackgroundRuling.h"
+#include "gui/UBToolWidget.h"
 
 class UBMainWindow;
 class UBApplication;
 class UBBoardView;
 
-class UBBackgroundRuling;
 class UBBackgroundManager;
 class UBDocument;
 class UBDocumentController;
@@ -54,11 +59,9 @@ class UBGraphicsScene;
 class UBDocumentProxy;
 class UBEmbedController;
 class UBBlackoutWidget;
-class UBToolWidget;
 class UBVersion;
 class UBSoftwareUpdate;
 class UBSoftwareUpdateDialog;
-class UBGraphicsMediaItem;
 class UBGraphicsWidgetItem;
 class UBBoardPaletteManager;
 class UBItem;

--- a/src/board/UBBoardView.cpp
+++ b/src/board/UBBoardView.cpp
@@ -69,7 +69,7 @@
 #include "domain/UBGraphicsWidgetItem.h"
 #include "domain/UBGraphicsPDFItem.h"
 #include "domain/UBGraphicsPolygonItem.h"
-#include "domain/UBItem.h"
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBGraphicsMediaItem.h"
 #include "domain/UBGraphicsSvgItem.h"
 #include "domain/UBGraphicsGroupContainerItem.h"

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -5,6 +5,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBGraphicsGroupContainerItem.h
     UBGraphicsGroupContainerItemDelegate.cpp
     UBGraphicsGroupContainerItemDelegate.h
+    UBGraphicsItem.cpp
+    UBGraphicsItem.h
     UBGraphicsItemDelegate.cpp
     UBGraphicsItemDelegate.h
     UBGraphicsItemGroupUndoCommand.cpp

--- a/src/domain/UBGraphicsDelegateFrame.cpp
+++ b/src/domain/UBGraphicsDelegateFrame.cpp
@@ -38,6 +38,7 @@
 #include "board/UBBoardController.h"
 #include "board/UBBoardView.h"
 
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBGraphicsItemDelegate.h"
 #include "domain/UBGraphicsScene.h"
 #include "domain/UBResizableGraphicsItem.h"

--- a/src/domain/UBGraphicsGroupContainerItem.cpp
+++ b/src/domain/UBGraphicsGroupContainerItem.cpp
@@ -31,13 +31,15 @@
 
 #include <QtGui>
 
-#include "UBGraphicsMediaItem.h"
-#include "UBGraphicsTextItem.h"
+#include "core/memcheck.h"
+#include "core/UB.h"
+
 #include "domain/UBGraphicsItemDelegate.h"
 #include "domain/UBGraphicsGroupContainerItemDelegate.h"
 #include "domain/UBGraphicsScene.h"
 
-#include "core/memcheck.h"
+#include "UBGraphicsMediaItem.h"
+#include "UBGraphicsTextItem.h"
 
 UBGraphicsGroupContainerItem::UBGraphicsGroupContainerItem(QGraphicsItem *parent)
     : QGraphicsItem(parent)

--- a/src/domain/UBGraphicsGroupContainerItem.h
+++ b/src/domain/UBGraphicsGroupContainerItem.h
@@ -40,6 +40,7 @@
 
 #include "core/UB.h"
 
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBItem.h"
 
 #include "frameworks/UBCoreGraphicsScene.h"

--- a/src/domain/UBGraphicsGroupContainerItem.h
+++ b/src/domain/UBGraphicsGroupContainerItem.h
@@ -31,8 +31,17 @@
 #define UBGRAPHICSGROUPCONTAINERITEM_H
 
 #include <QGraphicsItem>
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include <QRectF>
+#include <QStyleOptionGraphicsItem>
+#include <QWidget>
+#include <QVariant>
+
+#include "core/UB.h"
 
 #include "domain/UBItem.h"
+
 #include "frameworks/UBCoreGraphicsScene.h"
 
 class UBGraphicsGroupContainerItem : public QGraphicsItem, public UBItem, public UBGraphicsItem

--- a/src/domain/UBGraphicsItem.cpp
+++ b/src/domain/UBGraphicsItem.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2015-2022 Département de l'Instruction Publique (DIP-SEM)
+ *
+ * Copyright (C) 2013 Open Education Foundation
+ *
+ * Copyright (C) 2010-2013 Groupement d'Intérêt Public pour
+ * l'Education Numérique en Afrique (GIP ENA)
+ *
+ * This file is part of OpenBoard.
+ *
+ * OpenBoard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License,
+ * with a specific linking exception for the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the
+ * same license as the "OpenSSL" library).
+ *
+ * OpenBoard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBoard. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+
+#include "UBGraphicsItem.h"
+
+#include "core/memcheck.h"
+
+#include "domain/UBGraphicsPixmapItem.h"
+#include "domain/UBGraphicsTextItem.h"
+#include "domain/UBGraphicsSvgItem.h"
+#include "domain/UBGraphicsMediaItem.h"
+#include "domain/UBGraphicsStrokesGroup.h"
+#include "domain/UBGraphicsGroupContainerItem.h"
+#include "domain/UBGraphicsWidgetItem.h"
+#include "domain/UBGraphicsScene.h"
+#include "tools/UBGraphicsCurtainItem.h"
+#include "domain/UBGraphicsItemDelegate.h"
+
+UBGraphicsItem::~UBGraphicsItem()
+{
+    if (mDelegate!=NULL)
+        delete mDelegate;
+}
+
+void UBGraphicsItem::setDelegate(UBGraphicsItemDelegate* delegate)
+{
+    Q_ASSERT(mDelegate==NULL);
+    mDelegate = delegate;
+}
+
+UBGraphicsItemDelegate *UBGraphicsItem::Delegate() const
+{
+    return mDelegate;
+}
+
+void UBGraphicsItem::assignZValue(QGraphicsItem *item, qreal value)
+{
+    item->setZValue(value);
+    item->setData(UBGraphicsItemData::ItemOwnZValue, value);
+}
+
+bool UBGraphicsItem::isFlippable(QGraphicsItem *item)
+{
+    return item->data(UBGraphicsItemData::ItemFlippable).toBool();
+}
+
+bool UBGraphicsItem::isRotatable(QGraphicsItem *item)
+{
+    return item->data(UBGraphicsItemData::ItemRotatable).toBool();
+}
+
+bool UBGraphicsItem::isLocked(QGraphicsItem *item)
+{
+    return item->data(UBGraphicsItemData::ItemLocked).toBool();
+}
+
+bool UBGraphicsItem::isHiddenOnDisplay(QGraphicsItem *item)
+{
+    return item->data(UBGraphicsItemData::ItemIsHiddenOnDisplay).toBool();
+}
+
+void UBGraphicsItem::remove(bool canUndo)
+{
+    if (Delegate())
+        Delegate()->remove(canUndo);
+}
+
+UBGraphicsItemDelegate *UBGraphicsItem::Delegate(QGraphicsItem *pItem)
+{
+    UBGraphicsItemDelegate *result = 0;
+
+    switch (static_cast<int>(pItem->type())) {
+    case UBGraphicsPixmapItem::Type :
+        result = (static_cast<UBGraphicsPixmapItem*>(pItem))->Delegate();
+        break;
+    case UBGraphicsTextItem::Type :
+        result = (static_cast<UBGraphicsTextItem*>(pItem))->Delegate();
+        break;
+    case UBGraphicsSvgItem::Type :
+        result = (static_cast<UBGraphicsSvgItem*>(pItem))->Delegate();
+        break;
+    case UBGraphicsMediaItem::Type:
+    case UBGraphicsVideoItem::Type:
+    case UBGraphicsAudioItem::Type:
+        result = (static_cast<UBGraphicsMediaItem*>(pItem))->Delegate();
+        break;
+    case UBGraphicsStrokesGroup::Type :
+        result = (static_cast<UBGraphicsStrokesGroup*>(pItem))->Delegate();
+        break;
+    case UBGraphicsGroupContainerItem::Type :
+        result = (static_cast<UBGraphicsGroupContainerItem*>(pItem))->Delegate();
+        break;
+    case UBGraphicsWidgetItem::Type :
+        result = (static_cast<UBGraphicsWidgetItem*>(pItem))->Delegate();
+        break;
+    case UBGraphicsCurtainItem::Type :
+        result = (static_cast<UBGraphicsCurtainItem*>(pItem))->Delegate();
+        break;
+    }
+
+    return result;
+}

--- a/src/domain/UBGraphicsItem.h
+++ b/src/domain/UBGraphicsItem.h
@@ -27,16 +27,40 @@
 
 
 
-#include "UBItem.h"
+#ifndef UBGRAPHICSITEM_H
+#define UBGRAPHICSITEM_H
 
-UBItem::UBItem()
-    : mUuid(QUuid::createUuid())
-    , mRenderingQuality(UBItem::RenderingQualityNormal)
-{
-    // NOOP
-}
+#include <QGraphicsItem>
 
-UBItem::~UBItem()
+#include "UBGraphicsItemDelegate.h"
+
+class UBGraphicsItem
 {
-    // NOOP
-}
+protected:
+    UBGraphicsItem() : mDelegate(NULL)
+    {
+        // NOOP
+    }
+    virtual ~UBGraphicsItem();
+    void setDelegate(UBGraphicsItemDelegate* mDelegate);
+
+public:
+    virtual int type() const = 0;
+
+    UBGraphicsItemDelegate *Delegate() const;
+
+    static void assignZValue(QGraphicsItem*, qreal value);
+    static bool isRotatable(QGraphicsItem *item);
+    static bool isFlippable(QGraphicsItem *item);
+    static bool isLocked(QGraphicsItem *item);
+    static bool isHiddenOnDisplay(QGraphicsItem *item);
+
+    static UBGraphicsItemDelegate *Delegate(QGraphicsItem *pItem);
+
+    void remove(bool canUndo = true);
+
+private:
+    UBGraphicsItemDelegate* mDelegate;
+};
+
+#endif // UBGRAPHICSITEM_H

--- a/src/domain/UBGraphicsItemTransformUndoCommand.cpp
+++ b/src/domain/UBGraphicsItemTransformUndoCommand.cpp
@@ -28,11 +28,12 @@
 
 
 #include "UBGraphicsItemTransformUndoCommand.h"
-#include "UBResizableGraphicsItem.h"
-#include "domain/UBItem.h"
-#include "domain/UBGraphicsScene.h"
 
 #include "core/memcheck.h"
+
+#include "domain/UBGraphicsScene.h"
+
+#include "UBResizableGraphicsItem.h"
 
 UBGraphicsItemTransformUndoCommand::UBGraphicsItemTransformUndoCommand(QGraphicsItem* pItem,
      const QPointF& prevPos, const QTransform& prevTransform, const qreal& prevZValue,

--- a/src/domain/UBGraphicsItemUndoCommand.cpp
+++ b/src/domain/UBGraphicsItemUndoCommand.cpp
@@ -38,10 +38,10 @@
 #include "core/UBApplication.h"
 
 #include "UBGraphicsGroupContainerItem.h"
+#include "UBGraphicsItem.h"
 #include "UBGraphicsItemDelegate.h"
 #include "UBGraphicsPolygonItem.h"
 #include "UBGraphicsScene.h"
-#include "UBItem.h"
 
 UBGraphicsItemUndoCommand::UBGraphicsItemUndoCommand(std::shared_ptr<UBGraphicsScene> pScene, const QSet<QGraphicsItem*>& pRemovedItems, const QSet<QGraphicsItem*>& pAddedItems, const GroupDataTable &groupsMap): UBUndoCommand()
     , mScene(pScene)

--- a/src/domain/UBGraphicsItemUndoCommand.cpp
+++ b/src/domain/UBGraphicsItemUndoCommand.cpp
@@ -31,15 +31,17 @@
 
 #include <QtGui>
 
-#include "UBGraphicsScene.h"
-
-#include "core/UBApplication.h"
-
 #include "board/UBBoardController.h"
 
 #include "core/memcheck.h"
-#include "domain/UBGraphicsGroupContainerItem.h"
-#include "domain/UBGraphicsPolygonItem.h"
+#include "core/UB.h"
+#include "core/UBApplication.h"
+
+#include "UBGraphicsGroupContainerItem.h"
+#include "UBGraphicsItemDelegate.h"
+#include "UBGraphicsPolygonItem.h"
+#include "UBGraphicsScene.h"
+#include "UBItem.h"
 
 UBGraphicsItemUndoCommand::UBGraphicsItemUndoCommand(std::shared_ptr<UBGraphicsScene> pScene, const QSet<QGraphicsItem*>& pRemovedItems, const QSet<QGraphicsItem*>& pAddedItems, const GroupDataTable &groupsMap): UBUndoCommand()
     , mScene(pScene)

--- a/src/domain/UBGraphicsMediaItem.cpp
+++ b/src/domain/UBGraphicsMediaItem.cpp
@@ -27,19 +27,25 @@
 
 
 
-#include "UBGraphicsGroupContainerItem.h"
 #include "UBGraphicsMediaItem.h"
-#include "UBGraphicsMediaItemDelegate.h"
-#include "UBGraphicsScene.h"
-#include "UBGraphicsDelegateFrame.h"
-#include "document/UBDocumentProxy.h"
-#include "core/UBApplication.h"
-#include "core/UBPersistenceManager.h"
-#include "board/UBBoardController.h"
-#include "core/memcheck.h"
-#include "frameworks/UBFileSystemUtils.h"
 
 #include <QGraphicsVideoItem>
+
+#include "board/UBBoardController.h"
+
+#include "core/UB.h"
+#include "core/UBApplication.h"
+#include "core/UBPersistenceManager.h"
+#include "core/memcheck.h"
+
+#include "document/UBDocumentProxy.h"
+
+#include "frameworks/UBFileSystemUtils.h"
+
+#include "UBGraphicsDelegateFrame.h"
+#include "UBGraphicsGroupContainerItem.h"
+#include "UBGraphicsMediaItemDelegate.h"
+#include "UBGraphicsScene.h"
 
 bool UBGraphicsMediaItem::sIsMutedByDefault = false;
 

--- a/src/domain/UBGraphicsMediaItem.h
+++ b/src/domain/UBGraphicsMediaItem.h
@@ -40,7 +40,7 @@
 
 #include "core/UB.h"
 
-#include "domain/UBItem.h"
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBMediaAssetItem.h"
 #include "domain/UBResizableGraphicsItem.h"
 

--- a/src/domain/UBGraphicsMediaItem.h
+++ b/src/domain/UBGraphicsMediaItem.h
@@ -38,7 +38,9 @@
 // #include <QtMultimediaWidgets/QVideoWidget>
 // #include <QtMultimedia/QVideoFrame>
 
-#include "board/UBBoardController.h"
+#include "core/UB.h"
+
+#include "domain/UBItem.h"
 #include "domain/UBMediaAssetItem.h"
 #include "domain/UBResizableGraphicsItem.h"
 

--- a/src/domain/UBGraphicsPDFItem.h
+++ b/src/domain/UBGraphicsPDFItem.h
@@ -37,7 +37,6 @@
 #include "core/UB.h"
 #include "pdf/GraphicsPDFItem.h"
 
-class UBGraphicsItemDelegate;
 class UBGraphicsPixmapItem;
 
 class UBGraphicsPDFItem: public GraphicsPDFItem, public UBMediaAssetItem, public UBGraphicsItem

--- a/src/domain/UBGraphicsPDFItem.h
+++ b/src/domain/UBGraphicsPDFItem.h
@@ -32,10 +32,14 @@
 
 #include <QtGui>
 
-#include "UBMediaAssetItem.h"
-
 #include "core/UB.h"
+
 #include "pdf/GraphicsPDFItem.h"
+#include "pdf/PDFRenderer.h"
+
+#include "UBGraphicsItem.h"
+#include "UBItem.h"
+#include "UBMediaAssetItem.h"
 
 class UBGraphicsPixmapItem;
 

--- a/src/domain/UBGraphicsPixmapItem.h
+++ b/src/domain/UBGraphicsPixmapItem.h
@@ -36,8 +36,6 @@
 
 #include "UBMediaAssetItem.h"
 
-class UBGraphicsItemDelegate;
-
 class UBGraphicsPixmapItem : public QObject, public QGraphicsPixmapItem, public UBMediaAssetItem, public UBGraphicsItem
 {
     Q_OBJECT

--- a/src/domain/UBGraphicsPixmapItem.h
+++ b/src/domain/UBGraphicsPixmapItem.h
@@ -34,6 +34,9 @@
 
 #include "core/UB.h"
 
+#include "UBItem.h"
+#include "UBGraphicsItem.h"
+#include "UBGraphicsScene.h"
 #include "UBMediaAssetItem.h"
 
 class UBGraphicsPixmapItem : public QObject, public QGraphicsPixmapItem, public UBMediaAssetItem, public UBGraphicsItem

--- a/src/domain/UBGraphicsPolygonItem.h
+++ b/src/domain/UBGraphicsPolygonItem.h
@@ -35,7 +35,6 @@
 #include "UBGraphicsStrokesGroup.h"
 #include "domain/UBGraphicsGroupContainerItem.h"
 
-class UBItem;
 class UBGraphicsScene;
 class UBGraphicsStroke;
 

--- a/src/domain/UBGraphicsScene.h
+++ b/src/domain/UBGraphicsScene.h
@@ -25,28 +25,30 @@
  */
 
 
+
+
 #ifndef UBGRAPHICSSCENE_H_
 #define UBGRAPHICSSCENE_H_
 
 #include <QtGui>
 #include <optional>
 
-#include "frameworks/UBCoreGraphicsScene.h"
-
 #include "core/UB.h"
 
+#include "frameworks/UBCoreGraphicsScene.h"
+
+#include "gui/UBBackgroundRuling.h"
+
+#include "UBGraphicsTextItem.h"
 #include "UBItem.h"
 
-class UBBackgroundRuling;
 class UBGraphicsPixmapItem;
 class UBGraphicsSvgItem;
 class UBGraphicsPolygonItem;
 class UBGraphicsMediaItem;
 class UBGraphicsWidgetItem;
 class UBGraphicsW3CWidgetItem;
-class UBToolWidget;
 class UBGraphicsPDFItem;
-class UBGraphicsTextItem;
 class UBGraphicsRuler;
 class UBGraphicsProtractor;
 class UBGraphicsCompass;

--- a/src/domain/UBGraphicsStroke.cpp
+++ b/src/domain/UBGraphicsStroke.cpp
@@ -29,15 +29,17 @@
 
 #include "UBGraphicsStroke.h"
 
-#include "UBGraphicsPolygonItem.h"
-
 #include "board/UBBoardController.h"
-#include "core/UBApplication.h"
+
 #include "core/memcheck.h"
+#include "core/UBApplication.h"
+#include "core/UBSettings.h"
+
 #include "domain/UBGraphicsScene.h"
 
 #include "frameworks/UBGeometryUtils.h"
 
+#include "UBGraphicsPolygonItem.h"
 
 typedef QPair<QPointF, qreal> strokePoint;
 

--- a/src/domain/UBGraphicsStrokesGroup.h
+++ b/src/domain/UBGraphicsStrokesGroup.h
@@ -34,6 +34,7 @@
 #include <QGraphicsSceneMouseEvent>
 
 #include "core/UB.h"
+#include "UBGraphicsItem.h"
 #include "UBItem.h"
 
 class UBGraphicsStrokesGroup : public QGraphicsItemGroup, public UBItem, public UBGraphicsItem

--- a/src/domain/UBGraphicsSvgItem.h
+++ b/src/domain/UBGraphicsSvgItem.h
@@ -35,6 +35,7 @@
 
 #include "core/UB.h"
 
+#include "UBGraphicsItem.h"
 #include "UBGraphicsScene.h"
 #include "UBItem.h"
 #include "UBMediaAssetItem.h"

--- a/src/domain/UBGraphicsSvgItem.h
+++ b/src/domain/UBGraphicsSvgItem.h
@@ -31,11 +31,13 @@
 #define UBGRAPHICSSVGITEM_H_
 
 #include <QtGui>
-#include <QtSvg>
-
-#include "UBMediaAssetItem.h"
+#include <QGraphicsSvgItem>
 
 #include "core/UB.h"
+
+#include "UBGraphicsScene.h"
+#include "UBItem.h"
+#include "UBMediaAssetItem.h"
 
 class UBGraphicsItemDelegate;
 class UBGraphicsPixmapItem;

--- a/src/domain/UBGraphicsSvgItem.h
+++ b/src/domain/UBGraphicsSvgItem.h
@@ -39,7 +39,6 @@
 #include "UBItem.h"
 #include "UBMediaAssetItem.h"
 
-class UBGraphicsItemDelegate;
 class UBGraphicsPixmapItem;
 
 class UBGraphicsSvgItem: public QGraphicsSvgItem, public UBMediaAssetItem, public UBGraphicsItem

--- a/src/domain/UBGraphicsTextItem.h
+++ b/src/domain/UBGraphicsTextItem.h
@@ -31,8 +31,11 @@
 #define UBGRAPHICSTEXTITEM_H_
 
 #include <QtGui>
-#include "UBItem.h"
+
 #include "core/UB.h"
+
+#include "UBGraphicsItem.h"
+#include "UBItem.h"
 #include "UBResizableGraphicsItem.h"
 
 class UBGraphicsItemDelegate;

--- a/src/domain/UBGraphicsWidgetItem.h
+++ b/src/domain/UBGraphicsWidgetItem.h
@@ -36,6 +36,7 @@
 
 #include "core/UB.h"
 
+#include "UBGraphicsItem.h"
 #include "UBMediaAssetItem.h"
 #include "UBResizableGraphicsItem.h"
 

--- a/src/domain/UBItem.h
+++ b/src/domain/UBItem.h
@@ -32,10 +32,7 @@
 
 #include <QtGui>
 
-#include "domain/UBGraphicsItemDelegate.h"
-
 class UBGraphicsScene;
-class UBGraphicsItem;
 
 class UBItem
 {
@@ -99,35 +96,6 @@ class UBItem
         RenderingQuality mRenderingQuality;
 
         CacheBehavior mCacheBehavior;
-};
-
-class UBGraphicsItem
-{
-protected:
-    UBGraphicsItem() : mDelegate(NULL)
-    {
-        // NOOP
-    }
-    virtual ~UBGraphicsItem();
-    void setDelegate(UBGraphicsItemDelegate* mDelegate);
-
-public:
-    virtual int type() const = 0;
-
-    UBGraphicsItemDelegate *Delegate() const;
-
-    static void assignZValue(QGraphicsItem*, qreal value);
-    static bool isRotatable(QGraphicsItem *item);
-    static bool isFlippable(QGraphicsItem *item);
-    static bool isLocked(QGraphicsItem *item);
-    static bool isHiddenOnDisplay(QGraphicsItem *item);
-
-    static UBGraphicsItemDelegate *Delegate(QGraphicsItem *pItem);
-
-    void remove(bool canUndo = true);
-
-private:
-    UBGraphicsItemDelegate* mDelegate;
 };
 
 #endif // UBITEM_H

--- a/src/domain/UBSelectionFrame.cpp
+++ b/src/domain/UBSelectionFrame.cpp
@@ -25,22 +25,26 @@
  */
 
 
+
+
 #include "UBSelectionFrame.h"
 
 #include <QtGui>
 
-#include "domain/UBItem.h"
-#include "domain/UBGraphicsItemZLevelUndoCommand.h"
-#include "domain/UBGraphicsGroupContainerItem.h"
-#include "domain/UBGraphicsScene.h"
 #include "board/UBBoardController.h"
-#include "core/UBSettings.h"
-#include "core/UBApplication.h"
-#include "gui/UBResources.h"
-#include "gui/UBMainWindow.h"
-#include "core/UBApplication.h"
 #include "board/UBBoardView.h"
 #include "board/UBDrawingController.h"
+
+#include "core/UBSettings.h"
+#include "core/UBApplication.h"
+
+#include "gui/UBResources.h"
+#include "gui/UBMainWindow.h"
+
+#include "UBGraphicsItem.h"
+#include "UBGraphicsItemZLevelUndoCommand.h"
+#include "UBGraphicsGroupContainerItem.h"
+#include "UBGraphicsScene.h"
 
 UBSelectionFrame::UBSelectionFrame()
     : mThickness(UBSettings::settings()->objectFrameWidth)

--- a/src/domain/domain.pri
+++ b/src/domain/domain.pri
@@ -5,6 +5,7 @@ HEADERS += src/domain/UBGraphicsScene.h \
     src/domain/UBGraphicsItemTransformUndoCommand.h \
     src/domain/UBGraphicsPixmapItem.h \
     src/domain/UBPageSizeUndoCommand.h \
+    src/domain/UBGraphicsItem.h \
     src/domain/UBGraphicsSvgItem.h \
     src/domain/UBGraphicsPolygonItem.h \
     src/domain/UBItem.h \
@@ -35,6 +36,7 @@ SOURCES += src/domain/UBGraphicsScene.cpp \
     src/domain/UBGraphicsItemTransformUndoCommand.cpp \
     src/domain/UBGraphicsPixmapItem.cpp \
     src/domain/UBPageSizeUndoCommand.cpp \
+    src/domain/UBGraphicsItem.cpp \
     src/domain/UBGraphicsSvgItem.cpp \
     src/domain/UBGraphicsPolygonItem.cpp \
     src/domain/UBItem.cpp \

--- a/src/gui/UBBackgroundPalette.cpp
+++ b/src/gui/UBBackgroundPalette.cpp
@@ -2,6 +2,8 @@
 
 #include "UBBackgroundPalette.h"
 
+#include "core/UBSettings.h"
+
 #include "gui/UBBackgroundManager.h"
 #include "gui/UBFlowLayout.h"
 #include "gui/UBMainWindow.h"

--- a/src/gui/UBMagnifer.cpp
+++ b/src/gui/UBMagnifer.cpp
@@ -26,16 +26,19 @@
 
 
 
-#include <QtGui>
+
 #include "UBMagnifer.h"
 
-#include "core/UBApplication.h"
+#include <QtGui>
+
 #include "board/UBBoardController.h"
-#include "domain/UBGraphicsScene.h"
 #include "board/UBBoardView.h"
 
 #include "core/memcheck.h"
+#include "core/UBApplication.h"
+#include "core/UBSettings.h"
 
+#include "domain/UBGraphicsScene.h"
 
 UBMagnifier::UBMagnifier(QWidget *parent, bool isInteractive)
     : QWidget(parent, parent ? Qt::Widget : Qt::Tool | (Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint))

--- a/src/podcast/UBPodcastController.h
+++ b/src/podcast/UBPodcastController.h
@@ -36,8 +36,9 @@
 
 #include "core/UBApplicationController.h"
 
+#include "web/simplebrowser/webview.h"
+
 class UBGraphicsScene;
-class WebView;
 class UBPodcastRecordingPalette;
 
 class UBDesktopPortal;

--- a/src/tools/UBAbstractDrawRuler.cpp
+++ b/src/tools/UBAbstractDrawRuler.cpp
@@ -28,16 +28,19 @@
 
 
 #include "UBAbstractDrawRuler.h"
-#include <QtSvg>
-#include "core/UB.h"
-#include "gui/UBResources.h"
-#include "domain/UBGraphicsScene.h"
-#include "board/UBDrawingController.h"
-#include "core/UBApplication.h"
+
+#include <QGraphicsSvgItem>
+
 #include "board/UBBoardController.h"
+#include "board/UBDrawingController.h"
 
 #include "core/memcheck.h"
+#include "core/UB.h"
+#include "core/UBApplication.h"
 
+#include "domain/UBGraphicsScene.h"
+
+#include "gui/UBResources.h"
 
 const QColor UBAbstractDrawRuler::sLightBackgroundMiddleFillColor = QColor(0x72, 0x72, 0x72, sFillTransparency);
 const QColor UBAbstractDrawRuler::sLightBackgroundEdgeFillColor = QColor(0xc3, 0xc3, 0xc3, sFillTransparency);

--- a/src/tools/UBGraphicsAxes.h
+++ b/src/tools/UBGraphicsAxes.h
@@ -32,7 +32,7 @@
 
 
 #include <QtGui>
-#include <QtSvg>
+#include <QGraphicsSvgItem>
 
 #include "core/UB.h"
 #include "domain/UBItem.h"

--- a/src/tools/UBGraphicsCompass.h
+++ b/src/tools/UBGraphicsCompass.h
@@ -31,7 +31,7 @@
 #define UBGRAPHICSCOMPASS_H_
 
 #include <QtGui>
-#include <QtSvg>
+#include <QGraphicsSvgItem>
 
 #include "core/UB.h"
 #include "domain/UBItem.h"

--- a/src/tools/UBGraphicsCurtainItem.h
+++ b/src/tools/UBGraphicsCurtainItem.h
@@ -34,6 +34,7 @@
 
 #include "core/UB.h"
 
+#include "domain/UBGraphicsItem.h"
 #include "domain/UBItem.h"
 
 class UBGraphicsItemDelegate;

--- a/src/tools/UBGraphicsProtractor.cpp
+++ b/src/tools/UBGraphicsProtractor.cpp
@@ -28,17 +28,21 @@
 
 
 #include "UBGraphicsProtractor.h"
-#include "core/UBApplication.h"
-#include "gui/UBResources.h"
-#include "domain/UBGraphicsScene.h"
-#include "board/UBBoardController.h"
-#include "board/UBDrawingController.h"
-#include "UBAbstractDrawRuler.h"
-
-#include "core/memcheck.h"
 
 #include <QtWidgets/QGraphicsView>
 
+#include "board/UBBoardController.h"
+#include "board/UBDrawingController.h"
+
+#include "core/memcheck.h"
+#include "core/UBApplication.h"
+#include "core/UBSettings.h"
+
+#include "domain/UBGraphicsScene.h"
+
+#include "gui/UBResources.h"
+
+#include "UBAbstractDrawRuler.h"
 
 const QRectF UBGraphicsProtractor::sDefaultRect = QRectF(-250, -250, 500, 500);
 const qreal UBGraphicsProtractor::minRadius = 70;

--- a/src/tools/UBGraphicsProtractor.h
+++ b/src/tools/UBGraphicsProtractor.h
@@ -33,14 +33,15 @@
 #include <QtWidgets>
 #include <QtWidgets/QGraphicsItem>
 #include <QtWidgets/QGraphicsView>
-#include <QtSvg>
+#include <QGraphicsSvgItem>
 
 #include "core/UB.h"
-#include "tools/UBAbstractDrawRuler.h"
+
 #include "domain/UBItem.h"
 
 #include "frameworks/UBGeometryUtils.h"
 
+#include "tools/UBAbstractDrawRuler.h"
 
 class UBGraphicsScene;
 

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -40,6 +40,7 @@
 
 #include "core/memcheck.h"
 #include "core/UBApplication.h"
+#include "core/UBSettings.h"
 
 #include "domain/UBGraphicsScene.h"
 

--- a/src/tools/UBGraphicsRuler.cpp
+++ b/src/tools/UBGraphicsRuler.cpp
@@ -27,19 +27,23 @@
 
 
 
-#include <QLinearGradient>
+#include "UBGraphicsRuler.h"
+
 #include <QBrush>
+#include <QGraphicsSvgItem>
+#include <QLinearGradient>
 #include <QPainterPath>
 #include <QPixmap>
 
-#include "tools/UBGraphicsRuler.h"
-#include "domain/UBGraphicsScene.h"
-#include "core/UBApplication.h"
-#include "gui/UBResources.h"
 #include "board/UBBoardController.h" // TODO UB 4.x clean that dependency
 #include "board/UBDrawingController.h"
 
 #include "core/memcheck.h"
+#include "core/UBApplication.h"
+
+#include "domain/UBGraphicsScene.h"
+
+#include "gui/UBResources.h"
 
 const QRect UBGraphicsRuler::sDefaultRect = QRect(0, 0, 800, 96);
 

--- a/src/tools/UBGraphicsTriangle.cpp
+++ b/src/tools/UBGraphicsTriangle.cpp
@@ -38,6 +38,7 @@
 
 #include "core/memcheck.h"
 #include "core/UBApplication.h"
+#include "core/UBSettings.h"
 
 #include "domain/UBGraphicsScene.h"
 

--- a/src/tools/UBGraphicsTriangle.cpp
+++ b/src/tools/UBGraphicsTriangle.cpp
@@ -27,16 +27,19 @@
 
 
 
+#include "UBGraphicsTriangle.h"
+
 #include <QPolygonF>
+#include <QGraphicsSvgItem>
 #include <QtWidgets/QGraphicsPolygonItem>
 
-#include "tools/UBGraphicsTriangle.h"
-#include "core/UBApplication.h"
 #include "board/UBBoardController.h"
 #include "board/UBDrawingController.h"
-#include "domain/UBGraphicsScene.h"
 
 #include "core/memcheck.h"
+#include "core/UBApplication.h"
+
+#include "domain/UBGraphicsScene.h"
 
 const QRect UBGraphicsTriangle::sDefaultRect =  QRect(0, 0, 800, 400);
 const UBGraphicsTriangle::UBGraphicsTriangleOrientation UBGraphicsTriangle::sDefaultOrientation =UBGraphicsTriangle::BottomLeft;

--- a/src/web/UBWebController.h
+++ b/src/web/UBWebController.h
@@ -32,15 +32,15 @@
 
 #include <QtGui>
 #include <QRegularExpression>
-
 #include <QWebEnginePage>
 #include <QWebEngineUrlRequestInterceptor>
 
-#include "UBEmbedContent.h"
 #include "simplebrowser/downloadmanagerwidget.h"
+#include "simplebrowser/webview.h"
+
+#include "UBEmbedContent.h"
 
 class BrowserWindow;
-class WebView;
 class QMenu;
 class QWebEngineProfile;
 class QWebEngineView;

--- a/src/web/simplebrowser/browserwindow.h
+++ b/src/web/simplebrowser/browserwindow.h
@@ -56,6 +56,8 @@
 #include <QTime>
 #include <QWebEnginePage>
 
+#include "webview.h"
+
 QT_BEGIN_NAMESPACE
 class QLineEdit;
 class QProgressBar;
@@ -63,7 +65,6 @@ class QStatusBar;
 QT_END_NAMESPACE
 
 class TabWidget;
-class WebView;
 class WBHistoryManager;
 
 class BrowserWindow : public QWidget


### PR DESCRIPTION
GCC 16.1 introduces a new warning for SFINAE issues. They can cause a change in behaviour when imports get reordered, leading to hard to debug issues.
Additionally, many used definitions are now included directly instead of relying on transitive includes. Relying on transitivity is brittle and can easily cause issues in lots of files if that transitive chain is broken. 

----

Some forward declarations cause SFINAE issues, because the definition is needed to choose the correct template. This affects the classes UBGraphicsMediaItem, UBGraphicsTextItem, UBBackgroundRuling, UBToolWidget, and WebView.

To eliminate these forward declarations, the imports need to be restructured. The easiest case is replacing the forward declaration with the include of the definition.

This doesn't quite work for UBGraphicsMediaItem as it causes an include cycle:
src/domain/UBGraphicsMediaItem.h includes src/domain/UBItem.h which includes src/domain/UBGraphicsItemDelegate.h which includes src/domain/UBGraphicsMediaItem.h
The solution provided here is to turn the UBGraphicsMediaItem class into a forward declaration in src/domain/UBGraphicsItemDelegate.h

In the course of this work, UBGraphicsItem has been split from UBItem into its own file; this surfaced a lot of transitive includes that weren't properly declared.