### PR TITLE
Add a toolbar button: print the current board view

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -128,6 +128,10 @@ PageFormat=A4
 Resolution=300
 UsePDFMerger=true
 
+[Print]
+BackgroundGrid=true
+BackgroundColor=true
+
 [Podcast]
 AudioRecordingDevice=Default
 FramesPerSecond=10

--- a/resources/forms/preferences.ui
+++ b/resources/forms/preferences.ui
@@ -119,7 +119,7 @@
             </sizepolicy>
            </property>
            <property name="title">
-            <string>PDF</string>
+            <string>PDF and printing</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_13">
             <item row="0" column="1" colspan="2">
@@ -135,6 +135,20 @@
                <widget class="QCheckBox" name="exportBackgroundColor">
                 <property name="text">
                  <string>Export background color</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QCheckBox" name="printBackgroundGrid">
+                <property name="text">
+                 <string>Print background grid</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QCheckBox" name="printBackgroundColor">
+                <property name="text">
+                 <string>Print background color</string>
                 </property>
                </widget>
               </item>

--- a/src/board/UBBoardController.cpp
+++ b/src/board/UBBoardController.cpp
@@ -30,6 +30,8 @@
 #include "UBBoardController.h"
 
 #include <QtWidgets>
+#include <QPrintDialog>
+#include <QPrinter>
 
 #include "adaptors/UBMetadataDcSubsetAdaptor.h"
 #include "adaptors/UBSvgSubsetAdaptor.h"
@@ -87,6 +89,76 @@
 #include "web/UBEmbedParser.h"
 
 #include "core/memcheck.h"
+
+namespace
+{
+void printCurrentBoardView(UBBoardController* controller, UBMainWindow* mainWindow)
+{
+    const std::shared_ptr<UBGraphicsScene> scene = controller->activeScene();
+    UBBoardView* view = controller->controlView();
+
+    if (!scene || !view || !view->viewport())
+        return;
+
+    view->forcedTabletRelease();
+
+    QPrinter printer(QPrinter::HighResolution);
+    printer.setDocName(QObject::tr("OpenBoard current view"));
+    printer.setFullPage(true);
+
+    const QRect viewportRect = view->viewport()->rect();
+    printer.setPageOrientation(viewportRect.width() >= viewportRect.height()
+        ? QPageLayout::Landscape
+        : QPageLayout::Portrait);
+
+    QPrintDialog dialog(&printer, mainWindow);
+    dialog.setWindowTitle(QObject::tr("Print Current View"));
+
+    if (dialog.exec() != QDialog::Accepted)
+        return;
+
+    QPainter painter;
+
+    if (!painter.begin(&printer))
+    {
+        QMessageBox::warning(mainWindow, QObject::tr("Print"),
+                             QObject::tr("OpenBoard could not start the selected printer."));
+        return;
+    }
+
+    const QRectF printableRect = printer.pageLayout().paintRectPixels(printer.resolution());
+    const QRectF visibleSceneRect = view->mapToScene(viewportRect).boundingRect();
+    QSizeF fittedSize = visibleSceneRect.size();
+    fittedSize.scale(printableRect.size(), Qt::KeepAspectRatio);
+    const QRectF targetRect(
+        printableRect.left() + (printableRect.width() - fittedSize.width()) / 2.0,
+        printableRect.top() + (printableRect.height() - fittedSize.height()) / 2.0,
+        fittedSize.width(), fittedSize.height());
+
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setRenderHint(QPainter::TextAntialiasing);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform);
+
+    const bool originalDarkBackground = scene->isDarkBackground();
+    const UBBackgroundRuling* originalBackground = scene->background();
+    const bool printDarkBackground = originalDarkBackground
+        && UBSettings::settings()->printBackgroundColor->get().toBool();
+    const UBBackgroundRuling* printBackground =
+        UBSettings::settings()->printBackgroundGrid->get().toBool()
+        ? originalBackground
+        : nullptr;
+
+    scene->setSceneBackground(printDarkBackground, printBackground);
+    scene->setRenderingContext(UBGraphicsScene::NonScreen);
+    scene->setRenderingQuality(UBItem::RenderingQualityHigh, UBItem::CacheNotAllowed);
+    scene->render(&painter, targetRect, visibleSceneRect, Qt::KeepAspectRatio);
+    scene->setRenderingContext(UBGraphicsScene::Screen);
+    scene->setRenderingQuality(UBItem::RenderingQualityNormal, UBItem::CacheAllowed);
+    scene->setSceneBackground(originalDarkBackground, originalBackground);
+
+    painter.end();
+}
+}
 
 UBBoardController::UBBoardController(UBMainWindow* mainWindow)
     : UBDocumentContainer(mainWindow->centralWidget())
@@ -352,6 +424,19 @@ void UBBoardController::setCursorFromAngle(qreal angle, const QPoint offset)
 void UBBoardController::setupToolbar()
 {
     UBSettings *settings = UBSettings::settings();
+
+    QAction* printAction = new QAction(QIcon(":/images/toolbar/print.png"), tr("Print"),
+                                       mMainWindow->boardToolBar);
+    printAction->setToolTip(tr("Print the current board view, fitted to the selected page"));
+
+    const QList<QAction*> toolbarActions = mMainWindow->boardToolBar->actions();
+    const int backgroundsIndex = toolbarActions.indexOf(mMainWindow->actionBackgrounds);
+    QAction* insertBefore = backgroundsIndex >= 0 && backgroundsIndex + 1 < toolbarActions.size()
+        ? toolbarActions.at(backgroundsIndex + 1)
+        : nullptr;
+    mMainWindow->boardToolBar->insertAction(insertBefore, printAction);
+    connect(printAction, &QAction::triggered, this,
+            [this]() { printCurrentBoardView(this, mMainWindow); });
 
     buildColorActions();
 

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -299,6 +299,8 @@ void UBPreferencesController::wire()
     // PDF preferences
     connect(mPreferencesUI->exportBackgroundGrid, SIGNAL(clicked(bool)), settings->exportBackgroundGrid, SLOT(setBool(bool)));
     connect(mPreferencesUI->exportBackgroundColor, SIGNAL(clicked(bool)), settings->exportBackgroundColor, SLOT(setBool(bool)));
+    connect(mPreferencesUI->printBackgroundGrid, SIGNAL(clicked(bool)), settings->printBackgroundGrid, SLOT(setBool(bool)));
+    connect(mPreferencesUI->printBackgroundColor, SIGNAL(clicked(bool)), settings->printBackgroundColor, SLOT(setBool(bool)));
 
     // Documents Mode preferences
     connect(mPreferencesUI->showDateColumnOnAlphabeticalSort, SIGNAL(clicked(bool)), settings->showDateColumnOnAlphabeticalSort, SLOT(setBool(bool)));
@@ -465,6 +467,8 @@ void UBPreferencesController::init()
 
     mPreferencesUI->exportBackgroundGrid->setChecked(settings->exportBackgroundGrid->get().toBool());
     mPreferencesUI->exportBackgroundColor->setChecked(settings->exportBackgroundColor->get().toBool());
+    mPreferencesUI->printBackgroundGrid->setChecked(settings->printBackgroundGrid->get().toBool());
+    mPreferencesUI->printBackgroundColor->setChecked(settings->printBackgroundColor->get().toBool());
 
     mPreferencesUI->showDateColumnOnAlphabeticalSort->setChecked(settings->showDateColumnOnAlphabeticalSort->get().toBool());
     mPreferencesUI->emptyTrashForOlderDocuments->setChecked(settings->emptyTrashForOlderDocuments->get().toBool());
@@ -554,6 +558,8 @@ void UBPreferencesController::defaultSettings()
 
         mPreferencesUI->exportBackgroundGrid->setChecked(settings->exportBackgroundGrid->reset().toBool());
         mPreferencesUI->exportBackgroundColor->setChecked(settings->exportBackgroundColor->reset().toBool());
+        mPreferencesUI->printBackgroundGrid->setChecked(settings->printBackgroundGrid->reset().toBool());
+        mPreferencesUI->printBackgroundColor->setChecked(settings->printBackgroundColor->reset().toBool());
 
         mPreferencesUI->emptyTrashForOlderDocuments->setChecked(settings->emptyTrashForOlderDocuments->reset().toBool());
         mPreferencesUI->emptyTrashDaysValue->setValue(settings->emptyTrashDaysValue->reset().toInt());

--- a/src/core/UBSettings.cpp
+++ b/src/core/UBSettings.cpp
@@ -461,6 +461,9 @@ void UBSettings::init()
     exportBackgroundGrid = new UBSetting(this, "PDF", "ExportBackgroundGrid", false);
     exportBackgroundColor = new UBSetting(this, "PDF", "ExportBackgroundColor", false);
 
+    printBackgroundGrid = new UBSetting(this, "Print", "BackgroundGrid", true);
+    printBackgroundColor = new UBSetting(this, "Print", "BackgroundColor", true);
+
     podcastFramesPerSecond = new UBSetting(this, "Podcast", "FramesPerSecond", 10);
     podcastVideoSize = new UBSetting(this, "Podcast", "VideoSize", "Medium");
     podcastAudioRecordingDevice = new UBSetting(this, "Podcast", "AudioRecordingDevice", "Default");

--- a/src/core/UBSettings.h
+++ b/src/core/UBSettings.h
@@ -383,6 +383,9 @@ class UBSettings : public QObject
         UBSetting* exportBackgroundGrid;
         UBSetting* exportBackgroundColor;
 
+        UBSetting* printBackgroundGrid;
+        UBSetting* printBackgroundColor;
+
         UBSetting* podcastFramesPerSecond;
         UBSetting* podcastVideoSize;
         UBSetting* podcastWindowsMediaBitsPerSecond;


### PR DESCRIPTION
Add a board-toolbar print action that fits the visible scene to the selected page and preserves orientation.

Lets users independently choose whether to include the board background color and grid in settings.

Tested on Windows 10 on an old DTEN touch board.  Pretty cool to click twice and get hardcopy.