### PR TITLE
Add FreeBSD platform support

### DIFF
--- a/src/frameworks/CMakeLists.txt
+++ b/src/frameworks/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(openboard PRIVATE
     UBVersion.h
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|Linux")
     target_sources(openboard PRIVATE
         UBPlatformUtils_linux.cpp
     )

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -43,7 +43,9 @@
 #include "core/UBSettings.h"
 #include "gui/UBMainWindow.h"
 
+#ifdef Q_OS_FREEBSD
 static OnboardListener* listener = nullptr;
+#endif
 
 void UBPlatformUtils::init()
 {
@@ -94,7 +96,7 @@ QString UBPlatformUtils::applicationTemplateDirectory()
 void UBPlatformUtils::hideFile(const QString &filePath)
 {
     Q_UNUSED(filePath)
-    // TODO UB 4.x Not possible on Linux as such, the filename should have a . as first char in name
+    // TODO UB 4.x Not possible on FreeBSD and Linux as such, the filename should have a . as first char in name
 }
 
 void UBPlatformUtils::setFileType(const QString &filePath, unsigned long fileType)
@@ -102,7 +104,7 @@ void UBPlatformUtils::setFileType(const QString &filePath, unsigned long fileTyp
     Q_UNUSED(filePath)
     Q_UNUSED(fileType)
 
-    // No fileType equivalent on Linux
+    // No fileType equivalent on FreeBSD and Linux
 }
 
 void UBPlatformUtils::fadeDisplayOut()
@@ -478,14 +480,14 @@ QString UBPlatformUtils::urlFromClipboard()
 {
     QString qsRet;
 
-    // Not used on Linux
+    // Not used on FreeBSD and Linux
 
     return qsRet;
 }
 
 void UBPlatformUtils::setFrontProcess()
 {
-    // not used in Linux
+    // not used in FreeBSD and Linux
 }
 
 
@@ -501,6 +503,10 @@ void UBPlatformUtils::showFullScreen(QWidget *pWidget)
 
 void UBPlatformUtils::showOSK(bool show)
 {
+#ifdef Q_OS_FREEBSD
+     Q_UNUSED(show);
+     // No on-screen keyboard support on FreeBSD
+#else
     if (show)
     {
         QDBusInterface dbus("org.onboard.Onboard", "/org/onboard/Onboard/Keyboard");
@@ -562,4 +568,5 @@ void OnboardListener::onboardPropertiesChanged(QString interface, QMap<QString, 
             oskAction->trigger();
         }
     }
+#endif
 }

--- a/src/frameworks/UBPlatformUtils_linux.cpp
+++ b/src/frameworks/UBPlatformUtils_linux.cpp
@@ -43,7 +43,7 @@
 #include "core/UBSettings.h"
 #include "gui/UBMainWindow.h"
 
-#ifdef Q_OS_FREEBSD
+#ifndef Q_OS_FREEBSD
 static OnboardListener* listener = nullptr;
 #endif
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -95,7 +95,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     UBZoomPalette.h
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|Linux")
     target_sources(openboard PRIVATE
         UBKeyboardPalette_linux.cpp
     )

--- a/src/podcast/UBPodcastController.cpp
+++ b/src/podcast/UBPodcastController.cpp
@@ -64,7 +64,7 @@
 #elif defined(Q_OS_OSX)
     #include "ffmpeg/UBFFmpegVideoEncoder.h"
     #include "ffmpeg/UBMicrophoneInput.h"
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     #include "ffmpeg/UBFFmpegVideoEncoder.h"
     #include "ffmpeg/UBMicrophoneInput.h"
 #endif
@@ -315,7 +315,7 @@ void UBPodcastController::start()
         mVideoEncoder = new UBWindowsMediaVideoEncoder(this);  //deleted on stop
 #elif defined(Q_OS_OSX)
         mVideoEncoder = new UBFFmpegVideoEncoder(this);
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
         mVideoEncoder = new UBFFmpegVideoEncoder(this);
 #endif
 
@@ -780,7 +780,7 @@ QStringList UBPodcastController::audioRecordingDevices()
     devices = UBWaveRecorder::waveInDevices();
 #elif defined(Q_OS_OSX)
     devices = UBMicrophoneInput::availableDevicesNames();
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     devices = UBMicrophoneInput::availableDevicesNames();
 #endif
 

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -150,7 +150,7 @@ void UBEmbedController::textChanged(const QString& newText)
     static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
-#ifdef Q_OS_LINUX // Defined on X11.
+#ifdef defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) // Defined on X11.
     QString illegalCharList("      < > : \" / \\ | ? * ");
     static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif

--- a/src/web/UBEmbedController.cpp
+++ b/src/web/UBEmbedController.cpp
@@ -150,7 +150,7 @@ void UBEmbedController::textChanged(const QString& newText)
     static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif
 
-#ifdef defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) // Defined on X11.
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) // Defined on X11.
     QString illegalCharList("      < > : \" / \\ | ? * ");
     static const QRegularExpression regExp("[<>:\"/\\\\|?*]");
 #endif


### PR DESCRIPTION
This PR adds support for building OpenBoard on FreeBSD.

FreeBSD already has X11 and most POSIX APIs that the Linux
implementation uses, so most of the platform code can be shared.

## Changes

- `src/frameworks/CMakeLists.txt` and `src/gui/CMakeLists.txt`: compile
  `UBPlatformUtils_linux.cpp` and `UBKeyboardPalette_linux.cpp` on
  FreeBSD as well, using `CMAKE_SYSTEM_NAME MATCHES "FreeBSD|Linux"`.

- `src/frameworks/UBPlatformUtils_linux.cpp`: guard the DBus-based
  onboard keyboard integration with `#ifdef Q_OS_FREEBSD`, since the
  onboard daemon is not commonly available on FreeBSD.

- `src/web/UBEmbedController.cpp` and
  `src/podcast/UBPodcastController.cpp`: add `Q_OS_FREEBSD` alongside
  `Q_OS_LINUX` in the platform ifdefs.

## Context

OpenBoard is being packaged for the FreeBSD ports tree
([Bug 295104](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295104)).
These upstream changes will reduce the number of FreeBSD-specific
patches the port needs to carry.

## Testing

Tested on FreeBSD 15.0-CURRENT amd64 with Qt6.