### PR TITLE
fix: undo dissolving a group

### DIFF
--- a/src/domain/UBGraphicsGroupContainerItem.cpp
+++ b/src/domain/UBGraphicsGroupContainerItem.cpp
@@ -33,7 +33,9 @@
 
 #include "UBGraphicsMediaItem.h"
 #include "UBGraphicsTextItem.h"
+#include "core/UBApplication.h"
 #include "domain/UBGraphicsItemDelegate.h"
+#include "domain/UBGraphicsItemUndoCommand.h"
 #include "domain/UBGraphicsGroupContainerItemDelegate.h"
 #include "domain/UBGraphicsScene.h"
 
@@ -245,15 +247,35 @@ void UBGraphicsGroupContainerItem::copyItemParameters(UBItem *copy) const
     }
 }
 
-void UBGraphicsGroupContainerItem::destroy(bool canUndo) {
+void UBGraphicsGroupContainerItem::destroy(bool canUndo)
+{
+    UBGraphicsItemUndoCommand::GroupDataTable groupDataTable;
 
-    foreach (QGraphicsItem *item, childItems()) {
+    for (auto item : childItems())
+    {
         pRemoveFromGroup(item);
-        item->setFlag(QGraphicsItem::ItemIsSelectable, true);
-        item->setFlag(QGraphicsItem::ItemIsFocusable, true);
+        item->setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemIsFocusable);
+
+        if (canUndo)
+        {
+            const auto ubItem = dynamic_cast<UBItem*>(item);
+
+            if (ubItem)
+            {
+                groupDataTable.insert(this, ubItem->uuid());
+            }
+        }
     }
 
-    remove(canUndo);
+    auto scene = dynamic_cast<UBGraphicsScene*>(QGraphicsItem::scene());
+
+    remove(false);
+
+    if (canUndo && scene)
+    {
+        auto undoCommand = new UBGraphicsItemUndoCommand(scene->shared_from_this(), {this}, {}, groupDataTable);
+        UBApplication::undoStack->push(undoCommand);
+    }
 }
 
 void UBGraphicsGroupContainerItem::mousePressEvent(QGraphicsSceneMouseEvent *event)


### PR DESCRIPTION
- Dissolving a group cannot be undone, as the undo command does not restore group membership of items.
- Create the undo command directly in `UBGraphicsGroupContainerItem`.
- Use a `UBGraphicsItemUndoCommand` and add a `GroupDataTable` to restore group membership.

Fixes https://github.com/letsfindaway/OpenBoard/issues/249