### PR TITLE
Support Poppler 26.4+ API change

### DIFF
--- a/src/pdf/XPDFRenderer.cpp
+++ b/src/pdf/XPDFRenderer.cpp
@@ -176,9 +176,11 @@ QString XPDFRenderer::title() const
             Object title;
             infoDict->lookup((char*)"Title", &title);
 #endif
-            if (title.isString())
-            {
-#if POPPLER_VERSION_MAJOR > 0 || POPPLER_VERSION_MINOR >= 72
+	if (title.isString())
+        {
+#if POPPLER_VERSION_MAJOR > 26 || (POPPLER_VERSION_MAJOR == 26 && POPPLER_VERSION_MINOR >= 4)
+                return QString(title.getString().c_str());
+#elif POPPLER_VERSION_MAJOR > 0 || POPPLER_VERSION_MINOR >= 72
                 return QString(title.getString()->c_str());
 #else
                 return QString(title.getString()->getCString());


### PR DESCRIPTION
In Poppler 26.4, `getString()` was changed to return a reference to
`GooString` instead of a pointer, which breaks compilation against
recent Poppler versions.

This PR adds a new branch to the version check in
`src/pdf/XPDFRenderer.cpp` to handle the new API while keeping
compatibility with older versions.

## Testing

Tested on FreeBSD 15.0-CURRENT amd64.

## Context

Discovered while packaging OpenBoard for the FreeBSD ports tree
([Bug 295104](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295104)).