### PR TITLE
Fix/dice typo

### DIFF
--- a/resources/library/interactivities/Dice.wgt/i18n/Messages.properties
+++ b/resources/library/interactivities/Dice.wgt/i18n/Messages.properties
@@ -1,4 +1,4 @@
-fr.njin.i18n.document.title = Dices
+fr.njin.i18n.document.title = Dice
 
 fr.njin.i18n.toolbar.edit = Edit
 fr.njin.i18n.toolbar.view = Display
@@ -10,5 +10,5 @@ fr.njin.i18n.parameters.label.slate.themes = slate
 fr.njin.i18n.parameters.label.pad.themes = pad
 fr.njin.i18n.parameters.label.none.themes = none
 
-fr.njin.i18n.de.parameters.label.count = Number of dices
+fr.njin.i18n.de.parameters.label.count = Number of dice
 fr.njin.i18n.de.actions.label.launch = Roll !

--- a/resources/library/interactivities/Dice.wgt/js/help-template.js
+++ b/resources/library/interactivities/Dice.wgt/js/help-template.js
@@ -1,13 +1,13 @@
-<h3>Dices</h3>
+<h3>Dice</h3>
 <h4>For oral calculation or for various games</h4>
 
-<p>The dices interactivity allows you to display random dices faces.</p>
+<p>The dice interactivity allows you to display random dice faces.</p>
 <p>By clicking on the arrow or on "Launch" button, you have a new set of results. You can work the oral calculation with the displayed results or play to "the account is good".</p>
 <p>The calculations and reasoning can be written on the white board (outside the App).</p>
 <p>Enter the "Edit" mode to :</p>
 <ul>
 <li>choose the theme of the App : pad, slate, or none (by default : pad),</li>
-<li>determine the number of dices you want to use for your activity (1-6).</li>
+<li>determine the number of dice you want to use for your activity (1-6).</li>
 </ul>
 <p>The calculations and reasoning could be written on the page (outside the App).</p>
 <p>"Display" button comes back to the activity.</p>


### PR DESCRIPTION
Fixed a grammar mistake in the Dice widget , "Dices" is not standard English, "Dice" is already the correct plural. Updated the help text and i18n file. Left the internal #dices element ID untouched since that's code, not UI text.

Fixes #1438