### PR TITLE
feat: Align left sidebar with vertical stylus palette

### DIFF
--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -1008,9 +1008,7 @@ int UBBoardPaletteManager::leftDockPaletteOffset() const
     if (!UBSettings::settings()->appToolBarOrientationVertical->get().toBool())
         return 0;
 
-    constexpr int gap = 0; // optional z. B. 4, wenn du etwas Abstand willst
-
-    return mStylusPalette->geometry().right() + 1 + gap;
+    return mStylusPalette->geometry().right() + 1;
 }
 
 void UBBoardPaletteManager::updateLeftDockPaletteOffset()

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -120,6 +120,7 @@ UBBoardPaletteManager::~UBBoardPaletteManager()
 void UBBoardPaletteManager::initPalettesPosAtStartup()
 {
     mStylusPalette->initPosition();
+    updateLeftDockPaletteOffset();
 }
 
 void UBBoardPaletteManager::setupLayout()
@@ -501,6 +502,7 @@ void UBBoardPaletteManager::containerResized()
         mStylusPalette->move(userLeft, userTop);
         mStylusPalette->adjustSizeAndPosition();
         mStylusPalette->initPosition();
+        updateLeftDockPaletteOffset();
     }
 
     if(mZoomPalette)
@@ -569,6 +571,7 @@ void UBBoardPaletteManager::backgroundPaletteClosed()
 void UBBoardPaletteManager::toggleStylusPalette(bool checked)
 {
     mStylusPalette->setVisible(checked);
+    updateLeftDockPaletteOffset();
 }
 
 
@@ -963,6 +966,8 @@ void UBBoardPaletteManager::changeStylusPaletteOrientation(QVariant var)
 
     connect(mStylusPalette, SIGNAL(stylusToolDoubleClicked(int)), UBApplication::boardController, SLOT(stylusToolDoubleClicked(int)));
     mStylusPalette->setVisible(bVisible); // always show stylus palette at startup
+    mStylusPalette->initPosition();
+    updateLeftDockPaletteOffset();
 }
 
 
@@ -990,4 +995,28 @@ void UBBoardPaletteManager::stopDownloads()
         mpDownloadWidget->setVisibleState(false);
         mRightPalette->removeTab(mpDownloadWidget);
     }
+}
+
+int UBBoardPaletteManager::leftDockPaletteOffset() const
+{
+    if (!mStylusPalette)
+        return 0;
+
+    if (!mStylusPalette->isVisible())
+        return 0;
+
+    if (!UBSettings::settings()->appToolBarOrientationVertical->get().toBool())
+        return 0;
+
+    constexpr int gap = 0; // optional z. B. 4, wenn du etwas Abstand willst
+
+    return mStylusPalette->geometry().right() + 1 + gap;
+}
+
+void UBBoardPaletteManager::updateLeftDockPaletteOffset()
+{
+    if (!mLeftPalette)
+        return;
+
+    mLeftPalette->setAdditionalLeftOffset(leftDockPaletteOffset());
 }

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -119,8 +119,7 @@ UBBoardPaletteManager::~UBBoardPaletteManager()
 
 void UBBoardPaletteManager::initPalettesPosAtStartup()
 {
-    mStylusPalette->initPosition();
-    updateLeftDockPaletteOffset();
+    updateStylusPalettePosition();
 }
 
 void UBBoardPaletteManager::setupLayout()
@@ -484,6 +483,12 @@ void UBBoardPaletteManager::connectPalettes()
         }
     }
 
+    if(mLeftPalette)
+    {
+        connect(mLeftPalette, SIGNAL(pageSelectionChangedRequired()),
+                this, SLOT(updateStylusPalettePosition()));
+    }
+
 }
 
 
@@ -500,9 +505,7 @@ void UBBoardPaletteManager::containerResized()
     if(mStylusPalette)
     {
         mStylusPalette->move(userLeft, userTop);
-        mStylusPalette->adjustSizeAndPosition();
-        mStylusPalette->initPosition();
-        updateLeftDockPaletteOffset();
+        updateStylusPalettePosition();
     }
 
     if(mZoomPalette)
@@ -571,7 +574,7 @@ void UBBoardPaletteManager::backgroundPaletteClosed()
 void UBBoardPaletteManager::toggleStylusPalette(bool checked)
 {
     mStylusPalette->setVisible(checked);
-    updateLeftDockPaletteOffset();
+    updateStylusPalettePosition();
 }
 
 
@@ -669,6 +672,7 @@ void UBBoardPaletteManager::changeMode(eUBDockPaletteWidgetMode newMode, bool is
 
                 mLeftPalette->setVisible(leftPaletteVisible);
                 mRightPalette->setVisible(rightPaletteVisible);
+                updateStylusPalettePosition();
 #ifdef Q_OS_WIN
                 if (rightPaletteVisible)
                     mRightPalette->setAdditionalVOffset(0);
@@ -966,10 +970,41 @@ void UBBoardPaletteManager::changeStylusPaletteOrientation(QVariant var)
 
     connect(mStylusPalette, SIGNAL(stylusToolDoubleClicked(int)), UBApplication::boardController, SLOT(stylusToolDoubleClicked(int)));
     mStylusPalette->setVisible(bVisible); // always show stylus palette at startup
-    mStylusPalette->initPosition();
-    updateLeftDockPaletteOffset();
+    updateStylusPalettePosition();
 }
 
+int UBBoardPaletteManager::verticalStylusPaletteLeftOffset() const
+{
+    if (!mStylusPalette || !mLeftPalette)
+        return 0;
+
+    if(!mStylusPalette->isVisible())
+        return 0;
+
+    if(!mLeftPalette->isVisible())
+        return 0;
+
+    if(!UBSettings::settings()->appToolBarOrientationVertical->get().toBool())
+        return 0;
+
+    int offset = mLeftPalette->x() + mLeftPalette->width();
+
+    const QRect tabRect = mLeftPalette->getTabPaletteRect();
+
+    if(!tabRect.isNull())
+        offset = qMax(offset, tabRect.x() + tabRect.width());
+
+    return offset;
+}
+
+void UBBoardPaletteManager::updateStylusPalettePosition()
+{
+    if (!mStylusPalette)
+        return;
+
+    mStylusPalette->adjustSizeAndPosition();
+    mStylusPalette->initPosition(verticalStylusPaletteLeftOffset());
+}
 
 void UBBoardPaletteManager::refreshPalettes()
 {
@@ -995,26 +1030,4 @@ void UBBoardPaletteManager::stopDownloads()
         mpDownloadWidget->setVisibleState(false);
         mRightPalette->removeTab(mpDownloadWidget);
     }
-}
-
-int UBBoardPaletteManager::leftDockPaletteOffset() const
-{
-    if (!mStylusPalette)
-        return 0;
-
-    if (!mStylusPalette->isVisible())
-        return 0;
-
-    if (!UBSettings::settings()->appToolBarOrientationVertical->get().toBool())
-        return 0;
-
-    return mStylusPalette->geometry().right() + 1;
-}
-
-void UBBoardPaletteManager::updateLeftDockPaletteOffset()
-{
-    if (!mLeftPalette)
-        return;
-
-    mLeftPalette->setAdditionalLeftOffset(leftDockPaletteOffset());
 }

--- a/src/board/UBBoardPaletteManager.cpp
+++ b/src/board/UBBoardPaletteManager.cpp
@@ -485,7 +485,7 @@ void UBBoardPaletteManager::connectPalettes()
 
     if(mLeftPalette)
     {
-        connect(mLeftPalette, SIGNAL(pageSelectionChangedRequired()),
+        connect(mLeftPalette, SIGNAL(dockPaletteGeometryChanged()),
                 this, SLOT(updateStylusPalettePosition()));
     }
 
@@ -987,12 +987,10 @@ int UBBoardPaletteManager::verticalStylusPaletteLeftOffset() const
     if(!UBSettings::settings()->appToolBarOrientationVertical->get().toBool())
         return 0;
 
+    if(mLeftPalette->width() <=0)
+        return 0;
+
     int offset = mLeftPalette->x() + mLeftPalette->width();
-
-    const QRect tabRect = mLeftPalette->getTabPaletteRect();
-
-    if(!tabRect.isNull())
-        offset = qMax(offset, tabRect.x() + tabRect.width());
 
     return offset;
 }

--- a/src/board/UBBoardPaletteManager.h
+++ b/src/board/UBBoardPaletteManager.h
@@ -102,6 +102,8 @@ class UBBoardPaletteManager : public QObject
         void connectPalettes();
         void positionFreeDisplayPalette();
         void setupDockPaletteWidgets();
+        int leftDockPaletteOffset() const;
+        void updateLeftDockPaletteOffset();
 
         QWidget* mContainer;
         UBBoardController *mBoardControler;

--- a/src/board/UBBoardPaletteManager.h
+++ b/src/board/UBBoardPaletteManager.h
@@ -102,8 +102,7 @@ class UBBoardPaletteManager : public QObject
         void connectPalettes();
         void positionFreeDisplayPalette();
         void setupDockPaletteWidgets();
-        int leftDockPaletteOffset() const;
-        void updateLeftDockPaletteOffset();
+        int verticalStylusPaletteLeftOffset() const;
 
         QWidget* mContainer;
         UBBoardController *mBoardControler;
@@ -186,6 +185,7 @@ class UBBoardPaletteManager : public QObject
         void handButtonReleased();
 
         void changeStylusPaletteOrientation(QVariant var);
+        void updateStylusPalettePosition();
 };
 
 #endif /* UBBOARDPALETTEMANAGER_H_ */

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -65,6 +65,7 @@ UBDockPalette::UBDockPalette(eUBDockPaletteType paletteType, QWidget *parent, co
 , mCurrentTab(0)
 , mPaletteType(paletteType)
 , mTabPalette(new UBTabDockPalette(this, parent))
+, mAdditionalLeftOffset(0)
 {
     setObjectName(name);
 
@@ -160,6 +161,15 @@ void UBDockPalette::setOrientation(eUBDockOrientation orientation)
     }
 }
 
+void UBDockPalette::setAdditionalLeftOffset(int offset)
+{
+    if (mAdditionalLeftOffset == offset)
+        return;
+
+    mAdditionalLeftOffset = offset;
+    onResizeRequest();
+}
+
 /**
  * \brief Handle the resize event
  * @param event as the resize event
@@ -185,6 +195,9 @@ void UBDockPalette::resizeEvent(QResizeEvent *event)
     case eUBDockOrientation_Top:
         // Not supported yet
     case eUBDockOrientation_Left:
+        origin.setX(mAdditionalLeftOffset);
+        origin.setY(0);
+        break;
     default:
         origin.setX(0);
         origin.setY(0);
@@ -505,7 +518,7 @@ void UBDockPalette::onAllDownloadsFinished()
 
 void UBDockPalette::moveTabs()
 {
-    int x = width();
+    int x = this->x() + width();
     if (mOrientation == eUBDockOrientation_Right)
     {
         if (parentWidget())

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -192,6 +192,8 @@ void UBDockPalette::resizeEvent(QResizeEvent *event)
     }
     move(origin.x(), origin.y());
     moveTabs();
+    
+    emit dockPaletteGeometryChanged();
 }
 
 /**

--- a/src/gui/UBDockPalette.cpp
+++ b/src/gui/UBDockPalette.cpp
@@ -65,7 +65,6 @@ UBDockPalette::UBDockPalette(eUBDockPaletteType paletteType, QWidget *parent, co
 , mCurrentTab(0)
 , mPaletteType(paletteType)
 , mTabPalette(new UBTabDockPalette(this, parent))
-, mAdditionalLeftOffset(0)
 {
     setObjectName(name);
 
@@ -161,15 +160,6 @@ void UBDockPalette::setOrientation(eUBDockOrientation orientation)
     }
 }
 
-void UBDockPalette::setAdditionalLeftOffset(int offset)
-{
-    if (mAdditionalLeftOffset == offset)
-        return;
-
-    mAdditionalLeftOffset = offset;
-    onResizeRequest();
-}
-
 /**
  * \brief Handle the resize event
  * @param event as the resize event
@@ -195,9 +185,6 @@ void UBDockPalette::resizeEvent(QResizeEvent *event)
     case eUBDockOrientation_Top:
         // Not supported yet
     case eUBDockOrientation_Left:
-        origin.setX(mAdditionalLeftOffset);
-        origin.setY(0);
-        break;
     default:
         origin.setX(0);
         origin.setY(0);
@@ -518,7 +505,7 @@ void UBDockPalette::onAllDownloadsFinished()
 
 void UBDockPalette::moveTabs()
 {
-    int x = this->x() + width();
+    int x = width();
     if (mOrientation == eUBDockOrientation_Right)
     {
         if (parentWidget())

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -143,6 +143,7 @@ public:
     void setTabFlotable(bool newFlotable) {mTabPalette->mFlotable = newFlotable;}
     int getAdditionalVOffset() const {return mTabPalette->mVerticalOffset;}
     void setAdditionalVOffset(int newOffset) {mTabPalette->mVerticalOffset = newOffset;}
+    void setAdditionalLeftOffset(int offset);
 
     eUBDockPaletteType paletteType(){return mPaletteType;}
 
@@ -217,6 +218,7 @@ private:
 private:
     eUBDockPaletteType mPaletteType;
     UBTabDockPalette *mTabPalette;
+    int mAdditionalLeftOffset;
 };
 
 #endif // UBDOCKPALETTE_H

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -143,7 +143,6 @@ public:
     void setTabFlotable(bool newFlotable) {mTabPalette->mFlotable = newFlotable;}
     int getAdditionalVOffset() const {return mTabPalette->mVerticalOffset;}
     void setAdditionalVOffset(int newOffset) {mTabPalette->mVerticalOffset = newOffset;}
-    void setAdditionalLeftOffset(int offset);
 
     eUBDockPaletteType paletteType(){return mPaletteType;}
 
@@ -218,7 +217,6 @@ private:
 private:
     eUBDockPaletteType mPaletteType;
     UBTabDockPalette *mTabPalette;
-    int mAdditionalLeftOffset;
 };
 
 #endif // UBDOCKPALETTE_H

--- a/src/gui/UBDockPalette.h
+++ b/src/gui/UBDockPalette.h
@@ -155,6 +155,7 @@ public slots:
 signals:
     void mouseEntered();
     void pageSelectionChangedRequired();
+    void dockPaletteGeometryChanged();
 
 protected:
     virtual int border();

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -76,7 +76,7 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
     UBApplication::mainWindow->actionSnap->setProperty("ungrouped", true);
 
     setActions(actions);
-    setButtonIconSize(QSize(32, 32));
+    setButtonIconSize(QSize(42, 42));
     groupActions();
 
     UBShortcutManager::shortcutManager()->addActionGroup(mActionGroup);

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -76,7 +76,7 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
     UBApplication::mainWindow->actionSnap->setProperty("ungrouped", true);
 
     setActions(actions);
-    setButtonIconSize(QSize(42, 42));
+    setButtonIconSize(QSize(32, 32));
     groupActions();
 
     UBShortcutManager::shortcutManager()->addActionGroup(mActionGroup);

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -104,7 +104,7 @@ void UBStylusPalette::initPosition(int verticalLeftOffset)
     int parentHeight = pParentW->height();
 
     if(UBSettings::settings()->appToolBarOrientationVertical->get().toBool()){
-        int posX = qMax(border(), verticalLeftOffset);
+        int posX = border() + verticalLeftOffset;
         int posY = (parentHeight / 2) - (height() / 2);
         pos.setX(posX);
         pos.setY(posY);

--- a/src/gui/UBStylusPalette.cpp
+++ b/src/gui/UBStylusPalette.cpp
@@ -92,7 +92,7 @@ UBStylusPalette::UBStylusPalette(QWidget *parent, Qt::Orientation orient)
 
 }
 
-void UBStylusPalette::initPosition()
+void UBStylusPalette::initPosition(int verticalLeftOffset)
 {
     QWidget* pParentW = parentWidget();
     if(!pParentW) return ;
@@ -104,7 +104,7 @@ void UBStylusPalette::initPosition()
     int parentHeight = pParentW->height();
 
     if(UBSettings::settings()->appToolBarOrientationVertical->get().toBool()){
-        int posX = border();
+        int posX = qMax(border(), verticalLeftOffset);
         int posY = (parentHeight / 2) - (height() / 2);
         pos.setX(posX);
         pos.setY(posY);

--- a/src/gui/UBStylusPalette.h
+++ b/src/gui/UBStylusPalette.h
@@ -43,7 +43,7 @@ class UBStylusPalette : public UBActionPalette
         UBStylusPalette(QWidget *parent = 0, Qt::Orientation orient = Qt::Vertical);
         virtual ~UBStylusPalette();
 
-        void initPosition();
+        void initPosition(int verticalLeftOffset = 0);
 
     private slots:
 


### PR DESCRIPTION
- Add an optional left offset for the for the left dock palette
- Position the sidebar tab next to the vertical stylus palette
- Update the offset when the stylus palette changes orientation or visibility
- Keep the existing behavior unchanged for horizontal stylus palette

Closes #1483 
References: #1483 

Signed-off-by: claas998, baetjer, SofianElmotiem